### PR TITLE
[SYSTEMDS-75] Minor fixes for lineage tracing and full-reuse approach

### DIFF
--- a/src/main/java/org/tugraz/sysds/api/DMLOptions.java
+++ b/src/main/java/org/tugraz/sysds/api/DMLOptions.java
@@ -106,7 +106,10 @@ public class DMLOptions {
 			dmlOptions.lineage = true;
 			String lineageType = line.getOptionValue("lineage");
 			if (lineageType != null){
-				dmlOptions.lineage_dedup = lineageType.equalsIgnoreCase("dedup");
+				if (lineageType.equalsIgnoreCase("dedup"))
+					dmlOptions.lineage_dedup = lineageType.equalsIgnoreCase("dedup");
+				else
+					throw new org.apache.commons.cli.ParseException("Invalid argument specified for -lineage option");
 			}
 		}
 		dmlOptions.debug = line.hasOption("debug");

--- a/src/main/java/org/tugraz/sysds/runtime/controlprogram/ProgramBlock.java
+++ b/src/main/java/org/tugraz/sysds/runtime/controlprogram/ProgramBlock.java
@@ -39,12 +39,9 @@ import org.tugraz.sysds.runtime.controlprogram.caching.MatrixObject;
 import org.tugraz.sysds.runtime.controlprogram.caching.MatrixObject.UpdateType;
 import org.tugraz.sysds.runtime.controlprogram.context.ExecutionContext;
 import org.tugraz.sysds.runtime.instructions.Instruction;
-import org.tugraz.sysds.runtime.instructions.cp.BooleanObject;
-import org.tugraz.sysds.runtime.instructions.cp.Data;
-import org.tugraz.sysds.runtime.instructions.cp.DoubleObject;
-import org.tugraz.sysds.runtime.instructions.cp.IntObject;
-import org.tugraz.sysds.runtime.instructions.cp.ScalarObject;
-import org.tugraz.sysds.runtime.instructions.cp.StringObject;
+import org.tugraz.sysds.runtime.instructions.cp.*;
+import org.tugraz.sysds.runtime.lineage.LineageItem;
+import org.tugraz.sysds.runtime.lineage.LineageCache;
 import org.tugraz.sysds.runtime.matrix.data.MatrixBlock;
 import org.tugraz.sysds.utils.Statistics;
 
@@ -201,8 +198,13 @@ public abstract class ProgramBlock implements ParseInfo
 			// pre-process instruction (debug state, inst patching, listeners)
 			Instruction tmp = currInst.preprocessInstruction( ec );
 
-			// process actual instruction
-			tmp.processInstruction( ec );
+			// Try to reuse instruction result from lineage cache
+			boolean reused = LineageCache.reuse(tmp, ec);
+			
+			if (!reused) {
+				// process actual instruction
+				tmp.processInstruction(ec);
+			}
 
 			// post-process instruction (debug)
 			tmp.postprocessInstruction( ec );

--- a/src/main/java/org/tugraz/sysds/runtime/controlprogram/ProgramBlock.java
+++ b/src/main/java/org/tugraz/sysds/runtime/controlprogram/ProgramBlock.java
@@ -39,8 +39,12 @@ import org.tugraz.sysds.runtime.controlprogram.caching.MatrixObject;
 import org.tugraz.sysds.runtime.controlprogram.caching.MatrixObject.UpdateType;
 import org.tugraz.sysds.runtime.controlprogram.context.ExecutionContext;
 import org.tugraz.sysds.runtime.instructions.Instruction;
-import org.tugraz.sysds.runtime.instructions.cp.*;
-import org.tugraz.sysds.runtime.lineage.LineageItem;
+import org.tugraz.sysds.runtime.instructions.cp.BooleanObject;
+import org.tugraz.sysds.runtime.instructions.cp.Data;
+import org.tugraz.sysds.runtime.instructions.cp.DoubleObject;
+import org.tugraz.sysds.runtime.instructions.cp.IntObject;
+import org.tugraz.sysds.runtime.instructions.cp.ScalarObject;
+import org.tugraz.sysds.runtime.instructions.cp.StringObject;
 import org.tugraz.sysds.runtime.lineage.LineageCache;
 import org.tugraz.sysds.runtime.matrix.data.MatrixBlock;
 import org.tugraz.sysds.utils.Statistics;
@@ -204,6 +208,8 @@ public abstract class ProgramBlock implements ParseInfo
 			if (!reused) {
 				// process actual instruction
 				tmp.processInstruction(ec);
+				// cache result
+				LineageCache.put(tmp, ec);
 			}
 
 			// post-process instruction (debug)

--- a/src/main/java/org/tugraz/sysds/runtime/instructions/Instruction.java
+++ b/src/main/java/org/tugraz/sysds/runtime/instructions/Instruction.java
@@ -25,12 +25,7 @@ import org.tugraz.sysds.api.DMLScript;
 import org.tugraz.sysds.lops.Lop;
 import org.tugraz.sysds.parser.DataIdentifier;
 import org.tugraz.sysds.runtime.controlprogram.context.ExecutionContext;
-import org.tugraz.sysds.runtime.instructions.cp.ComputationCPInstruction;
-import org.tugraz.sysds.runtime.instructions.cp.Data;
 import org.tugraz.sysds.runtime.lineage.Lineage;
-import org.tugraz.sysds.runtime.lineage.LineageCache;
-import org.tugraz.sysds.runtime.lineage.LineageItem;
-import org.tugraz.sysds.runtime.lineage.LineageTraceable;
 
 
 public abstract class Instruction 
