### PR TITLE
parfor test on image operations mirror, brightness using synthetic data

### DIFF
--- a/src/test/java/org/tugraz/sysds/test/functions/parfor/ParForImageBrightnessTest.java
+++ b/src/test/java/org/tugraz/sysds/test/functions/parfor/ParForImageBrightnessTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2019 Graz University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.tugraz.sysds.test.functions.parfor;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.tugraz.sysds.common.Types;
+import org.tugraz.sysds.runtime.matrix.data.MatrixValue;
+import org.tugraz.sysds.test.AutomatedTestBase;
+import org.tugraz.sysds.test.TestConfiguration;
+import org.tugraz.sysds.test.TestUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+
+import static org.junit.Assert.fail;
+
+public class ParForImageBrightnessTest extends AutomatedTestBase
+{
+	private final static String TEST_NAME = "parfor_image_brightness";
+	private final static String TEST_DIR = "functions/parfor/";
+	private static final String TEST_CLASS_DIR = TEST_DIR + ParForImageBrightnessTest.class.getSimpleName() + "/";
+
+	private final static double spSparse = 0.1;
+	private final static double spDense = 0.9;
+	private final static int image_width = 32;
+	private final static int image_height = 32;
+	private final static int rows = 128; // -> number of images
+	private final static int cols = image_width * image_height;
+	private final static int num_augmentations = 5;
+
+	//FIXME: results between R and DML quite imprecise
+//	private final static double eps = 1e-10;
+	private final static double eps = 1;
+
+	@Override
+	public void setUp() {
+		addTestConfiguration(TEST_NAME,new TestConfiguration(TEST_CLASS_DIR, TEST_NAME,new String[]{"B"}));
+	}
+
+	@Test
+	public void testImageBrightnessDenseCP() {
+		runImageBrightnessTest(false, Types.ExecType.CP);
+	}
+
+	@Test
+	public void testImageBrightnessDenseSP() { runImageBrightnessTest(false, Types.ExecType.SPARK); }
+
+	@Test
+	public void testImageBrightnessSparseCP() {
+		runImageBrightnessTest(true, Types.ExecType.CP);
+	}
+
+	@Test
+	public void testImageBrightnessSparseSP() { runImageBrightnessTest(true, Types.ExecType.SPARK); }
+
+	private void runImageBrightnessTest(boolean sparse, Types.ExecType instType)
+	{
+		Types.ExecMode platformOld = rtplatform;
+		switch( instType ) {
+			case SPARK: rtplatform = Types.ExecMode.SPARK; break;
+			default: rtplatform = Types.ExecMode.HYBRID; break;
+		}
+
+		double sparsity = sparse ? spSparse : spDense;
+
+		try
+		{
+			loadTestConfiguration(getTestConfiguration(TEST_NAME));
+
+			//generate actual dataset
+			double[][] A = getRandomMatrix(rows, cols, 0, 255, sparsity, 7);
+			writeInputMatrixWithMTD("A", A, true);
+
+			double[][] brightness_adjustments = getRandomMatrix(num_augmentations, 1, -127, 127, 1.0, 7);
+			writeInputMatrixWithMTD("brightness_adjustments", brightness_adjustments, true);
+
+			String HOME = SCRIPT_DIR + TEST_DIR;
+			fullDMLScriptName = HOME + TEST_NAME + ".dml";
+			programArgs = new String[]{"-explain","-stats", "-nvargs",
+					"in_file=" + input("A"),
+					"out_file=" + output("B"),
+					"width=" + image_width,
+					"height=" + image_height,
+					"brightness_adjustments=" +  input("brightness_adjustments.mtx")
+			};
+
+			fullRScriptName = HOME + TEST_NAME + ".R";
+			rCmd = "Rscript" + " " + fullRScriptName + " " + inputDir() + " " + expectedDir()
+					+ " " + image_width + " " + image_height;
+
+			runTest(true, false, null, -1);
+
+			runRScript(true);
+
+			//compare matrices
+			HashMap<MatrixValue.CellIndex, Double> dmlfile = readDMLMatrixFromHDFS("B");
+			HashMap<MatrixValue.CellIndex, Double> rfile  = readRMatrixFromFS("B");
+			TestUtils.compareMatrices(dmlfile, rfile, eps, "Stat-DML", "Stat-R");
+		}
+		finally {
+			rtplatform = platformOld;
+		}
+	}
+}

