### PR TITLE
[SYSTEMDS-70] Add lineage tracing for MultiReturnInstructions

### DIFF
--- a/src/main/java/org/tugraz/sysds/runtime/instructions/cp/ComputationCPInstruction.java
+++ b/src/main/java/org/tugraz/sysds/runtime/instructions/cp/ComputationCPInstruction.java
@@ -76,7 +76,7 @@ public abstract class ComputationCPInstruction extends CPInstruction implements 
 	}
 
 	@Override
-	public LineageItem getLineageItem() {
+	public LineageItem[] getLineageItems() {
 		ArrayList<LineageItem> lineages = new ArrayList<>();
 		if (input1 != null)
 			lineages.add(Lineage.getOrCreate(input1));
@@ -84,7 +84,7 @@ public abstract class ComputationCPInstruction extends CPInstruction implements 
 			lineages.add(Lineage.getOrCreate(input2));
 		if (input3 != null)
 			lineages.add(Lineage.getOrCreate(input3));
-		return new LineageItem(output.getName(),
-			getOpcode(), lineages.toArray(new LineageItem[0]));
+		return new LineageItem[]{new LineageItem(output.getName(),
+				getOpcode(), lineages.toArray(new LineageItem[0]))};
 	}
 }

--- a/src/main/java/org/tugraz/sysds/runtime/instructions/cp/DataGenCPInstruction.java
+++ b/src/main/java/org/tugraz/sysds/runtime/instructions/cp/DataGenCPInstruction.java
@@ -302,7 +302,7 @@ public class DataGenCPInstruction extends UnaryCPInstruction {
 	}
 	
 	@Override
-	public LineageItem getLineageItem() {
+	public LineageItem[] getLineageItems() {
 		String tmpInstStr = instString;
 		if (getSeed() == DataGenOp.UNSPECIFIED_SEED) {
 			int position = (method == DataGenMethod.RAND) ? 9 :
@@ -310,6 +310,6 @@ public class DataGenCPInstruction extends UnaryCPInstruction {
 			tmpInstStr = InstructionUtils.replaceOperand(
 				tmpInstStr, position, String.valueOf(runtimeSeed));
 		}
-		return new LineageItem(output.getName(), tmpInstStr, getOpcode());
+		return new LineageItem[]{new LineageItem(output.getName(), tmpInstStr, getOpcode())};
 	}
 }

--- a/src/main/java/org/tugraz/sysds/runtime/instructions/cp/MultiReturnBuiltinCPInstruction.java
+++ b/src/main/java/org/tugraz/sysds/runtime/instructions/cp/MultiReturnBuiltinCPInstruction.java
@@ -26,6 +26,8 @@ import org.tugraz.sysds.common.Types.ValueType;
 import org.tugraz.sysds.runtime.DMLRuntimeException;
 import org.tugraz.sysds.runtime.controlprogram.context.ExecutionContext;
 import org.tugraz.sysds.runtime.instructions.InstructionUtils;
+import org.tugraz.sysds.runtime.lineage.Lineage;
+import org.tugraz.sysds.runtime.lineage.LineageItem;
 import org.tugraz.sysds.runtime.matrix.data.LibCommonsMath;
 import org.tugraz.sysds.runtime.matrix.data.MatrixBlock;
 import org.tugraz.sysds.runtime.matrix.operators.Operator;
@@ -106,5 +108,23 @@ public class MultiReturnBuiltinCPInstruction extends ComputationCPInstruction {
 		for(int i=0; i < _outputs.size(); i++) {
 			ec.setMatrixOutput(_outputs.get(i).getName(), out[i], getExtendedOpcode());
 		}
+	}
+	
+	@Override
+	public LineageItem[] getLineageItems() {
+		ArrayList<LineageItem> lineages = new ArrayList<>();
+		if (input1 != null)
+			lineages.add(Lineage.getOrCreate(input1));
+		if (input2 != null)
+			lineages.add(Lineage.getOrCreate(input2));
+		if (input3 != null)
+			lineages.add(Lineage.getOrCreate(input3));
+		
+		ArrayList<LineageItem> items = new ArrayList<>();
+		for (CPOperand out : _outputs) {
+			items.add(new LineageItem(out.getName(),
+					getOpcode(), lineages.toArray(new LineageItem[0])));
+		}
+		return items.toArray(new LineageItem[items.size()]);
 	}
 }