@@ -222,6 +217,9 @@ public abstract class Instruction
 	 * @return instruction
 	 */
 	public Instruction preprocessInstruction(ExecutionContext ec){
+		// Lineage tracing
+		if (DMLScript.LINEAGE)
+			Lineage.trace(this, ec);
 		//return instruction ifself
 		return this;
 	}
@@ -241,16 +239,5 @@ public abstract class Instruction
 	 * @param ec execution context
 	 */
 	public void postprocessInstruction(ExecutionContext ec) {
-		if (DMLScript.LINEAGE) {
-			Lineage.trace(this, ec);
-			
-			if (this instanceof ComputationCPInstruction) {
-				LineageItem[] items = ((LineageTraceable) this).getLineageItems();
-				if (items.length == 1) {
-					Data dat = ec.getVariable(((ComputationCPInstruction) this).output);
-					LineageCache.put(items[0], dat);
-				}
-			}
-		}
 	}
 }

--- a/src/main/java/org/tugraz/sysds/runtime/instructions/Instruction.java
+++ b/src/main/java/org/tugraz/sysds/runtime/instructions/Instruction.java
@@ -25,7 +25,12 @@ import org.tugraz.sysds.api.DMLScript;
 import org.tugraz.sysds.lops.Lop;
 import org.tugraz.sysds.parser.DataIdentifier;
 import org.tugraz.sysds.runtime.controlprogram.context.ExecutionContext;
+import org.tugraz.sysds.runtime.instructions.cp.ComputationCPInstruction;
+import org.tugraz.sysds.runtime.instructions.cp.Data;
 import org.tugraz.sysds.runtime.lineage.Lineage;
+import org.tugraz.sysds.runtime.lineage.LineageCache;
+import org.tugraz.sysds.runtime.lineage.LineageItem;
+import org.tugraz.sysds.runtime.lineage.LineageTraceable;
 
 
 public abstract class Instruction 
@@ -236,7 +241,16 @@ public abstract class Instruction
 	 * @param ec execution context
 	 */
 	public void postprocessInstruction(ExecutionContext ec) {
-		if (DMLScript.LINEAGE)
+		if (DMLScript.LINEAGE) {
 			Lineage.trace(this, ec);
+			
+			if (this instanceof ComputationCPInstruction) {
+				LineageItem[] items = ((LineageTraceable) this).getLineageItems();
+				if (items.length == 1) {
+					Data dat = ec.getVariable(((ComputationCPInstruction) this).output);
+					LineageCache.put(items[0], dat);
+				}
+			}
+		}
 	}
 }