--- a/src/test/java/org/tugraz/sysds/test/functions/parfor/ParForImageMirrorTest.java
+++ b/src/test/java/org/tugraz/sysds/test/functions/parfor/ParForImageMirrorTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2019 Graz University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.tugraz.sysds.test.functions.parfor;
+
+import org.junit.Test;
+import org.tugraz.sysds.common.Types;
+import org.tugraz.sysds.runtime.matrix.data.MatrixValue;
+import org.tugraz.sysds.test.AutomatedTestBase;
+import org.tugraz.sysds.test.TestConfiguration;
+import org.tugraz.sysds.test.TestUtils;
+
+import java.util.HashMap;
+
+public class ParForImageMirrorTest extends AutomatedTestBase
+{
+	private final static String TEST_NAME = "parfor_image_mirror";
+	private final static String TEST_DIR = "functions/parfor/";
+	private static final String TEST_CLASS_DIR = TEST_DIR + ParForImageMirrorTest.class.getSimpleName() + "/";
+
+	private final static double spSparse = 0.1;
+	private final static double spDense = 0.9;
+	private final static int image_width = 32;
+	private final static int image_height = 32;
+	private final static int rows = 128; // -> number of images
+	private final static int cols = image_width * image_height;
+	private final static double eps = 1e-10;
+
+	@Override
+	public void setUp() {
+		addTestConfiguration(TEST_NAME,new TestConfiguration(TEST_CLASS_DIR, TEST_NAME,new String[]{"B"}));
+	}
+
+	@Test
+	public void testImageMirrorDenseCP() {
+		runImageMirrorTest(false, Types.ExecType.CP);
+	}
+
+	@Test
+	public void testImageMirrorDenseSP() { runImageMirrorTest( false, Types.ExecType.SPARK);	}
+
+	@Test
+	public void testImageMirrorSparseCP() {
+		runImageMirrorTest(true, Types.ExecType.CP);
+	}
+
+	@Test
+	public void testImageMirrorSparseSP() { runImageMirrorTest( true, Types.ExecType.SPARK); }
+
+
+	private void runImageMirrorTest(boolean sparse, Types.ExecType instType)
+	{
+		Types.ExecMode platformOld = rtplatform;
+		switch( instType ) {
+			case SPARK: rtplatform = Types.ExecMode.SPARK; break;
+			default: rtplatform = Types.ExecMode.HYBRID; break;
+		}
+
+		double sparsity = sparse ? spSparse : spDense;
+
+		try
+		{
+			loadTestConfiguration(getTestConfiguration(TEST_NAME));
+
+			//generate actual dataset
+			double[][] A = getRandomMatrix(rows, cols, 0, 255, sparsity, 7);
+			writeInputMatrixWithMTD("A", A, true);
+
+
+			String HOME = SCRIPT_DIR + TEST_DIR;
+			fullDMLScriptName = HOME + TEST_NAME + ".dml";
+			programArgs = new String[]{"-explain","-stats", "-nvargs",
+					"in_file=" + input("A"),
+					"out_file=" + output("B"),
+					"width=" + image_width,
+					"height=" + image_height,
+			};
+
+			fullRScriptName = HOME + TEST_NAME + ".R";
+			rCmd = "Rscript" + " " + fullRScriptName + " " + inputDir() + " " + expectedDir()
+					+ " " + image_width + " " + image_height;
+
+			runTest(true, false, null, -1);
+
+			runRScript(true);
+
+			//compare matrices
+			HashMap<MatrixValue.CellIndex, Double> dmlfile = readDMLMatrixFromHDFS("B");
+			HashMap<MatrixValue.CellIndex, Double> rfile  = readRMatrixFromFS("B");
+			TestUtils.compareMatrices(dmlfile, rfile, eps, "Stat-DML", "Stat-R");
+
+		}
+		finally {
+			rtplatform = platformOld;
+		}
+	}
+}

--- a/src/test/scripts/functions/parfor/parfor_image_brightness.R
+++ b/src/test/scripts/functions/parfor/parfor_image_brightness.R
@@ -1,0 +1,58 @@
+#-------------------------------------------------------------
+#
+# Copyright 2019 Graz University of Technology
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#-------------------------------------------------------------
+
+args = commandArgs(TRUE)
+options(digits=22)
+library("Matrix")
+
+adjustBrightness = function(M, val, chan_max)
+{
+  out = matrix(0, nrow(M), ncol(M));
+  for( i in 1:ncol(M) ) 
+  {
+    col = as.vector(M[,i])
+    #col = rev(col);
+    col = pmax(0, pmin(col + val, chan_max))
+    out[,i] = col;
+  }
+  return(out)
+}
+
+images = as.matrix(readMM(paste(args[1], "A.mtx", sep="")))
+width = as.integer(args[3])
+height = as.integer(args[4])
+max_value=255
+brightness_adjustments = as.matrix(readMM(paste(args[1], "brightness_adjustments.mtx", sep="")))
+num_augmentations = nrow(brightness_adjustments)
+augmented_images = matrix(0, num_augmentations * nrow(images), ncol(images))
+
+for (idx in 0:(nrow(images)-1)) {
+  i = idx + 1
+  
+  image2d = matrix(images[i,], width, height)
+  
+  for(a in 1:num_augmentations) {
+    # do augmentation
+    img_out = adjustBrightness(image2d, as.integer(brightness_adjustments[a]), max_value)
+    
+    # reshape and store augmentation
+    augmented_images[idx*num_augmentations+a,] = matrix(img_out, 1, width * height)
+  }
+}
+
+writeMM(as(augmented_images, "CsparseMatrix"), paste(args[2], "B", sep=""))

