### PR TITLE
[SYSTEMDS-75] Adapt LineageCache to MatrixBlock

### DIFF
--- a/src/main/java/org/tugraz/sysds/api/DMLOptions.java
+++ b/src/main/java/org/tugraz/sysds/api/DMLOptions.java
@@ -58,7 +58,8 @@ public class DMLOptions {
 	public String               script        = null;             // the script itself
 	public boolean              help          = false;            // whether to print the usage option
 	public boolean              lineage       = false;            // whether compute lineage trace
-	public boolean              lineage_dedup = false;             // whether deduplicate lineage items
+	public boolean              lineage_dedup = false;            // whether deduplicate lineage items
+	public boolean              lineage_reuse = false;            // whether lineage-based reuse of intermediates
 
 	public final static DMLOptions defaultOptions = new DMLOptions(null);
 
@@ -108,6 +109,8 @@ public class DMLOptions {
 			if (lineageType != null){
 				if (lineageType.equalsIgnoreCase("dedup"))
 					dmlOptions.lineage_dedup = lineageType.equalsIgnoreCase("dedup");
+				else if (lineageType.equalsIgnoreCase("reuse"))
+					dmlOptions.lineage_reuse = lineageType.equalsIgnoreCase("reuse");
 				else
 					throw new org.apache.commons.cli.ParseException("Invalid argument specified for -lineage option");
 			}

--- a/src/main/java/org/tugraz/sysds/api/DMLScript.java
+++ b/src/main/java/org/tugraz/sysds/api/DMLScript.java
@@ -97,6 +97,7 @@ public class DMLScript
 	public static String      GPU_MEMORY_ALLOCATOR = "cuda";                                // GPU memory allocator to use
 	public static boolean     LINEAGE = DMLOptions.defaultOptions.lineage;                  // whether compute lineage trace
 	public static boolean     LINEAGE_DEDUP = DMLOptions.defaultOptions.lineage_dedup;      // whether deduplicate lineage items
+	public static boolean     LINEAGE_REUSE = DMLOptions.defaultOptions.lineage_reuse;      // whether lineage-based reuse
 
 	public static boolean           USE_ACCELERATOR     = DMLOptions.defaultOptions.gpu;
 	public static boolean           FORCE_ACCELERATOR   = DMLOptions.defaultOptions.forceGPU;
@@ -198,6 +199,7 @@ public class DMLScript
 			EXEC_MODE           = dmlOptions.execMode;
 			LINEAGE             = dmlOptions.lineage;
 			LINEAGE_DEDUP       = dmlOptions.lineage_dedup;
+			LINEAGE_REUSE       = dmlOptions.lineage_reuse;
 
 			String fnameOptConfig = dmlOptions.configFile;
 			boolean isFile = dmlOptions.filePath != null;

--- a/src/main/java/org/tugraz/sysds/runtime/instructions/cp/MatrixIndexingCPInstruction.java
+++ b/src/main/java/org/tugraz/sysds/runtime/instructions/cp/MatrixIndexingCPInstruction.java
@@ -28,9 +28,13 @@ import org.tugraz.sysds.runtime.DMLRuntimeException;
 import org.tugraz.sysds.runtime.controlprogram.caching.MatrixObject;
 import org.tugraz.sysds.runtime.controlprogram.caching.MatrixObject.UpdateType;
 import org.tugraz.sysds.runtime.controlprogram.context.ExecutionContext;
+import org.tugraz.sysds.runtime.lineage.Lineage;
+import org.tugraz.sysds.runtime.lineage.LineageItem;
 import org.tugraz.sysds.runtime.matrix.data.MatrixBlock;
 import org.tugraz.sysds.runtime.util.IndexRange;
 import org.tugraz.sysds.utils.Statistics;
+
+import java.util.ArrayList;
 
 public final class MatrixIndexingCPInstruction extends IndexingCPInstruction {
 
@@ -116,5 +120,27 @@ public final class MatrixIndexingCPInstruction extends IndexingCPInstruction {
 		}
 		else
 			throw new DMLRuntimeException("Invalid opcode (" + opcode +") encountered in MatrixIndexingCPInstruction.");
+	}
+	
+	@Override
+	public LineageItem[] getLineageItems() {
+		ArrayList<LineageItem> lineages = new ArrayList<>();
+		if (input1 != null)
+			lineages.add(Lineage.getOrCreate(input1));
+		if (input2 != null)
+			lineages.add(Lineage.getOrCreate(input2));
+		if (input3 != null)
+			lineages.add(Lineage.getOrCreate(input3));
+		if (colLower != null)
+			lineages.add(Lineage.getOrCreate(colLower));
+		if (colUpper != null)
+			lineages.add(Lineage.getOrCreate(colUpper));
+		if (rowLower != null)
+			lineages.add(Lineage.getOrCreate(rowLower));
+		if (rowUpper != null)
+			lineages.add(Lineage.getOrCreate(rowUpper));
+		
+		return new LineageItem[]{new LineageItem(output.getName(),
+				getOpcode(), lineages.toArray(new LineageItem[0]))};
 	}
 }

--- a/src/main/java/org/tugraz/sysds/runtime/lineage/LineageCache.java
+++ b/src/main/java/org/tugraz/sysds/runtime/lineage/LineageCache.java
@@ -1,28 +1,30 @@
 package org.tugraz.sysds.runtime.lineage;
 
 import org.tugraz.sysds.api.DMLScript;
+import org.tugraz.sysds.common.Types;
+import org.tugraz.sysds.runtime.controlprogram.caching.MatrixObject;
 import org.tugraz.sysds.runtime.controlprogram.context.ExecutionContext;
 import org.tugraz.sysds.runtime.instructions.Instruction;
 import org.tugraz.sysds.runtime.instructions.cp.ComputationCPInstruction;
-import org.tugraz.sysds.runtime.instructions.cp.Data;
-import org.tugraz.sysds.runtime.instructions.cp.DataGenCPInstruction;
+import org.tugraz.sysds.runtime.matrix.data.MatrixBlock;
 
 import java.util.HashMap;
 import java.util.Map;
 
 public class LineageCache {
-	private static final Map<LineageItem, Data> _cache = new HashMap<>();
-	
-	public static void put(LineageItem key, Data value) {
-		_cache.put(key, value);
-	}
+	private static final Map<LineageItem, MatrixBlock> _cache = new HashMap<>();
 	
 	public static void put(Instruction inst, ExecutionContext ec) {
-		if (inst instanceof DataGenCPInstruction) {
-			LineageItem[] items = ((LineageTraceable) inst).getLineageItems();
-			for (LineageItem item : items) {
-				Data d = ec.getVariable(((ComputationCPInstruction) inst).output);
-				LineageCache.put(item, d);
+		if (!DMLScript.LINEAGE_REUSE)
+			return;
+		
+		if (inst instanceof ComputationCPInstruction &&
+				((ComputationCPInstruction) inst).output.getDataType() == Types.DataType.MATRIX) {
+			
+			for (LineageItem item : ((LineageTraceable) inst).getLineageItems()) {
+				MatrixObject mo = ec.getMatrixObject(((ComputationCPInstruction) inst).output);
+				LineageCache._cache.put(item, mo.acquireRead());
+				mo.release();
 			}
 		}
 	}
@@ -31,7 +33,7 @@ public class LineageCache {
 		return _cache.containsKey(key);
 	}
 	
-	public static Data get(LineageItem key) {
+	public static MatrixBlock get(LineageItem key) {
 		return _cache.get(key);
 	}
 	
@@ -40,17 +42,16 @@ public class LineageCache {
 	}
 	
 	public static boolean reuse(Instruction inst, ExecutionContext ec) {
-		if (!DMLScript.LINEAGE)
+		if (!DMLScript.LINEAGE && DMLScript.LINEAGE_REUSE)
 			return false;
 		
 		if (inst instanceof ComputationCPInstruction) {
 			boolean reused = true;
 			LineageItem[] items = ((ComputationCPInstruction) inst).getLineageItems();
 			for (LineageItem item : items) {
-				if (LineageCache.probe(item)) {
-					Data d = LineageCache.get(item);
-					ec.setVariable(((ComputationCPInstruction) inst).output.getName(), d);
-				} else
+				if (LineageCache.probe(item))
+					ec.setMatrixOutput(((ComputationCPInstruction) inst).output.getName(), LineageCache.get(item));
+				else
 					reused = false;
 			}
 			return reused && items.length > 0;

--- a/src/test/java/org/tugraz/sysds/test/component/misc/CLIOptionsParserTest.java
+++ b/src/test/java/org/tugraz/sysds/test/component/misc/CLIOptionsParserTest.java
@@ -129,6 +129,7 @@ public class CLIOptionsParserTest {
         DMLOptions o = DMLOptions.parseCLArguments(args);
         Assert.assertEquals(true, o.lineage);
 		Assert.assertEquals(false, o.lineage_dedup);
+		Assert.assertEquals(false, o.lineage_reuse);
     }
     
 	@Test
@@ -138,11 +139,39 @@ public class CLIOptionsParserTest {
 		DMLOptions o = DMLOptions.parseCLArguments(args);
 		Assert.assertEquals(true, o.lineage);
 		Assert.assertEquals(true, o.lineage_dedup);
+		Assert.assertEquals(false, o.lineage_reuse);
+	}
+	
+	@Test
+	public void testLineageReuse() throws Exception {
+		String cl = "systemml -f test.dml -lineage reuse";
+		String[] args = cl.split(" ");
+		DMLOptions o = DMLOptions.parseCLArguments(args);
+		Assert.assertEquals(true, o.lineage);
+		Assert.assertEquals(true, o.lineage_reuse);
+		Assert.assertEquals(false, o.lineage_dedup);
+	}
+	
+	@Test
+	public void testLineageDedupAndReuse() throws Exception {
+		String cl = "systemml -f test.dml -lineage dedup reuse";
+		String[] args = cl.split(" ");
+		DMLOptions o = DMLOptions.parseCLArguments(args);
+		Assert.assertEquals(true, o.lineage);
+		Assert.assertEquals(true, o.lineage_dedup);
+		Assert.assertEquals(true, o.lineage_reuse);
 	}
 	
 	@Test(expected = ParseException.class)
-	public void testBadLineageOption() throws Exception {
+	public void testBadLineageOptionDedup() throws Exception {
 		String cl = "systemml -f test.dml -lineage ded";
+		String[] args = cl.split(" ");
+		DMLOptions.parseCLArguments(args);
+	}
+	
+	@Test(expected = ParseException.class)
+	public void testBadLineageOptionReuse() throws Exception {
+		String cl = "systemml -f test.dml -lineage rese";
 		String[] args = cl.split(" ");
 		DMLOptions.parseCLArguments(args);
 	}

--- a/src/test/java/org/tugraz/sysds/test/functions/lineage/FullReuseTest.java
+++ b/src/test/java/org/tugraz/sysds/test/functions/lineage/FullReuseTest.java
@@ -19,14 +19,13 @@ package org.tugraz.sysds.test.functions.lineage;
 import org.junit.Test;
 import org.tugraz.sysds.hops.OptimizerUtils;
 import org.tugraz.sysds.runtime.lineage.Lineage;
-import org.tugraz.sysds.runtime.lineage.LineageItem;
-import org.tugraz.sysds.runtime.lineage.LineageParser;
+import org.tugraz.sysds.runtime.matrix.data.MatrixValue;
 import org.tugraz.sysds.test.AutomatedTestBase;
 import org.tugraz.sysds.test.TestConfiguration;
 import org.tugraz.sysds.test.TestUtils;
-import org.tugraz.sysds.utils.Explain;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 public class FullReuseTest extends AutomatedTestBase {
@@ -34,27 +33,30 @@ public class FullReuseTest extends AutomatedTestBase {
 	protected static final String TEST_DIR = "functions/lineage/";
 	protected static final String TEST_NAME1 = "FullReuse1";
 	protected static final String TEST_NAME2 = "FullReuse2";
+	protected static final String TEST_NAME3 = "FullReuse3";
 	protected String TEST_CLASS_DIR = TEST_DIR + FullReuseTest.class.getSimpleName() + "/";
-	
-	protected static final int numRecords = 1024;
-	protected static final int numFeatures = 1024;
-	
 	
 	@Override
 	public void setUp() {
 		TestUtils.clearAssertionInformation();
 		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1));
 		addTestConfiguration(TEST_NAME2, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME2));
+		addTestConfiguration(TEST_NAME3, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME3));
 	}
 	
 	@Test
 	public void testLineageTrace1() {
 		testLineageTrace(TEST_NAME1);
 	}
-
+	
 	@Test
 	public void testLineageTrace2() {
 		testLineageTrace(TEST_NAME2);
+	}
+	
+	@Test
+	public void testLineageTrace3() {
+		testLineageTrace(TEST_NAME3);
 	}
 	
 	public void testLineageTrace(String testname) {
@@ -67,34 +69,37 @@ public class FullReuseTest extends AutomatedTestBase {
 			OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION = false;
 			OptimizerUtils.ALLOW_SUM_PRODUCT_REWRITES = false;
 			
-			int rows = numRecords;
-			int cols = numFeatures;
-			
 			getAndLoadTestConfiguration(testname);
+			fullDMLScriptName = getScript();
 			
-			List<String> proArgs = new ArrayList<String>();
-			
+			// Without lineage-based reuse enabled
+			List<String> proArgs = new ArrayList<>();
 			proArgs.add("-stats");
 			proArgs.add("-lineage");
-			proArgs.add("-explain");
+//			proArgs.add("-explain");
 			proArgs.add("-args");
-			proArgs.add(input("X"));
 			proArgs.add(output("X"));
 			programArgs = proArgs.toArray(new String[proArgs.size()]);
 			
-			fullDMLScriptName = getScript();
+			Lineage.resetInternalState();
+			runTest(true, EXCEPTION_NOT_EXPECTED, null, -1);
+			HashMap<MatrixValue.CellIndex, Double> X_orig = readDMLMatrixFromHDFS("X");
 			
-			double[][] X = getRandomMatrix(rows, cols, 0, 1, 0.8, -1);
-			writeInputMatrixWithMTD("X", X, true);
+			// With lineage-based reuse enabled
+			proArgs.clear();
+			proArgs.add("-stats");
+			proArgs.add("-lineage");
+			proArgs.add("reuse");
+//			proArgs.add("-explain");
+			proArgs.add("-args");
+			proArgs.add(output("X"));
+			programArgs = proArgs.toArray(new String[proArgs.size()]);
 			
 			Lineage.resetInternalState();
 			runTest(true, EXCEPTION_NOT_EXPECTED, null, -1);
+			HashMap<MatrixValue.CellIndex, Double> X_reused = readDMLMatrixFromHDFS("X");
 			
-			String X_lineage = readDMLLineageFromHDFS("X");
-			
-			LineageItem X_li = LineageParser.parseLineageTrace(X_lineage);
-			
-			TestUtils.compareScalars(X_lineage, Explain.explain(X_li));
+			TestUtils.compareMatrices(X_orig, X_reused, 1e-6, "Origin", "Reused");
 		} finally {
 			OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION = old_simplification;
 			OptimizerUtils.ALLOW_SUM_PRODUCT_REWRITES = old_sum_product;

--- a/src/test/scripts/functions/lineage/FullReuse1.dml
+++ b/src/test/scripts/functions/lineage/FullReuse1.dml
@@ -15,15 +15,9 @@
 # limitations under the License.
 #
 #-------------------------------------------------------------
-
-# How to invoke this dml script LineageTrace.dml?
-# Assume LR_HOME is set to the home of the dml script
-# Assume rows = 20 and cols = 20 for X
-# hadoop jar SystemML.jar -f $LR_HOME/LineageTrace.dml -args "$INPUT_DIR/X" "$OUTPUT_DIR/X" "$OUTPUT_DIR/Y"
+# Increase k for better performance gains
 
 X = rand(rows=1024, cols=1024, seed=42);
-
-# Increase k for better performance gains
 k = 10
 
 for(i in 1:k){

--- a/src/test/scripts/functions/lineage/FullReuse1.dml
+++ b/src/test/scripts/functions/lineage/FullReuse1.dml
@@ -21,11 +21,14 @@
 # Assume rows = 20 and cols = 20 for X
 # hadoop jar SystemML.jar -f $LR_HOME/LineageTrace.dml -args "$INPUT_DIR/X" "$OUTPUT_DIR/X" "$OUTPUT_DIR/Y"
 
-X = read($1);
+X = rand(rows=1024, cols=1024, seed=42);
 
-for(i in 1:10){
+# Increase k for better performance gains
+k = 10
+
+for(i in 1:k){
     tmp = t(X) %*% X;
 }
 
-write(tmp, $2, format="text");
+write(tmp, $1, format="text");
 

--- a/src/test/scripts/functions/lineage/FullReuse2.dml
+++ b/src/test/scripts/functions/lineage/FullReuse2.dml
@@ -15,13 +15,8 @@
 # limitations under the License.
 #
 #-------------------------------------------------------------
-
-# How to invoke this dml script LineageTrace.dml?
-# Assume LR_HOME is set to the home of the dml script
-# Assume rows = 20 and cols = 20 for X
-# hadoop jar SystemML.jar -f $LR_HOME/LineageTrace.dml -args "$INPUT_DIR/X" "$OUTPUT_DIR/X" "$OUTPUT_DIR/Y"
-
 # Increase rows and cols for better performance gains
+
 r = 100000
 c = 100
 

--- a/src/test/scripts/functions/lineage/FullReuse3.dml
+++ b/src/test/scripts/functions/lineage/FullReuse3.dml
@@ -21,15 +21,12 @@
 # Assume rows = 20 and cols = 20 for X
 # hadoop jar SystemML.jar -f $LR_HOME/LineageTrace.dml -args "$INPUT_DIR/X" "$OUTPUT_DIR/X" "$OUTPUT_DIR/Y"
 
-# Increase rows and cols for better performance gains
-r = 100000
-c = 100
-
-X = rand(rows=r, cols=c, seed=42);
-y = rand(rows=r, cols=1, seed=43);
+# Increase rows and cols for performance comparision
+X = rand(rows=1000000, cols=100, seed=42);
+y = rand(rows=1000000, cols=1, seed=43);
 
 j = 10
-R = matrix(0, c, j);
+R = matrix(0, ncol(X), j);
 
 for(i in 1:j) {
   lambda = 10 ^ -i;
@@ -41,4 +38,4 @@ for(i in 1:j) {
   R[,i] = beta;
 }
 
-write(R, $1, format="text");
+write(R, $2, format="text");

--- a/src/test/scripts/functions/lineage/FullReuse3.dml
+++ b/src/test/scripts/functions/lineage/FullReuse3.dml
@@ -15,27 +15,19 @@
 # limitations under the License.
 #
 #-------------------------------------------------------------
+# Increase rows and cols for better performance gain
 
-# How to invoke this dml script LineageTrace.dml?
-# Assume LR_HOME is set to the home of the dml script
-# Assume rows = 20 and cols = 20 for X
-# hadoop jar SystemML.jar -f $LR_HOME/LineageTrace.dml -args "$INPUT_DIR/X" "$OUTPUT_DIR/X" "$OUTPUT_DIR/Y"
+X = rand(rows=1024, cols=16, seed=42);
+tmp = X[,1];
+R = matrix(0, ncol(X), 1);
 
-# Increase rows and cols for performance comparision
-X = rand(rows=1000000, cols=100, seed=42);
-y = rand(rows=1000000, cols=1, seed=43);
+for(i in 2:ncol(X)) {
+  A = t(tmp) %*% tmp;
+  R[i,] = sum(A)
 
-j = 10
-R = matrix(0, ncol(X), j);
-
-for(i in 1:j) {
-  lambda = 10 ^ -i;
-
-  A = t(X) %*% X + diag(matrix(lambda, rows=ncol(X), cols=1));
-  b = t(X) %*% y;
-  beta = solve(A, b);
-
-  R[,i] = beta;
+  tmp = cbind(tmp, X[,i]);
+  A = t(tmp) %*% tmp;
+  R[i,] += sum(A)
 }
 
-write(R, $2, format="text");
+write(R, $1, format="text");


### PR DESCRIPTION

 * Changed the value for `LineageCache` from `Data` to `MatrixBlock`
    Only enabled for ComputationCPInstruction which returns a `MatrixObject` as output
 * Add cli parameter `-lineage reuse' for check soundness of lineage-based reusing
 * Add additional `CPOperand` tracing for `MatrixIndexingCPInstruction`