--- a/src/main/java/org/tugraz/sysds/runtime/instructions/cp/DataGenCPInstruction.java
+++ b/src/main/java/org/tugraz/sysds/runtime/instructions/cp/DataGenCPInstruction.java
@@ -50,7 +50,7 @@ public class DataGenCPInstruction extends UnaryCPInstruction {
 	private final double minValue, maxValue, sparsity;
 	private final String pdf, pdfParams;
 	private final long seed;
-	private long runtimeSeed;
+	private Long runtimeSeed;
 
 	// sequence specific attributes
 	private final CPOperand seq_from, seq_to, seq_incr;
@@ -266,9 +266,10 @@ public class DataGenCPInstruction extends UnaryCPInstruction {
 			
 			//generate pseudo-random seed (because not specified) 
 			long lSeed = seed; //seed per invocation
-			if( lSeed == DataGenOp.UNSPECIFIED_SEED ) {
-				lSeed = DataGenOp.generateRandomSeed();
-				runtimeSeed = lSeed;
+			if (lSeed == DataGenOp.UNSPECIFIED_SEED) {
+				if (runtimeSeed == null)
+					runtimeSeed = DataGenOp.generateRandomSeed();
+				lSeed = runtimeSeed;
 			}
 			
 			if( LOG.isTraceEnabled() )
@@ -363,11 +364,17 @@ public class DataGenCPInstruction extends UnaryCPInstruction {
 	public LineageItem[] getLineageItems() {
 		String tmpInstStr = instString;
 		if (getSeed() == DataGenOp.UNSPECIFIED_SEED) {
+			
+			//generate pseudo-random seed (because not specified)
+			if (runtimeSeed == null)
+				runtimeSeed = DataGenOp.generateRandomSeed();
+			
 			int position = (method == DataGenMethod.RAND) ? SEED_POSITION_RAND + 1 :
-				(method == DataGenMethod.SAMPLE) ? SEED_POSITION_SAMPLE + 1 : 0;
+					(method == DataGenMethod.SAMPLE) ? SEED_POSITION_SAMPLE + 1 : 0;
 			tmpInstStr = InstructionUtils.replaceOperand(
-				tmpInstStr, position, String.valueOf(runtimeSeed));
+					tmpInstStr, position, String.valueOf(runtimeSeed));
 		}
+		
 		return new LineageItem[]{new LineageItem(output.getName(), tmpInstStr, getOpcode())};
 	}
 }

--- a/src/main/java/org/tugraz/sysds/runtime/instructions/cp/DataGenCPInstruction.java
+++ b/src/main/java/org/tugraz/sysds/runtime/instructions/cp/DataGenCPInstruction.java
@@ -59,6 +59,10 @@ public class DataGenCPInstruction extends UnaryCPInstruction {
 	private final boolean replace;
 	private final int numThreads;
 
+	// seed positions
+	private static final int SEED_POSITION_RAND = 9;
+	private static final int SEED_POSITION_SAMPLE = 4;
+
 	private DataGenCPInstruction(Operator op, DataGenMethod mthd, CPOperand in, CPOperand out, 
 			CPOperand rows, CPOperand cols, CPOperand dims, int rpb, int cpb, String minValue, String maxValue, double sparsity, long seed,
 			String probabilityDensityFunction, String pdfParams, int k, 
@@ -132,6 +136,8 @@ public class DataGenCPInstruction extends UnaryCPInstruction {
 	public long getCols() {
 		return cols.isLiteral() ? Long.parseLong(cols.getName()) : -1;
 	}
+
+	public String getDims() { return dims.getName(); }
 	
 	public int getRowsInBlock() {
 		return rowsInBlock;
@@ -204,8 +210,8 @@ public class DataGenCPInstruction extends UnaryCPInstruction {
 			int cpb = Integer.parseInt(s[5]);
 			double sparsity = !s[8].contains(Lop.VARIABLE_NAME_PLACEHOLDER) ?
 					Double.valueOf(s[8]) : -1;
-			long seed = !s[9].contains(Lop.VARIABLE_NAME_PLACEHOLDER) ?
-					Long.valueOf(s[9]) : -1;
+			long seed = !s[SEED_POSITION_RAND].contains(Lop.VARIABLE_NAME_PLACEHOLDER) ?
+					Long.valueOf(s[SEED_POSITION_RAND]) : -1;
 			String pdf = s[10];
 			String pdfParams = !s[11].contains( Lop.VARIABLE_NAME_PLACEHOLDER) ?
 				s[11] : null;
@@ -231,7 +237,7 @@ public class DataGenCPInstruction extends UnaryCPInstruction {
 			boolean replace = (!s[3].contains(Lop.VARIABLE_NAME_PLACEHOLDER) 
 				&& Boolean.valueOf(s[3]));
 			
-			long seed = Long.parseLong(s[4]);
+			long seed = Long.parseLong(s[SEED_POSITION_SAMPLE]);
 			int rpb = Integer.parseInt(s[5]);
 			int cpb = Integer.parseInt(s[6]);
 			
@@ -357,8 +363,8 @@ public class DataGenCPInstruction extends UnaryCPInstruction {
 	public LineageItem[] getLineageItems() {
 		String tmpInstStr = instString;
 		if (getSeed() == DataGenOp.UNSPECIFIED_SEED) {
-			int position = (method == DataGenMethod.RAND) ? 10 :
-				(method == DataGenMethod.SAMPLE) ? 5 : 0;
+			int position = (method == DataGenMethod.RAND) ? SEED_POSITION_RAND + 1 :
+				(method == DataGenMethod.SAMPLE) ? SEED_POSITION_SAMPLE + 1 : 0;
 			tmpInstStr = InstructionUtils.replaceOperand(
 				tmpInstStr, position, String.valueOf(runtimeSeed));
 		}

--- a/src/main/java/org/tugraz/sysds/runtime/instructions/cp/DataGenCPInstruction.java
+++ b/src/main/java/org/tugraz/sysds/runtime/instructions/cp/DataGenCPInstruction.java
@@ -266,7 +266,7 @@ public class DataGenCPInstruction extends UnaryCPInstruction {
 			
 			//generate pseudo-random seed (because not specified) 
 			long lSeed = seed; //seed per invocation
-			if (lSeed == DataGenOp.UNSPECIFIED_SEED) {
+			if( lSeed == DataGenOp.UNSPECIFIED_SEED ) {
 				if (runtimeSeed == null)
 					runtimeSeed = DataGenOp.generateRandomSeed();
 				lSeed = runtimeSeed;
@@ -364,7 +364,6 @@ public class DataGenCPInstruction extends UnaryCPInstruction {
 	public LineageItem[] getLineageItems() {
 		String tmpInstStr = instString;
 		if (getSeed() == DataGenOp.UNSPECIFIED_SEED) {
-			
 			//generate pseudo-random seed (because not specified)
 			if (runtimeSeed == null)
 				runtimeSeed = DataGenOp.generateRandomSeed();
@@ -374,7 +373,6 @@ public class DataGenCPInstruction extends UnaryCPInstruction {
 			tmpInstStr = InstructionUtils.replaceOperand(
 					tmpInstStr, position, String.valueOf(runtimeSeed));
 		}
-		
 		return new LineageItem[]{new LineageItem(output.getName(), tmpInstStr, getOpcode())};
 	}
 }

--- a/src/main/java/org/tugraz/sysds/runtime/instructions/cp/VariableCPInstruction.java
+++ b/src/main/java/org/tugraz/sysds/runtime/instructions/cp/VariableCPInstruction.java
@@ -1171,7 +1171,7 @@ public class VariableCPInstruction extends CPInstruction implements LineageTrace
 				for (CPOperand input : getInputs())
 					if (!input.getName().isEmpty())
 						lineages.add(Lineage.getOrCreate(input));
-				if (_formatProperties != null && !_formatProperties.getDescription().isEmpty())
+				if (_formatProperties != null && _formatProperties.getDescription() != null && !_formatProperties.getDescription().isEmpty())
 					lineages.add(new LineageItem(_formatProperties.getDescription()));
 				li = new LineageItem(getInput1().getName(),
 						getOpcode(), lineages.toArray(new LineageItem[0]));

--- a/src/main/java/org/tugraz/sysds/runtime/instructions/spark/ComputationSPInstruction.java
+++ b/src/main/java/org/tugraz/sysds/runtime/instructions/spark/ComputationSPInstruction.java
@@ -26,10 +26,15 @@ import org.tugraz.sysds.runtime.functionobjects.ReduceAll;
 import org.tugraz.sysds.runtime.functionobjects.ReduceCol;
 import org.tugraz.sysds.runtime.functionobjects.ReduceRow;
 import org.tugraz.sysds.runtime.instructions.cp.CPOperand;
+import org.tugraz.sysds.runtime.lineage.Lineage;
+import org.tugraz.sysds.runtime.lineage.LineageItem;
+import org.tugraz.sysds.runtime.lineage.LineageTraceable;
 import org.tugraz.sysds.runtime.matrix.operators.Operator;
 import org.tugraz.sysds.runtime.meta.MatrixCharacteristics;
 
-public abstract class ComputationSPInstruction extends SPInstruction {
+import java.util.ArrayList;
+
+public abstract class ComputationSPInstruction extends SPInstruction implements LineageTraceable {
 	public CPOperand output;
 	public CPOperand input1, input2, input3;
 
@@ -103,5 +108,18 @@ public abstract class ComputationSPInstruction extends SPInstruction {
 			else if( ixFn instanceof ReduceRow )
 				mcOut.set(1, mc1.getCols(), mc1.getRowsPerBlock(), mc1.getColsPerBlock());
 		}
+	}
+	
+	@Override
+	public LineageItem[] getLineageItems() {
+		ArrayList<LineageItem> lineages = new ArrayList<>();
+		if (input1 != null)
+			lineages.add(Lineage.getOrCreate(input1));
+		if (input2 != null)
+			lineages.add(Lineage.getOrCreate(input2));
+		if (input3 != null)
+			lineages.add(Lineage.getOrCreate(input3));
+		return new LineageItem[]{new LineageItem(output.getName(),
+				getOpcode(), lineages.toArray(new LineageItem[0]))};
 	}
 }

--- a/src/main/java/org/tugraz/sysds/runtime/instructions/spark/ReblockSPInstruction.java
+++ b/src/main/java/org/tugraz/sysds/runtime/instructions/spark/ReblockSPInstruction.java
@@ -54,7 +54,7 @@ import org.tugraz.sysds.utils.Statistics;
 
 import java.util.ArrayList;
 
-public class ReblockSPInstruction extends UnarySPInstruction implements LineageTraceable {
+public class ReblockSPInstruction extends UnarySPInstruction{
 	private int brlen;
 	private int bclen;
 	private boolean outputEmptyBlocks;
@@ -242,16 +242,16 @@ public class ReblockSPInstruction extends UnarySPInstruction implements LineageT
 		}
 	}
 
-	@Override
-	public LineageItem[] getLineageItems() {
-		ArrayList<LineageItem> lineages = new ArrayList<>();
-		if (input1 != null)
-			lineages.add(Lineage.getOrCreate(input1));
-		if (input2 != null)
-			lineages.add(Lineage.getOrCreate(input2));
-		if (input3 != null)
-			lineages.add(Lineage.getOrCreate(input3));
-
-		return new LineageItem[]{new LineageItem(output.getName(), getOpcode(), lineages.toArray(new LineageItem[0]))};
-	}
+//	@Override
+//	public LineageItem[] getLineageItems() {
+//		ArrayList<LineageItem> lineages = new ArrayList<>();
+//		if (input1 != null)
+//			lineages.add(Lineage.getOrCreate(input1));
+//		if (input2 != null)
+//			lineages.add(Lineage.getOrCreate(input2));
+//		if (input3 != null)
+//			lineages.add(Lineage.getOrCreate(input3));
+//
+//		return new LineageItem[]{new LineageItem(output.getName(), getOpcode(), lineages.toArray(new LineageItem[0]))};
+//	}
 }

--- a/src/main/java/org/tugraz/sysds/runtime/instructions/spark/ReblockSPInstruction.java
+++ b/src/main/java/org/tugraz/sysds/runtime/instructions/spark/ReblockSPInstruction.java
@@ -39,9 +39,6 @@ import org.tugraz.sysds.runtime.instructions.spark.utils.RDDConverterUtils;
 import org.tugraz.sysds.runtime.io.FileFormatPropertiesCSV;
 import org.tugraz.sysds.runtime.io.FileFormatPropertiesMM;
 import org.tugraz.sysds.runtime.io.IOUtilFunctions;
-import org.tugraz.sysds.runtime.lineage.Lineage;
-import org.tugraz.sysds.runtime.lineage.LineageItem;
-import org.tugraz.sysds.runtime.lineage.LineageTraceable;
 import org.tugraz.sysds.runtime.matrix.data.FrameBlock;
 import org.tugraz.sysds.runtime.matrix.data.InputInfo;
 import org.tugraz.sysds.runtime.matrix.data.MatrixBlock;
@@ -52,9 +49,7 @@ import org.tugraz.sysds.runtime.meta.MatrixCharacteristics;
 import org.tugraz.sysds.runtime.meta.MetaDataFormat;
 import org.tugraz.sysds.utils.Statistics;
 
-import java.util.ArrayList;
-
-public class ReblockSPInstruction extends UnarySPInstruction{
+public class ReblockSPInstruction extends UnarySPInstruction {
 	private int brlen;
 	private int bclen;
 	private boolean outputEmptyBlocks;
@@ -241,17 +236,4 @@ public class ReblockSPInstruction extends UnarySPInstruction{
 				+ "for ReblockSPInstruction: " + InputInfo.inputInfoToString(iinfo));
 		}
 	}
-
-//	@Override
-//	public LineageItem[] getLineageItems() {
-//		ArrayList<LineageItem> lineages = new ArrayList<>();
-//		if (input1 != null)
-//			lineages.add(Lineage.getOrCreate(input1));
-//		if (input2 != null)
-//			lineages.add(Lineage.getOrCreate(input2));
-//		if (input3 != null)
-//			lineages.add(Lineage.getOrCreate(input3));
-//
-//		return new LineageItem[]{new LineageItem(output.getName(), getOpcode(), lineages.toArray(new LineageItem[0]))};
-//	}
 }

--- a/src/main/java/org/tugraz/sysds/runtime/lineage/Lineage.java
+++ b/src/main/java/org/tugraz/sysds/runtime/lineage/Lineage.java
@@ -48,20 +48,20 @@ public class Lineage {
 	
 	public static LineageItem getOrCreate(CPOperand variable) {
 		return _initDedupBlock.empty() ?
-			_globalLineages.getOrCreate(variable) :
-			_initDedupBlock.peek().getActiveMap().getOrCreate(variable);
+				_globalLineages.getOrCreate(variable) :
+				_initDedupBlock.peek().getActiveMap().getOrCreate(variable);
 	}
 	
 	public static boolean contains(CPOperand variable) {
 		return _initDedupBlock.empty() ?
-			_globalLineages.containsKey(variable.getName()) :
-			_initDedupBlock.peek().getActiveMap().containsKey(variable.getName());
+				_globalLineages.containsKey(variable.getName()) :
+				_initDedupBlock.peek().getActiveMap().containsKey(variable.getName());
 	}
 	
 	public static LineageItem get(CPOperand variable) {
 		return _initDedupBlock.empty() ?
-			_globalLineages.get(variable) :
-			_initDedupBlock.peek().getActiveMap().get(variable);
+				_globalLineages.get(variable) :
+				_initDedupBlock.peek().getActiveMap().get(variable);
 	}
 	
 	public static void pushInitDedupBlock(LineageDedupBlock ldb) {
@@ -82,7 +82,13 @@ public class Lineage {
 		_activeDedupBlock.pop();
 	}
 	
-	public static void resetLineageMaps() {
+	public static void resetObjects() {
+		LineageItem.resetIDSequence();
+		LineageCache.resetCache();
+		Lineage.resetLineageMaps();
+	}
+	
+	private static void resetLineageMaps() {
 		_globalLineages.resetLineageMaps();
 	}
 }

--- a/src/main/java/org/tugraz/sysds/runtime/lineage/LineageCache.java
+++ b/src/main/java/org/tugraz/sysds/runtime/lineage/LineageCache.java
@@ -1,9 +1,11 @@
 package org.tugraz.sysds.runtime.lineage;
 
+import org.tugraz.sysds.api.DMLScript;
 import org.tugraz.sysds.runtime.controlprogram.context.ExecutionContext;
 import org.tugraz.sysds.runtime.instructions.Instruction;
 import org.tugraz.sysds.runtime.instructions.cp.ComputationCPInstruction;
 import org.tugraz.sysds.runtime.instructions.cp.Data;
+import org.tugraz.sysds.runtime.instructions.cp.DataGenCPInstruction;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -15,6 +17,16 @@ public class LineageCache {
 		_cache.put(key, value);
 	}
 	
+	public static void put(Instruction inst, ExecutionContext ec) {
+		if (inst instanceof DataGenCPInstruction) {
+			LineageItem[] items = ((LineageTraceable) inst).getLineageItems();
+			for (LineageItem item : items) {
+				Data d = ec.getVariable(((ComputationCPInstruction) inst).output);
+				LineageCache.put(item, d);
+			}
+		}
+	}
+	
 	public static boolean probe(LineageItem key) {
 		return _cache.containsKey(key);
 	}
@@ -23,7 +35,14 @@ public class LineageCache {
 		return _cache.get(key);
 	}
 	
+	public static void resetCache() {
+		_cache.clear();
+	}
+	
 	public static boolean reuse(Instruction inst, ExecutionContext ec) {
+		if (!DMLScript.LINEAGE)
+			return false;
+		
 		if (inst instanceof ComputationCPInstruction) {
 			boolean reused = true;
 			LineageItem[] items = ((ComputationCPInstruction) inst).getLineageItems();

--- a/src/main/java/org/tugraz/sysds/runtime/lineage/LineageCache.java
+++ b/src/main/java/org/tugraz/sysds/runtime/lineage/LineageCache.java
@@ -1,0 +1,42 @@
+package org.tugraz.sysds.runtime.lineage;
+
+import org.tugraz.sysds.runtime.controlprogram.context.ExecutionContext;
+import org.tugraz.sysds.runtime.instructions.Instruction;
+import org.tugraz.sysds.runtime.instructions.cp.ComputationCPInstruction;
+import org.tugraz.sysds.runtime.instructions.cp.Data;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class LineageCache {
+	private static final Map<LineageItem, Data> _cache = new HashMap<>();
+	
+	public static void put(LineageItem key, Data value) {
+		_cache.put(key, value);
+	}
+	
+	public static boolean probe(LineageItem key) {
+		return _cache.containsKey(key);
+	}
+	
+	public static Data get(LineageItem key) {
+		return _cache.get(key);
+	}
+	
+	public static boolean reuse(Instruction inst, ExecutionContext ec) {
+		if (inst instanceof ComputationCPInstruction) {
+			boolean reused = true;
+			LineageItem[] items = ((ComputationCPInstruction) inst).getLineageItems();
+			for (LineageItem item : items) {
+				if (LineageCache.probe(item)) {
+					Data d = LineageCache.get(item);
+					ec.setVariable(((ComputationCPInstruction) inst).output.getName(), d);
+				} else
+					reused = false;
+			}
+			return reused && items.length > 0;
+		} else {
+			return false;
+		}
+	}
+}

--- a/src/main/java/org/tugraz/sysds/runtime/lineage/LineageItemUtils.java
+++ b/src/main/java/org/tugraz/sysds/runtime/lineage/LineageItemUtils.java
@@ -169,7 +169,7 @@ public class LineageItemUtils {
 					HashMap<String, Hop> params = new HashMap<>();
 					params.put(DataExpression.RAND_ROWS, new LiteralOp(rand.getRows()));
 					params.put(DataExpression.RAND_COLS, new LiteralOp(rand.getCols()));
-					params.put(DataExpression.RAND_DIMS, new LiteralOp("-1"));
+					params.put(DataExpression.RAND_DIMS, new LiteralOp(rand.getDims()));
 					params.put(DataExpression.RAND_MIN, new LiteralOp(rand.getMinValue()));
 					params.put(DataExpression.RAND_MAX, new LiteralOp(rand.getMaxValue()));
 					params.put(DataExpression.RAND_PDF, new LiteralOp(rand.getPdf()));

--- a/src/main/java/org/tugraz/sysds/runtime/lineage/LineageItemUtils.java
+++ b/src/main/java/org/tugraz/sysds/runtime/lineage/LineageItemUtils.java
@@ -143,6 +143,8 @@ public class LineageItemUtils {
 		pb.setInstructions(dag.getJobs(null,
 				ConfigurationManager.getDMLConfig()));
 		
+		// reset cache due to cleaned data objects
+		LineageCache.resetCache();
 		//execute instructions and get result
 		pb.execute(ec);
 		return ec.getVariable(varname);

--- a/src/test/java/org/tugraz/sysds/test/component/misc/CLIOptionsParserTest.java
+++ b/src/test/java/org/tugraz/sysds/test/component/misc/CLIOptionsParserTest.java
@@ -139,8 +139,15 @@ public class CLIOptionsParserTest {
 		Assert.assertEquals(true, o.lineage);
 		Assert.assertEquals(true, o.lineage_dedup);
 	}
-
-    @Test
+	
+	@Test(expected = ParseException.class)
+	public void testBadLineageOption() throws Exception {
+		String cl = "systemml -f test.dml -lineage ded";
+		String[] args = cl.split(" ");
+		DMLOptions.parseCLArguments(args);
+	}
+	
+	@Test
 	public void testGPUForce() throws Exception {
 		String cl = "systemml -f test.dml -gpu force";
 		String[] args = cl.split(" ");

--- a/src/test/java/org/tugraz/sysds/test/functions/lineage/FullReuseTest.java
+++ b/src/test/java/org/tugraz/sysds/test/functions/lineage/FullReuseTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2019 Graz University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.tugraz.sysds.test.functions.lineage;
+
+import org.junit.Test;
+import org.tugraz.sysds.hops.OptimizerUtils;
+import org.tugraz.sysds.runtime.lineage.LineageItem;
+import org.tugraz.sysds.runtime.lineage.LineageParser;
+import org.tugraz.sysds.test.AutomatedTestBase;
+import org.tugraz.sysds.test.TestConfiguration;
+import org.tugraz.sysds.test.TestUtils;
+import org.tugraz.sysds.utils.Explain;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class FullReuseTest extends AutomatedTestBase {
+	
+	protected static final String TEST_DIR = "functions/lineage/";
+	protected static final String TEST_NAME1 = "FullReuse1";
+	protected String TEST_CLASS_DIR = TEST_DIR + FullReuseTest.class.getSimpleName() + "/";
+	
+	protected static final int numRecords = 1024;
+	protected static final int numFeatures = 1024;
+	
+	
+	@Override
+	public void setUp() {
+		TestUtils.clearAssertionInformation();
+		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1));
+	}
+	
+	@Test
+	public void testLineageTrace1() {
+		testLineageTrace(TEST_NAME1);
+	}
+	
+	public void testLineageTrace(String testname) {
+		boolean old_simplification = OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION;
+		boolean old_sum_product = OptimizerUtils.ALLOW_SUM_PRODUCT_REWRITES;
+		
+		try {
+			System.out.println("------------ BEGIN " + testname + "------------");
+			
+			OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION = false;
+			OptimizerUtils.ALLOW_SUM_PRODUCT_REWRITES = false;
+			
+			int rows = numRecords;
+			int cols = numFeatures;
+			
+			getAndLoadTestConfiguration(testname);
+			
+			List<String> proArgs = new ArrayList<String>();
+			
+			proArgs.add("-stats");
+			proArgs.add("-lineage");
+			proArgs.add("-explain");
+			proArgs.add("-args");
+			proArgs.add(input("X"));
+			proArgs.add(output("X"));
+			programArgs = proArgs.toArray(new String[proArgs.size()]);
+			
+			fullDMLScriptName = getScript();
+			
+			double[][] X = getRandomMatrix(rows, cols, 0, 1, 0.8, -1);
+			writeInputMatrixWithMTD("X", X, true);
+			
+			LineageItem.resetIDSequence();
+			runTest(true, EXCEPTION_NOT_EXPECTED, null, -1);
+			
+			String X_lineage = readDMLLineageFromHDFS("X");
+			
+			LineageItem X_li = LineageParser.parseLineageTrace(X_lineage);
+			
+			TestUtils.compareScalars(X_lineage, Explain.explain(X_li));
+		} finally {
+			OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION = old_simplification;
+			OptimizerUtils.ALLOW_SUM_PRODUCT_REWRITES = old_sum_product;
+		}
+	}
+}

--- a/src/test/java/org/tugraz/sysds/test/functions/lineage/FullReuseTest.java
+++ b/src/test/java/org/tugraz/sysds/test/functions/lineage/FullReuseTest.java
@@ -18,6 +18,7 @@ package org.tugraz.sysds.test.functions.lineage;
 
 import org.junit.Test;
 import org.tugraz.sysds.hops.OptimizerUtils;
+import org.tugraz.sysds.runtime.lineage.Lineage;
 import org.tugraz.sysds.runtime.lineage.LineageItem;
 import org.tugraz.sysds.runtime.lineage.LineageParser;
 import org.tugraz.sysds.test.AutomatedTestBase;
@@ -32,6 +33,7 @@ public class FullReuseTest extends AutomatedTestBase {
 	
 	protected static final String TEST_DIR = "functions/lineage/";
 	protected static final String TEST_NAME1 = "FullReuse1";
+	protected static final String TEST_NAME2 = "FullReuse2";
 	protected String TEST_CLASS_DIR = TEST_DIR + FullReuseTest.class.getSimpleName() + "/";
 	
 	protected static final int numRecords = 1024;
@@ -42,11 +44,17 @@ public class FullReuseTest extends AutomatedTestBase {
 	public void setUp() {
 		TestUtils.clearAssertionInformation();
 		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1));
+		addTestConfiguration(TEST_NAME2, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME2));
 	}
 	
 	@Test
 	public void testLineageTrace1() {
 		testLineageTrace(TEST_NAME1);
+	}
+
+	@Test
+	public void testLineageTrace2() {
+		testLineageTrace(TEST_NAME2);
 	}
 	
 	public void testLineageTrace(String testname) {
@@ -79,7 +87,7 @@ public class FullReuseTest extends AutomatedTestBase {
 			double[][] X = getRandomMatrix(rows, cols, 0, 1, 0.8, -1);
 			writeInputMatrixWithMTD("X", X, true);
 			
-			LineageItem.resetIDSequence();
+			Lineage.resetObjects();
 			runTest(true, EXCEPTION_NOT_EXPECTED, null, -1);
 			
 			String X_lineage = readDMLLineageFromHDFS("X");

--- a/src/test/java/org/tugraz/sysds/test/functions/lineage/LineageTraceDedupTest.java
+++ b/src/test/java/org/tugraz/sysds/test/functions/lineage/LineageTraceDedupTest.java
@@ -119,8 +119,7 @@ public class LineageTraceDedupTest extends AutomatedTestBase {
 			proArgs.add(output("R"));
 			programArgs = proArgs.toArray(new String[proArgs.size()]);
 
-			LineageItem.resetIDSequence();
-			Lineage.resetLineageMaps();
+			Lineage.resetObjects();
 			runTest(true, EXCEPTION_NOT_EXPECTED, null, -1);
 
 			String trace = readDMLLineageFromHDFS("R");
@@ -137,7 +136,7 @@ public class LineageTraceDedupTest extends AutomatedTestBase {
 			proArgs.add(output("R"));
 			programArgs = proArgs.toArray(new String[proArgs.size()]);
 			
-			LineageItem.resetIDSequence();
+			Lineage.resetObjects();
 			runTest(true, EXCEPTION_NOT_EXPECTED, null, -1);
 			
 			String dedup_trace = readDMLLineageFromHDFS("R");

--- a/src/test/java/org/tugraz/sysds/test/functions/lineage/LineageTraceEqualsTest.java
+++ b/src/test/java/org/tugraz/sysds/test/functions/lineage/LineageTraceEqualsTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import org.junit.Test;
 import org.tugraz.sysds.hops.OptimizerUtils;
+import org.tugraz.sysds.runtime.lineage.Lineage;
 import org.tugraz.sysds.runtime.lineage.LineageItem;
 import org.tugraz.sysds.runtime.lineage.LineageParser;
 import org.tugraz.sysds.test.AutomatedTestBase;
@@ -86,7 +87,7 @@ public class LineageTraceEqualsTest extends AutomatedTestBase {
 			double[][] m = getRandomMatrix(rows, cols, 0, 1, 0.8, -1);
 			writeInputMatrixWithMTD("M", m, true);
 			
-			LineageItem.resetIDSequence();
+			Lineage.resetObjects();
 			runTest(true, EXCEPTION_NOT_EXPECTED, null, -1);
 			
 			String X_lineage = readDMLLineageFromHDFS("X");

--- a/src/test/java/org/tugraz/sysds/test/functions/lineage/LineageTraceExecTest.java
+++ b/src/test/java/org/tugraz/sysds/test/functions/lineage/LineageTraceExecTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.tugraz.sysds.runtime.controlprogram.caching.MatrixObject;
 import org.tugraz.sysds.runtime.instructions.cp.Data;
 import org.tugraz.sysds.runtime.instructions.cp.ScalarObject;
+import org.tugraz.sysds.runtime.lineage.Lineage;
 import org.tugraz.sysds.runtime.lineage.LineageItem;
 import org.tugraz.sysds.runtime.lineage.LineageItemUtils;
 import org.tugraz.sysds.runtime.lineage.LineageParser;
@@ -107,6 +108,7 @@ public class LineageTraceExecTest extends AutomatedTestBase {
 			writeInputMatrixWithMTD("X", X, true);
 		}
 		
+		Lineage.resetObjects();
 		//run the test
 		runTest(true, EXCEPTION_NOT_EXPECTED, null, -1);
 		

--- a/src/test/java/org/tugraz/sysds/test/functions/lineage/LineageTraceRandomTest.java
+++ b/src/test/java/org/tugraz/sysds/test/functions/lineage/LineageTraceRandomTest.java
@@ -18,6 +18,7 @@ package org.tugraz.sysds.test.functions.lineage;
 
 import org.junit.Test;
 import org.tugraz.sysds.hops.OptimizerUtils;
+import org.tugraz.sysds.runtime.lineage.Lineage;
 import org.tugraz.sysds.runtime.lineage.LineageItem;
 import org.tugraz.sysds.runtime.lineage.LineageParser;
 import org.tugraz.sysds.test.AutomatedTestBase;
@@ -70,7 +71,7 @@ public class LineageTraceRandomTest extends AutomatedTestBase {
 			
 			fullDMLScriptName = getScript();
 			
-			LineageItem.resetIDSequence();
+			Lineage.resetObjects();
 			runTest(true, EXCEPTION_NOT_EXPECTED, null, -1);
 			
 			String X_lineage = readDMLLineageFromHDFS("X");

--- a/src/test/java/org/tugraz/sysds/test/functions/lineage/LineageTraceTest.java
+++ b/src/test/java/org/tugraz/sysds/test/functions/lineage/LineageTraceTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import org.junit.Test;
 import org.tugraz.sysds.hops.OptimizerUtils;
+import org.tugraz.sysds.runtime.lineage.Lineage;
 import org.tugraz.sysds.runtime.lineage.LineageItem;
 import org.tugraz.sysds.runtime.lineage.LineageParser;
 import org.tugraz.sysds.test.AutomatedTestBase;
@@ -100,7 +101,7 @@ public class LineageTraceTest extends AutomatedTestBase {
 			double[][] X = getRandomMatrix(rows, cols, 0, 1, 0.8, -1);
 			writeInputMatrixWithMTD("X", X, true);
 			
-			LineageItem.resetIDSequence();
+			Lineage.resetObjects();
 			runTest(true, EXCEPTION_NOT_EXPECTED, null, -1);
 			
 			String X_lineage = readDMLLineageFromHDFS("X");

--- a/src/test/scripts/functions/lineage/FullReuse1.dml
+++ b/src/test/scripts/functions/lineage/FullReuse1.dml
@@ -1,0 +1,31 @@
+#-------------------------------------------------------------
+#
+# Copyright 2019 Graz University of Technology
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#-------------------------------------------------------------
+
+# How to invoke this dml script LineageTrace.dml?
+# Assume LR_HOME is set to the home of the dml script
+# Assume rows = 20 and cols = 20 for X
+# hadoop jar SystemML.jar -f $LR_HOME/LineageTrace.dml -args "$INPUT_DIR/X" "$OUTPUT_DIR/X" "$OUTPUT_DIR/Y"
+
+X = read($1);
+
+for(i in 1:100){
+    tmp = t(X) %*% X;
+}
+
+write(tmp, $2, format="text");
+

--- a/src/test/scripts/functions/lineage/FullReuse2.dml
+++ b/src/test/scripts/functions/lineage/FullReuse2.dml
@@ -21,11 +21,23 @@
 # Assume rows = 20 and cols = 20 for X
 # hadoop jar SystemML.jar -f $LR_HOME/LineageTrace.dml -args "$INPUT_DIR/X" "$OUTPUT_DIR/X" "$OUTPUT_DIR/Y"
 
-X = read($1);
+# Increase rows and cols for performance comparision
+X = rand(rows=10000, cols=100);
+y = rand(rows=10000, cols=1);
 
-for(i in 1:10){
-    tmp = t(X) %*% X;
+j = 10
+R = matrix(0, ncol(X), j);
+
+for(i in 1:j) {
+  lambda = 10 ^ -i;
+
+  print("lambda: " + toString(lambda));
+
+  A = t(X) %*% X + diag(matrix(lambda, rows=ncol(X), cols=1));
+  b = t(X) %*% y;
+  beta = solve(A, b);
+
+  R[,i] = beta;
 }
 
-write(tmp, $2, format="text");
-
+write(R, $2, format="text");


### PR DESCRIPTION
Hey @mboehm7,

I have some small changes for lineage tracing:

 * Fix CLI bug for `-lineage dedup` command
 * Add `LineageTracable` interface for `ComputationSPInstruction` 
 * Move `Lineage.trace()` from `postprocessInstruction()` into `preprocessInstruction()`
 * Adapt runtimeSeed generation for `DataGenCPInstruction`
 * Add simple full-reuse of already computed instructions by `LineageItem` as key