--- a/src/main/java/org/tugraz/sysds/runtime/instructions/cp/VariableCPInstruction.java
+++ b/src/main/java/org/tugraz/sysds/runtime/instructions/cp/VariableCPInstruction.java
@@ -1129,22 +1129,28 @@ public class VariableCPInstruction extends CPInstruction implements LineageTrace
 	}
 	
 	@Override
-	public LineageItem getLineageItem() {
+	public LineageItem[] getLineageItems() {
+		LineageItem li = null;
 		switch (getVariableOpcode()) {
 			case CreateVariable:
-				if( !getInput1().getName().contains(org.tugraz.sysds.lops.Data.PREAD_PREFIX) )
-					return null; //otherwise fall through
-			case Read:
-				return new LineageItem(getInput1().getName(), toString(), getOpcode());
-			case AssignVariable:{
-				return new LineageItem(getInput2().getName(), getOpcode(),
-					new LineageItem[] {Lineage.getOrCreate(getInput1())});
+				if (!getInput1().getName().contains(org.tugraz.sysds.lops.Data.PREAD_PREFIX))
+					break; //otherwise fall through
+			
+			case Read: {
+				li = new LineageItem(getInput1().getName(), toString(), getOpcode());
+				break;
+			}
+			case AssignVariable: {
+				li = new LineageItem(getInput2().getName(), getOpcode(),
+						new LineageItem[]{Lineage.getOrCreate(getInput1())});
+				break;
 			}
 			case CopyVariable: {
 				if (!Lineage.contains(getInput1()))
 					throw new DMLRuntimeException("Could not find LineageItem for " + getInput1().getName());
-				return new LineageItem(getInput2().getName(), getOpcode(),
-					new LineageItem[] {Lineage.get(getInput1())});
+				li = new LineageItem(getInput2().getName(), getOpcode(),
+						new LineageItem[]{Lineage.get(getInput1())});
+				break;
 			}
 			case Write: {
 				ArrayList<LineageItem> lineages = new ArrayList<>();
@@ -1153,8 +1159,9 @@ public class VariableCPInstruction extends CPInstruction implements LineageTrace
 						lineages.add(Lineage.getOrCreate(input));
 				if (_formatProperties != null && !_formatProperties.getDescription().isEmpty())
 					lineages.add(new LineageItem(_formatProperties.getDescription()));
-				return new LineageItem(getInput1().getName(),
-					getOpcode(), lineages.toArray(new LineageItem[0]));
+				li = new LineageItem(getInput1().getName(),
+						getOpcode(), lineages.toArray(new LineageItem[0]));
+				break;
 			}
 			case MoveVariable: {
 				ArrayList<LineageItem> lineages = new ArrayList<>();
@@ -1165,13 +1172,18 @@ public class VariableCPInstruction extends CPInstruction implements LineageTrace
 					if (getInput3() != null)
 						lineages.add(Lineage.getOrCreate(getInput3()));
 				}
-				return new LineageItem(getInput2().getName(), 
-					getOpcode(), lineages.toArray(new LineageItem[0]));
+				li = new LineageItem(getInput2().getName(),
+						getOpcode(), lineages.toArray(new LineageItem[0]));
+				break;
 			}
 			case RemoveVariable:
 			default:
-				return null;
 		}
+		
+		if (li == null)
+			return null;
+		else
+			return new LineageItem[]{li};
 	}
 	
 	public boolean isVariableCastInstruction() {

--- a/src/main/java/org/tugraz/sysds/runtime/instructions/spark/ReblockSPInstruction.java
+++ b/src/main/java/org/tugraz/sysds/runtime/instructions/spark/ReblockSPInstruction.java
@@ -241,7 +241,7 @@ public class ReblockSPInstruction extends UnarySPInstruction implements LineageT
 	}
 
 	@Override
-	public LineageItem getLineageItem() {
+	public LineageItem[] getLineageItems() {
 		ArrayList<LineageItem> lineages = new ArrayList<>();
 		if (input1 != null)
 			lineages.add(Lineage.getOrCreate(input1));
@@ -250,6 +250,6 @@ public class ReblockSPInstruction extends UnarySPInstruction implements LineageT
 		if (input3 != null)
 			lineages.add(Lineage.getOrCreate(input3));
 
-		return new LineageItem(output.getName(), getOpcode(), lineages.toArray(new LineageItem[0]));
+		return new LineageItem[]{new LineageItem(output.getName(), getOpcode(), lineages.toArray(new LineageItem[0]))};
 	}
 }

--- a/src/main/java/org/tugraz/sysds/runtime/lineage/LineageMap.java
+++ b/src/main/java/org/tugraz/sysds/runtime/lineage/LineageMap.java
@@ -30,8 +30,62 @@ public class LineageMap {
 		if (!(inst instanceof LineageTraceable))
 			throw new DMLRuntimeException("Unknown Instruction (" + inst.getOpcode() + ") traced.");
 		
-		LineageItem li = ((LineageTraceable) inst).getLineageItem();
-		
+		LineageItem[] items = ((LineageTraceable) inst).getLineageItems();
+		if (items == null || items.length < 1)
+			trace(inst, ec, null);
+		else
+			for (LineageItem li : items)
+				trace(inst, ec, li);
+	}
+	
+	public void processDedupItem(LineageMap lm, Long path) {
+		for (Map.Entry<String, LineageItem> entry : lm._traces.entrySet()) {
+			if (_traces.containsKey(entry.getKey())) {
+				addLineageItem(new LineageItem(entry.getKey(),
+						path.toString(), LineageItem.dedupItemOpcode,
+						new LineageItem[]{_traces.get(entry.getKey()), entry.getValue()}));
+			}
+		}
+	}
+	
+	public LineageItem getOrCreate(CPOperand variable) {
+		if (variable == null)
+			return null;
+		String varname = variable.getName();
+		//handle literals (never in traces)
+		if (variable.isLiteral()) {
+			LineageItem ret = _literals.get(varname);
+			if (ret == null)
+				_literals.put(varname, ret = new LineageItem(
+						varname, variable.getLineageLiteral()));
+			return ret;
+		}
+		//handle variables
+		LineageItem ret = _traces.get(variable.getName());
+		return (ret != null) ? ret :
+				new LineageItem(varname, variable.getLineageLiteral());
+	}
+	
+	public LineageItem get(CPOperand variable) {
+		if (variable == null)
+			return null;
+		return _traces.get(variable.getName());
+	}
+	
+	public boolean contains(CPOperand variable) {
+		return _traces.containsKey(variable.getName());
+	}
+	
+	public boolean containsKey(String key) {
+		return _traces.containsKey(key);
+	}
+	
+	public void resetLineageMaps() {
+		_traces.clear();
+		_literals.clear();
+	}
+	
+	private void trace(Instruction inst, ExecutionContext ec, LineageItem li) {
 		if (inst instanceof VariableCPInstruction) {
 			VariableCPInstruction vcp_inst = ((VariableCPInstruction) inst);
 			
@@ -43,7 +97,7 @@ public class LineageMap {
 				}
 				case Read:
 				case CreateVariable: {
-					if( li != null )
+					if (li != null)
 						addLineageItem(li);
 					break;
 				}
@@ -68,52 +122,6 @@ public class LineageMap {
 		
 	}
 	
-	public void processDedupItem(LineageMap lm, Long path) {
-		for (Map.Entry<String, LineageItem> entry : lm._traces.entrySet()) {
-			if (_traces.containsKey(entry.getKey())) {
-				addLineageItem(new LineageItem(entry.getKey(),
-					path.toString(), LineageItem.dedupItemOpcode,
-					new LineageItem[] {_traces.get(entry.getKey()), entry.getValue()}));
-			}
-		}
-	}
-	
-	public LineageItem getOrCreate(CPOperand variable) {
-		if (variable == null)
-			return null;
-		String varname = variable.getName();
-		//handle literals (never in traces)
-		if( variable.isLiteral() ) {
-			LineageItem ret = _literals.get(varname);
-			if( ret == null )
-				_literals.put(varname, ret = new LineageItem(
-					varname, variable.getLineageLiteral()));
-			return ret;
-		}
-		//handle variables
-		LineageItem ret = _traces.get(variable.getName());
-		return (ret != null) ? ret : 
-			new LineageItem(varname, variable.getLineageLiteral());
-	}
-	
-	public LineageItem get(CPOperand variable) {
-		if (variable == null)
-			return null;
-		return _traces.get(variable.getName());
-	}
-	
-	public boolean contains(CPOperand variable) {
-		return _traces.containsKey(variable.getName());
-	}
-	
-	public boolean containsKey(String key) {
-		return _traces.containsKey(key);
-	}
-	
-	public void resetLineageMaps() {
-		_traces.clear();
-		_literals.clear();
-	}
 	
 	private void processCopyLI(LineageItem li) {
 		if (li.getInputs().length != 1)

--- a/src/main/java/org/tugraz/sysds/runtime/lineage/LineageParser.java
+++ b/src/main/java/org/tugraz/sysds/runtime/lineage/LineageParser.java
@@ -57,7 +57,13 @@ public class LineageParser {
 					if (!(inst instanceof LineageTraceable))
 						throw new ParseException("Invalid Instruction (" + inst.getOpcode() + ") traced");
 					
-					li = new LineageItem(id, ((LineageTraceable) inst).getLineageItem());
+					LineageItem[] items = ((LineageTraceable) inst).getLineageItems();
+					if (items == null)
+						throw new ParseException("Instruction without output (" + inst.getOpcode() + ") not supported");
+					if (items.length != 1)
+						throw new ParseException("Instruction with multiple outputs (" + inst.getOpcode() + ") not supported");
+					
+					li = new LineageItem(id, items[0]);
 					break;
 				
 				case Literal:

--- a/src/main/java/org/tugraz/sysds/runtime/lineage/LineageTraceable.java
+++ b/src/main/java/org/tugraz/sysds/runtime/lineage/LineageTraceable.java
@@ -16,5 +16,5 @@
 package org.tugraz.sysds.runtime.lineage;
 
 public interface LineageTraceable {
-	public LineageItem getLineageItem();
+	public LineageItem[] getLineageItems();
 }

--- a/src/test/java/org/tugraz/sysds/test/functions/lineage/LineageTraceTest.java
+++ b/src/test/java/org/tugraz/sysds/test/functions/lineage/LineageTraceTest.java
@@ -34,6 +34,7 @@ public class LineageTraceTest extends AutomatedTestBase {
 	protected static final String TEST_NAME1 = "LineageTrace1";
 	protected static final String TEST_NAME2 = "LineageTrace2";
 	protected static final String TEST_NAME3 = "LineageTrace3";
+	protected static final String TEST_NAME4 = "LineageTrace4";
 	protected String TEST_CLASS_DIR = TEST_DIR + LineageTraceTest.class.getSimpleName() + "/";
 	
 	protected static final int numRecords = 10;
@@ -46,6 +47,7 @@ public class LineageTraceTest extends AutomatedTestBase {
 		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1));
 		addTestConfiguration(TEST_NAME2, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME2));
 		addTestConfiguration(TEST_NAME3, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME3));
+		addTestConfiguration(TEST_NAME4, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME4));
 	}
 	
 	@Test
@@ -61,6 +63,11 @@ public class LineageTraceTest extends AutomatedTestBase {
 	@Test
 	public void testLineageTrace3() {
 		testLineageTrace(TEST_NAME3);
+	}
+	
+	@Test
+	public void testLineageTrace4() {
+		testLineageTrace(TEST_NAME4);
 	}
 	
 	public void testLineageTrace(String testname) {

--- a/src/test/scripts/functions/lineage/LineageTrace4.dml
+++ b/src/test/scripts/functions/lineage/LineageTrace4.dml
@@ -1,0 +1,34 @@
+#-------------------------------------------------------------
+#
+# Copyright 2019 Graz University of Technology
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#-------------------------------------------------------------
+
+# How to invoke this dml script LineageTrace.dml?
+# Assume LR_HOME is set to the home of the dml script
+# Assume rows = 20 and cols = 20 for X
+# hadoop jar SystemML.jar -f $LR_HOME/LineageTrace.dml -args "$INPUT_DIR/X" "$OUTPUT_DIR/X" "$OUTPUT_DIR/Y"
+
+A = read($1);
+
+A = A * 3;
+A = A + 5;
+
+A = t(A) %*% A;
+
+[eval, evec] = eigen(A);
+
+write(eval, $2, format="text");
+write(evec, $3, format="text");


### PR DESCRIPTION
I added lineage tracing for instruction with multiple output. E.g. `eigen()`

Therefore, I changed the method signature of `LineageTraceable` interface and adapt logic in `MultiReturnBuiltinCPInstruction`.