--- a/src/test/scripts/functions/parfor/parfor_image_brightness.dml
+++ b/src/test/scripts/functions/parfor/parfor_image_brightness.dml
@@ -1,0 +1,40 @@
+#-------------------------------------------------------------
+#
+# Copyright 2019 Graz University of Technology
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#-------------------------------------------------------------
+
+images = read($in_file)
+brightness_adjustments = read($brightness_adjustments)
+num_augmentations = nrow(brightness_adjustments)
+
+augmented_images = matrix(0, rows=num_augmentations * nrow(images), cols=ncol(images))
+max_value=255
+
+parfor (idx in 0:(nrow(images)-1), check = 0) {
+  i = idx + 1
+
+  image2d = matrix(images[i,], $height, $width)
+
+  for(a in 1:num_augmentations) {
+    # do augmentation
+    img_out = img_brightness(image2d, as.scalar(brightness_adjustments[a]), max_value)
+
+    # reshape and store augmentation
+    augmented_images[idx*num_augmentations+a,] = matrix(img_out, 1, $width * $height)
+  }
+}
+
+write(augmented_images, $out_file)

--- a/src/test/scripts/functions/parfor/parfor_image_mirror.R
+++ b/src/test/scripts/functions/parfor/parfor_image_mirror.R
@@ -1,0 +1,56 @@
+#-------------------------------------------------------------
+#
+# Copyright 2019 Graz University of Technology
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#-------------------------------------------------------------
+
+args = commandArgs(TRUE)
+options(digits=22)
+library("Matrix")
+
+reverseMatrix = function(M)
+{
+  out = matrix(0, nrow(M), ncol(M));
+  for( i in 1:ncol(M) ) 
+  {
+    col = as.vector(M[,i])
+    col = rev(col);
+    out[,i] = col;
+  }
+  return(out)
+}
+
+images = as.matrix(readMM(paste(args[1], "A.mtx", sep="")))
+width = as.integer(args[3])
+height = as.integer(args[4])
+augmented_images = matrix(0, 2 * nrow(images), ncol(images))
+
+for (idx in 0:(nrow(images)-1)) {
+  i = idx + 1
+  
+  image2d = matrix(images[i,], width, height)
+  
+  for(a in 1:2) {
+    # do augmentation
+    x_flip = t(reverseMatrix(t(image2d)))
+    y_flip = reverseMatrix(image2d)
+    
+    # reshape and store augmentation
+    augmented_images[idx*2+1,] = matrix(x_flip, 1, width * height)
+    augmented_images[idx*2+2,] = matrix(y_flip, 1, width * height)
+  }
+}
+
+writeMM(as(augmented_images, "CsparseMatrix"), paste(args[2], "B", sep=""))

--- a/src/test/scripts/functions/parfor/parfor_image_mirror.dml
+++ b/src/test/scripts/functions/parfor/parfor_image_mirror.dml
@@ -1,0 +1,34 @@
+#-------------------------------------------------------------
+#
+# Copyright 2019 Graz University of Technology
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#-------------------------------------------------------------
+
+images=read($in_file)
+
+augmented_images = matrix(0, rows=2*nrow(images), cols=ncol(images))
+
+parfor (idx in 0:(nrow(images)-1), check = 0) {
+  i = idx + 1
+  image2d = matrix(images[i,], $height, $width)
+
+  x_flip = img_mirror(image2d, TRUE)
+  augmented_images[idx*2+1,] = matrix(x_flip, 1, $width * $height)
+
+  y_flip = img_mirror(image2d, FALSE)
+  augmented_images[idx*2+2,] = matrix(y_flip, 1, $width * $height)
+}
+
+write(augmented_images, $out_file)


### PR DESCRIPTION
One issue: brightness test seems to be inaccurate for reasons I could not uncover in a reasonable amount of time so I leave it as a FIXME for now to get the PR reviewed.
Set the eps value in ParForImageBrightnessTest.java to the usual accuracy to see the test fail.