### PR TITLE
Add simple binary Spark and CP instructions for tensors

### DIFF
--- a/docs/builtins-reference.md
+++ b/docs/builtins-reference.md
@@ -54,8 +54,8 @@ tensor(data, dims, byRow = TRUE)
 ### Arguments
 | Name    | Type           | Default  | Description |
 | :------ | :------------- | -------- | :---------- |
-| data    | Matrix[?], Tensor[?], String, Scalar[?] | required | The data with which the tensor should be filled. See [`data`-Argument](#data-argument).|
-| dims    | Matrix[Integer], Tensor[Integer], String, List[Integer] | required | The dimensions of the tensor. See [`dims`-Argument](#dims-argument). |
+| data    | Matrix[?], Tensor[?], Scalar[?] | required | The data with which the tensor should be filled. See [`data`-Argument](#data-argument).|
+| dims    | Matrix[Integer], Tensor[Integer], Scalar[String], List[Integer] | required | The dimensions of the tensor. See [`dims`-Argument](#dims-argument). |
 | byRow   | Boolean        | TRUE     | NOT USED. Will probably be removed or replaced. |
 
 Note that this function is highly **unstable** and will be overworked and might change signature and functionality.
@@ -101,6 +101,8 @@ print("Tensor D: Values=tst, dims=Tensor C");
 D = tensor("tst", C); # fill with string, dimensions given by tensor
 print(toString(D))
 ```
+
+Note that reshape construction is not yet supported for **SPARK** execution.
 
 # DML-Bodied Built-In Functions
 

--- a/src/main/java/org/tugraz/sysds/hops/BinaryOp.java
+++ b/src/main/java/org/tugraz/sysds/hops/BinaryOp.java
@@ -879,6 +879,9 @@ public class BinaryOp extends MultiThreadedHop
 	}
 
 	private static MMBinaryMethod optFindMMBinaryMethodSpark(Hop left, Hop right) {
+		// TODO size information for tensor
+		if (left._dataType == DataType.TENSOR && right._dataType == DataType.TENSOR)
+			return MMBinaryMethod.MR_BINARY_R;
 		long m1_dim1 = left.getDim1();
 		long m1_dim2 = left.getDim2();
 		long m2_dim1 =  right.getDim1();

--- a/src/main/java/org/tugraz/sysds/hops/BinaryOp.java
+++ b/src/main/java/org/tugraz/sysds/hops/BinaryOp.java
@@ -59,12 +59,13 @@ public class BinaryOp extends MultiThreadedHop
 {
 	//we use the full remote memory budget (but reduced by sort buffer), 
 	public static final double APPEND_MEM_MULTIPLIER = 1.0;
-	
+
 	private Hop.OpOp2 op;
 	private boolean outer = false;
 	
 	public static AppendMethod FORCED_APPEND_METHOD = null;
-	
+	public static MMBinaryMethod FORCED_BINARY_METHOD = null;
+
 	public enum AppendMethod { 
 		CP_APPEND, //in-memory general case append (implicitly selected for CP)
 		MR_MAPPEND, //map-only append (rhs must be vector and fit in mapper mem)
@@ -73,7 +74,7 @@ public class BinaryOp extends MultiThreadedHop
 		SP_GAlignedAppend // special case for general case in Spark where left.getCols() % left.getColsPerBlock() == 0
 	}
 	
-	private enum MMBinaryMethod {
+	public enum MMBinaryMethod {
 		CP_BINARY, //(implicitly selected for CP) 
 		MR_BINARY_R, //both mm, mv 
 		MR_BINARY_M, //only mv (mr/spark)
@@ -414,7 +415,7 @@ public class BinaryOp extends MultiThreadedHop
 		} 
 		else 
 		{
-			// Both operands are Matrixes
+			// Both operands are Matrixes or Tensors
 			ExecType et = optFindExecType();
 			boolean isGPUSoftmax = et == ExecType.GPU && op == Hop.OpOp2.DIV && 
 					getInput().get(0) instanceof UnaryOp && getInput().get(1) instanceof AggUnaryOp && 
@@ -433,7 +434,7 @@ public class BinaryOp extends MultiThreadedHop
 				Lop binary = null;
 				
 				boolean isLeftXGt = (getInput().get(0) instanceof BinaryOp) && ((BinaryOp) getInput().get(0)).getOp() == OpOp2.GREATER;
-				Hop potentialZero = isLeftXGt ? ((BinaryOp) getInput().get(0)).getInput().get(1) : null;
+				Hop potentialZero = isLeftXGt ? getInput().get(0).getInput().get(1) : null;
 				
 				boolean isLeftXGt0 = isLeftXGt && potentialZero != null
 					&& HopRewriteUtils.isLiteralOfValue(potentialZero, 0);
@@ -458,6 +459,8 @@ public class BinaryOp extends MultiThreadedHop
 				Hop left = getInput().get(0);
 				Hop right = getInput().get(1);
 				MMBinaryMethod mbin = optFindMMBinaryMethodSpark(left, right);
+				if (FORCED_BINARY_METHOD != null)
+					mbin = FORCED_BINARY_METHOD;
 				
 				Lop  binary = null;
 				if( mbin == MMBinaryMethod.MR_BINARY_UAGG_CHAIN ) {
@@ -467,11 +470,11 @@ public class BinaryOp extends MultiThreadedHop
 							getDataType(), getValueType(), et);
 				}
 				else if (mbin == MMBinaryMethod.MR_BINARY_M) {
-					boolean partitioned = false;
-					boolean isColVector = (right.getDim2()==1 && left.getDim1()==right.getDim1());
-					
+					boolean isColVector = dt1 != DataType.TENSOR && dt2 != DataType.TENSOR &&
+							(right.getDim2() == 1 && left.getDim1() == right.getDim1());
+
 					binary = new BinaryM(left.constructLops(), right.constructLops(),
-							HopsOpOp2LopsB.get(op), getDataType(), getValueType(), et, partitioned, isColVector); 
+							HopsOpOp2LopsB.get(op), getDataType(), getValueType(), et, false, isColVector);
 				}
 				else {
 					binary = new Binary(left.constructLops(), right.constructLops(), 
@@ -487,7 +490,7 @@ public class BinaryOp extends MultiThreadedHop
 
 	@Override
 	public String getOpString() {
-		String s = new String("");
+		String s = "";
 		s += "b(" + HopsOpOp2String.get(op) + ")";
 		return s;
 	}

--- a/src/main/java/org/tugraz/sysds/hops/BinaryOp.java
+++ b/src/main/java/org/tugraz/sysds/hops/BinaryOp.java
@@ -436,8 +436,7 @@ public class BinaryOp extends MultiThreadedHop
 				boolean isLeftXGt = (getInput().get(0) instanceof BinaryOp) && ((BinaryOp) getInput().get(0)).getOp() == OpOp2.GREATER;
 				Hop potentialZero = isLeftXGt ? getInput().get(0).getInput().get(1) : null;
 				
-				boolean isLeftXGt0 = isLeftXGt && potentialZero != null
-					&& HopRewriteUtils.isLiteralOfValue(potentialZero, 0);
+				boolean isLeftXGt0 = isLeftXGt && HopRewriteUtils.isLiteralOfValue(potentialZero, 0);
 				
 				if(op == OpOp2.MULT && isLeftXGt0 && 
 					!getInput().get(0).isVector() && !getInput().get(1).isVector()
@@ -474,7 +473,7 @@ public class BinaryOp extends MultiThreadedHop
 							(right.getDim2() == 1 && left.getDim1() == right.getDim1());
 
 					binary = new BinaryM(left.constructLops(), right.constructLops(),
-							HopsOpOp2LopsB.get(op), getDataType(), getValueType(), et, false, isColVector);
+							HopsOpOp2LopsB.get(op), getDataType(), getValueType(), et, isColVector);
 				}
 				else {
 					binary = new Binary(left.constructLops(), right.constructLops(), 
@@ -490,9 +489,7 @@ public class BinaryOp extends MultiThreadedHop
 
 	@Override
 	public String getOpString() {
-		String s = "";
-		s += "b(" + HopsOpOp2String.get(op) + ")";
-		return s;
+		return "b(" + HopsOpOp2String.get(op) + ")";
 	}
 
 	@Override

--- a/src/main/java/org/tugraz/sysds/lops/BinaryM.java
+++ b/src/main/java/org/tugraz/sysds/lops/BinaryM.java
@@ -56,14 +56,13 @@ public class BinaryM extends Lop
 	 * @param dt data type
 	 * @param vt value type
 	 * @param et exec type
-	 * @param partitioned true if partitioned
 	 * @param colVector true if colVector
 	 */
-	public BinaryM(Lop input1, Lop input2, OperationTypes op, DataType dt, ValueType vt, ExecType et, boolean partitioned, boolean colVector ) {
+	public BinaryM(Lop input1, Lop input2, OperationTypes op, DataType dt, ValueType vt, ExecType et, boolean colVector ) {
 		super(Lop.Type.Binary, dt, vt);
 		
 		_operation = op;
-		_cacheType = partitioned ? CacheType.RIGHT_PART : CacheType.RIGHT;
+		_cacheType = CacheType.RIGHT;
 		_vectorType = colVector ? VectorType.COL_VECTOR : VectorType.ROW_VECTOR;
 		
 		this.addInput(input1);

--- a/src/main/java/org/tugraz/sysds/runtime/controlprogram/caching/CacheBlockFactory.java
+++ b/src/main/java/org/tugraz/sysds/runtime/controlprogram/caching/CacheBlockFactory.java
@@ -1,4 +1,6 @@
 /*
+ * Modifications Copyright 2019 Graz University of Technology
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -21,6 +23,9 @@ package org.tugraz.sysds.runtime.controlprogram.caching;
 
 import java.util.ArrayList;
 
+import org.tugraz.sysds.runtime.data.BasicTensor;
+import org.tugraz.sysds.runtime.data.DataTensor;
+import org.tugraz.sysds.runtime.data.TensorIndexes;
 import org.tugraz.sysds.runtime.matrix.data.FrameBlock;
 import org.tugraz.sysds.runtime.matrix.data.MatrixBlock;
 import org.tugraz.sysds.runtime.matrix.data.MatrixIndexes;
@@ -37,23 +42,31 @@ public class CacheBlockFactory
 		switch( code ) {
 			case 0: return new MatrixBlock();
 			case 1: return new FrameBlock();
+			case 2: return new BasicTensor();
+			case 3: return new DataTensor();
 		}
 		throw new RuntimeException("Unsupported cache block type: "+code);
 	}
 
 	public static int getCode(CacheBlock block) {
-		if( block instanceof MatrixBlock )
+		if (block instanceof MatrixBlock)
 			return 0;
-		else if( block instanceof FrameBlock )
+		else if (block instanceof FrameBlock)
 			return 1;
-		throw new RuntimeException("Unsupported cache block type: "+block.getClass().getName());
+		else if (block instanceof BasicTensor)
+			return 2;
+		else if (block instanceof DataTensor)
+			return 3;
+		throw new RuntimeException("Unsupported cache block type: " + block.getClass().getName());
 	}
 
 	public static ArrayList<?> getPairList(CacheBlock block) {
 		int code = getCode(block);
-		switch( code ) {
-			case 0: return new ArrayList<Pair<MatrixIndexes,MatrixBlock>>();
-			case 1: return new ArrayList<Pair<Long,FrameBlock>>();
+		switch (code) {
+			case 0: return new ArrayList<Pair<MatrixIndexes, MatrixBlock>>();
+			case 1: return new ArrayList<Pair<Long, FrameBlock>>();
+			case 2: return new ArrayList<Pair<TensorIndexes, BasicTensor>>();
+			case 3: return new ArrayList<Pair<TensorIndexes, DataTensor>>();
 		}
 		throw new RuntimeException("Unsupported cache block type: "+code);
 	}

--- a/src/main/java/org/tugraz/sysds/runtime/controlprogram/context/ExecutionContext.java
+++ b/src/main/java/org/tugraz/sysds/runtime/controlprogram/context/ExecutionContext.java
@@ -446,7 +446,12 @@ public class ExecutionContext {
 	public void releaseTensorInput(String varName) {
 		getTensorObject(varName).release();
 	}
-	
+
+	public void releaseTensorInput(String... varNames) {
+		for( String varName : varNames )
+			releaseTensorInput(varName);
+	}
+
 	public ScalarObject getScalarInput(CPOperand input) {
 		return input.isLiteral() ? input.getLiteral() : 
 			getScalarInput(input.getName(), input.getValueType(), false);

--- a/src/main/java/org/tugraz/sysds/runtime/controlprogram/context/SparkExecutionContext.java
+++ b/src/main/java/org/tugraz/sysds/runtime/controlprogram/context/SparkExecutionContext.java
@@ -1160,7 +1160,13 @@ public class SparkExecutionContext extends ExecutionContext
 				lower[i] = (int) ((ix.getIndex(i) - 1) * dc.getBlockSize(i));
 				upper[i] = lower[i] + block.getDim(i) - 1;
 			}
-			out.getNextIndexes(upper);
+			upper[upper.length - 1]++;
+			for (int i = upper.length - 1; i > 0; i--) {
+				if (upper[i] == block.getDim(i)) {
+					upper[i] = 0;
+					upper[i - 1]++;
+				}
+			}
 
 			// TODO sparse copy
 			out.copy(lower, upper, block);

--- a/src/main/java/org/tugraz/sysds/runtime/data/BasicTensor.java
+++ b/src/main/java/org/tugraz/sysds/runtime/data/BasicTensor.java
@@ -37,6 +37,7 @@ import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.util.Arrays;
 
 public class BasicTensor extends TensorBlock implements Externalizable
 {
@@ -666,8 +667,15 @@ public class BasicTensor extends TensorBlock implements Externalizable
 
 	@Override
 	public CacheBlock slice(int rl, int ru, int cl, int cu, CacheBlock block) {
-		// TODO Auto-generated method stub
-		return null;
+		BasicTensor bt = (BasicTensor) block;
+		int[] dims = Arrays.copyOf(_dims, _dims.length);
+		dims[0] = ru - rl + 1;
+		dims[1] = cu - cl + 1;
+		bt.reset(dims, false);
+		int[] offsets = new int[dims.length];
+		offsets[0] = rl;
+		offsets[1] = cl;
+		return slice(offsets, bt);
 	}
 
 	/**
@@ -678,6 +686,7 @@ public class BasicTensor extends TensorBlock implements Externalizable
 	 * @return the sliced result block
 	 */
 	public BasicTensor slice(int[] offsets, BasicTensor outBlock) {
+		// TODO change signature to use upper lower instead of offsets and size of outBlock
 		// TODO perf
 		int[] srcIx = new int[offsets.length];
 		Array.copy(offsets, 0, srcIx, 0, offsets.length);

--- a/src/main/java/org/tugraz/sysds/runtime/data/DataTensor.java
+++ b/src/main/java/org/tugraz/sysds/runtime/data/DataTensor.java
@@ -309,6 +309,14 @@ public class DataTensor extends TensorBlock {
 		throw new DMLRuntimeException("DataTensor.binaryOperations is not implemented yet.");
 	}
 
+	@Override
+	protected DataTensor checkType(TensorBlock that) {
+		if (that instanceof DataTensor)
+			return (DataTensor) that;
+		else
+			throw new DMLRuntimeException("BasicTensor.checkType(TensorBlock) given TensorBlock was no BasicTensor");
+	}
+
 	public void copy(DataTensor that) {
 		_dims = that._dims.clone();
 		_schema = that._schema.clone();

--- a/src/main/java/org/tugraz/sysds/runtime/data/DataTensor.java
+++ b/src/main/java/org/tugraz/sysds/runtime/data/DataTensor.java
@@ -20,6 +20,9 @@ import org.apache.commons.lang.math.IntRange;
 import org.tugraz.sysds.common.Types.ValueType;
 import org.tugraz.sysds.runtime.DMLRuntimeException;
 import org.tugraz.sysds.runtime.controlprogram.caching.CacheBlock;
+import org.tugraz.sysds.runtime.matrix.operators.AggregateOperator;
+import org.tugraz.sysds.runtime.matrix.operators.AggregateUnaryOperator;
+import org.tugraz.sysds.runtime.matrix.operators.BinaryOperator;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -286,6 +289,24 @@ public class DataTensor extends TensorBlock {
 		if (getNumDims() != 2)
 			throw new DMLRuntimeException("DataTensor.set(int,int,double) dimension mismatch: expected=2 actual=" + getNumDims());
 		_colsdata[_schema[c].ordinal()].set(r, _colsToIx[c], v);
+	}
+
+	@Override
+	public TensorBlock aggregateUnaryOperations(AggregateUnaryOperator op, TensorBlock result) {
+		// TODO aggregateUnaryOperations for DataTensor
+		throw new DMLRuntimeException("DataTensor.aggregateUnaryOperations is not implemented yet.");
+	}
+
+	@Override
+	public void incrementalAggregate(AggregateOperator aggOp, TensorBlock partialResult) {
+		// TODO incrementalAggregate for DataTensor
+		throw new DMLRuntimeException("DataTensor.incrementalAggregate is not implemented yet.");
+	}
+
+	@Override
+	public TensorBlock binaryOperations(BinaryOperator op, TensorBlock thatValue, TensorBlock result) {
+		// TODO binaryOperations for DataTensor
+		throw new DMLRuntimeException("DataTensor.binaryOperations is not implemented yet.");
 	}
 
 	public void copy(DataTensor that) {

--- a/src/main/java/org/tugraz/sysds/runtime/data/LibTensorBincell.java
+++ b/src/main/java/org/tugraz/sysds/runtime/data/LibTensorBincell.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019 Graz University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.tugraz.sysds.runtime.data;
+
+import org.tugraz.sysds.runtime.matrix.operators.BinaryOperator;
+import org.tugraz.sysds.runtime.util.UtilFunctions;
+
+public class LibTensorBincell {
+	public static boolean isValidDimensionsBinary(TensorBlock m1, TensorBlock m2) {
+		if (m1.getNumDims() != m2.getNumDims())
+			return false;
+
+		for (int i = 0; i < m1.getNumDims(); i++)
+			if (m1.getDim(i) != m2.getDim(i) && m2.getDim(i) != 1)
+				return false;
+		return true;
+	}
+
+	/**
+	 * tensor-tensor binary operations
+	 *
+	 * @param m1  input tensor 1
+	 * @param m2  input tensor 2
+	 * @param ret result tensor
+	 * @param op  binary operator
+	 */
+	public static void bincellOp(BasicTensor m1, BasicTensor m2, BasicTensor ret, BinaryOperator op) {
+		// TODO perf (empty, sparse safe, etc.)
+		int[] ix1 = new int[ret.getNumDims()];
+		int[] ix2 = new int[ret.getNumDims()];
+		for (long i = 0; i < ret.getLength(); i++) {
+			double v1 = UtilFunctions.objectToDouble(m1.getValueType(), m1.get(ix1));
+			double v2 = UtilFunctions.objectToDouble(m2.getValueType(), m2.get(ix2));
+			ret.set(ix1, op.fn.execute(v1, v2));
+
+			int j = ix1.length - 1;
+			ix1[j]++;
+			if (m2.getDim(j) != 1)
+				ix2[j]++;
+			while (ix1[j] == m1.getDim(j)) {
+				ix1[j] = 0;
+				ix2[j] = 0;
+				j--;
+				if (j < 0)
+					break;
+				ix1[j]++;
+				if (m2.getDim(j) != 1)
+					ix2[j]++;
+			}
+		}
+	}
+}

--- a/src/main/java/org/tugraz/sysds/runtime/data/LibTensorBincell.java
+++ b/src/main/java/org/tugraz/sysds/runtime/data/LibTensorBincell.java
@@ -40,6 +40,7 @@ public class LibTensorBincell {
 	 * @param op  binary operator
 	 */
 	public static void bincellOp(BasicTensor m1, BasicTensor m2, BasicTensor ret, BinaryOperator op) {
+		// TODO separate implementations for matching dims and broadcasting
 		// TODO perf (empty, sparse safe, etc.)
 		int[] ix1 = new int[ret.getNumDims()];
 		int[] ix2 = new int[ret.getNumDims()];

--- a/src/main/java/org/tugraz/sysds/runtime/data/TensorBlock.java
+++ b/src/main/java/org/tugraz/sysds/runtime/data/TensorBlock.java
@@ -18,6 +18,7 @@
 package org.tugraz.sysds.runtime.data;
 
 import org.tugraz.sysds.common.Types.ValueType;
+import org.tugraz.sysds.runtime.DMLRuntimeException;
 import org.tugraz.sysds.runtime.controlprogram.caching.CacheBlock;
 import org.tugraz.sysds.runtime.matrix.operators.AggregateOperator;
 import org.tugraz.sysds.runtime.matrix.operators.AggregateUnaryOperator;
@@ -132,7 +133,11 @@ public abstract class TensorBlock implements CacheBlock
 
 	public abstract TensorBlock binaryOperations(BinaryOperator op, TensorBlock thatValue, TensorBlock result);
 
+	protected abstract TensorBlock checkType(TensorBlock that);
+
 	public static ValueType resultValueType(ValueType in1, ValueType in2) {
+		if (in1 == ValueType.UNKNOWN || in2 == ValueType.UNKNOWN)
+			throw new DMLRuntimeException("Operations on unknown value types not possible");
 		if (in1 == ValueType.STRING || in2 == ValueType.STRING)
 			return ValueType.STRING;
 		if (in1 == ValueType.FP64 || in2 == ValueType.FP64)
@@ -145,6 +150,6 @@ public abstract class TensorBlock implements CacheBlock
 			return ValueType.INT32;
 		if (in1 == ValueType.BOOLEAN || in2 == ValueType.BOOLEAN)
 			return ValueType.INT64;
-		return ValueType.UNKNOWN;
+		throw new DMLRuntimeException("TensorBlock(ValueType,ValueType) value types not recognized");
 	}
 }

--- a/src/main/java/org/tugraz/sysds/runtime/data/TensorBlock.java
+++ b/src/main/java/org/tugraz/sysds/runtime/data/TensorBlock.java
@@ -17,7 +17,11 @@
 
 package org.tugraz.sysds.runtime.data;
 
+import org.tugraz.sysds.common.Types.ValueType;
 import org.tugraz.sysds.runtime.controlprogram.caching.CacheBlock;
+import org.tugraz.sysds.runtime.matrix.operators.AggregateOperator;
+import org.tugraz.sysds.runtime.matrix.operators.AggregateUnaryOperator;
+import org.tugraz.sysds.runtime.matrix.operators.BinaryOperator;
 import org.tugraz.sysds.runtime.util.UtilFunctions;
 
 public abstract class TensorBlock implements CacheBlock
@@ -100,7 +104,47 @@ public abstract class TensorBlock implements CacheBlock
 
 	public abstract double get(int r, int c);
 
+	/**
+	 * Set a cell to the value given as an `Object`. The type is inferred by either the `schema` or `valueType`, depending
+	 * if the `TensorBlock` is a `BasicTensor` or `DataTensor`.
+	 * @param ix indexes in each dimension, starting with 0
+	 * @param v value to set
+	 */
 	public abstract void set(int[] ix, Object v);
 
+	/**
+	 * Set a cell in a 2-dimensional tensor.
+	 * @param r row of the cell
+	 * @param c column of the cell
+	 * @param v value to set
+	 */
 	public abstract void set(int r, int c, double v);
+
+	/**
+	 * Aggregate a unary operation on this tensor.
+	 * @param op the operation to apply
+	 * @param result the result tensor
+	 * @return the result tensor
+	 */
+	public abstract TensorBlock aggregateUnaryOperations(AggregateUnaryOperator op, TensorBlock result);
+
+	public abstract void incrementalAggregate(AggregateOperator aggOp, TensorBlock partialResult);
+
+	public abstract TensorBlock binaryOperations(BinaryOperator op, TensorBlock thatValue, TensorBlock result);
+
+	public static ValueType resultValueType(ValueType in1, ValueType in2) {
+		if (in1 == ValueType.STRING || in2 == ValueType.STRING)
+			return ValueType.STRING;
+		if (in1 == ValueType.FP64 || in2 == ValueType.FP64)
+			return ValueType.FP64;
+		if (in1 == ValueType.FP32 || in2 == ValueType.FP32)
+			return ValueType.FP32;
+		if (in1 == ValueType.INT64 || in2 == ValueType.INT64)
+			return ValueType.INT64;
+		if (in1 == ValueType.INT32 || in2 == ValueType.INT32)
+			return ValueType.INT32;
+		if (in1 == ValueType.BOOLEAN || in2 == ValueType.BOOLEAN)
+			return ValueType.INT64;
+		return ValueType.UNKNOWN;
+	}
 }

--- a/src/main/java/org/tugraz/sysds/runtime/data/TensorBlock.java
+++ b/src/main/java/org/tugraz/sysds/runtime/data/TensorBlock.java
@@ -136,20 +136,20 @@ public abstract class TensorBlock implements CacheBlock
 	protected abstract TensorBlock checkType(TensorBlock that);
 
 	public static ValueType resultValueType(ValueType in1, ValueType in2) {
+		// TODO reconsider with operation types
 		if (in1 == ValueType.UNKNOWN || in2 == ValueType.UNKNOWN)
 			throw new DMLRuntimeException("Operations on unknown value types not possible");
-		if (in1 == ValueType.STRING || in2 == ValueType.STRING)
+		else if (in1 == ValueType.STRING || in2 == ValueType.STRING)
 			return ValueType.STRING;
-		if (in1 == ValueType.FP64 || in2 == ValueType.FP64)
+		else if (in1 == ValueType.FP64 || in2 == ValueType.FP64)
 			return ValueType.FP64;
-		if (in1 == ValueType.FP32 || in2 == ValueType.FP32)
+		else if (in1 == ValueType.FP32 || in2 == ValueType.FP32)
 			return ValueType.FP32;
-		if (in1 == ValueType.INT64 || in2 == ValueType.INT64)
+		else if (in1 == ValueType.INT64 || in2 == ValueType.INT64)
 			return ValueType.INT64;
-		if (in1 == ValueType.INT32 || in2 == ValueType.INT32)
+		else if (in1 == ValueType.INT32 || in2 == ValueType.INT32)
 			return ValueType.INT32;
-		if (in1 == ValueType.BOOLEAN || in2 == ValueType.BOOLEAN)
+		else // Boolean - Boolean
 			return ValueType.INT64;
-		throw new DMLRuntimeException("TensorBlock(ValueType,ValueType) value types not recognized");
 	}
 }

--- a/src/main/java/org/tugraz/sysds/runtime/data/TensorIndexes.java
+++ b/src/main/java/org/tugraz/sysds/runtime/data/TensorIndexes.java
@@ -58,6 +58,10 @@ public class TensorIndexes implements WritableComparable<TensorIndexes>, Externa
 		return _ix[dim];
 	}
 
+	public long[] getIndexes() {
+		return _ix;
+	}
+
 	public int getNumDims() {
 		return _ix.length;
 	}

--- a/src/main/java/org/tugraz/sysds/runtime/instructions/cp/BinaryCPInstruction.java
+++ b/src/main/java/org/tugraz/sysds/runtime/instructions/cp/BinaryCPInstruction.java
@@ -45,11 +45,13 @@ public abstract class BinaryCPInstruction extends ComputationCPInstruction {
 		checkOutputDataType(in1, in2, out);
 		
 		Operator operator = InstructionUtils.parseBinaryOrBuiltinOperator(opcode, in1, in2);
-		
-		if( in1.getDataType() == DataType.SCALAR && in2.getDataType() == DataType.SCALAR ) 
+
+		if (in1.getDataType() == DataType.SCALAR && in2.getDataType() == DataType.SCALAR)
 			return new BinaryScalarScalarCPInstruction(operator, in1, in2, out, opcode, str);
-		else if( in1.getDataType() == DataType.MATRIX && in2.getDataType() == DataType.MATRIX )
+		else if (in1.getDataType() == DataType.MATRIX && in2.getDataType() == DataType.MATRIX)
 			return new BinaryMatrixMatrixCPInstruction(operator, in1, in2, out, opcode, str);
+		else if (in1.getDataType() == DataType.TENSOR && in2.getDataType() == DataType.TENSOR)
+			return new BinaryTensorTensorCPInstruction(operator, in1, in2, out, opcode, str);
 		else
 			return new BinaryMatrixScalarCPInstruction(operator, in1, in2, out, opcode, str);
 	}

--- a/src/main/java/org/tugraz/sysds/runtime/instructions/cp/BinaryTensorTensorCPInstruction.java
+++ b/src/main/java/org/tugraz/sysds/runtime/instructions/cp/BinaryTensorTensorCPInstruction.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 Graz University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.tugraz.sysds.runtime.instructions.cp;
+
+import org.tugraz.sysds.runtime.controlprogram.context.ExecutionContext;
+import org.tugraz.sysds.runtime.data.BasicTensor;
+import org.tugraz.sysds.runtime.data.TensorBlock;
+import org.tugraz.sysds.runtime.matrix.operators.BinaryOperator;
+import org.tugraz.sysds.runtime.matrix.operators.Operator;
+
+public class BinaryTensorTensorCPInstruction extends BinaryCPInstruction {
+
+	protected BinaryTensorTensorCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out,
+			String opcode, String istr) {
+		super(CPType.Binary, op, in1, in2, out, opcode, istr);
+	}
+
+	@Override
+	public void processInstruction(ExecutionContext ec) {
+		// Read input tensors
+		TensorBlock inBlock1 = ec.getTensorInput(input1.getName());
+		TensorBlock inBlock2 = ec.getTensorInput(input2.getName());
+
+		// Perform computation using input tensors, and produce the result tensor
+		BinaryOperator bop = (BinaryOperator) _optr;
+		BasicTensor retBlock = (BasicTensor) (inBlock1.binaryOperations (bop, inBlock2, null));
+		
+		// Release the memory occupied by input matrices
+		ec.releaseTensorInput(input1.getName(), input2.getName());
+		
+		// TODO Ensure right dense/sparse output representation (guarded by released input memory)
+
+		// Attach result matrix with MatrixObject associated with output_name
+		ec.setTensorOutput(output.getName(), retBlock);
+	}
+}

--- a/src/main/java/org/tugraz/sysds/runtime/instructions/spark/BinarySPInstruction.java
+++ b/src/main/java/org/tugraz/sysds/runtime/instructions/spark/BinarySPInstruction.java
@@ -196,6 +196,7 @@ public abstract class BinarySPInstruction extends ComputationSPInstruction {
 
 		BinaryOperator bop = (BinaryOperator) _optr;
 
+		// TODO blocking scheme for tensors/matrices with mismatching number of dimensions
 		for (int i = 0; i < tc1.getNumDims(); i++) {
 			long numReps = getNumDimReplicas(tc1, tc2, i);
 			if (numReps > 1)

--- a/src/main/java/org/tugraz/sysds/runtime/instructions/spark/BinaryTensorTensorBroadcastSPInstruction.java
+++ b/src/main/java/org/tugraz/sysds/runtime/instructions/spark/BinaryTensorTensorBroadcastSPInstruction.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Graz University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.tugraz.sysds.runtime.instructions.spark;
+
+import org.tugraz.sysds.runtime.controlprogram.context.ExecutionContext;
+import org.tugraz.sysds.runtime.instructions.cp.CPOperand;
+import org.tugraz.sysds.runtime.matrix.operators.Operator;
+
+public class BinaryTensorTensorBroadcastSPInstruction extends BinarySPInstruction {
+
+	protected BinaryTensorTensorBroadcastSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode, String istr) {
+		super(SPType.Binary, op, in1, in2, out, opcode, istr);
+	}
+
+	@Override
+	public void processInstruction(ExecutionContext ec) {
+		//common binary matrix-matrix process instruction
+		super.processTensorTensorBroadcastBinaryInstruction(ec);
+	}
+}

--- a/src/main/java/org/tugraz/sysds/runtime/instructions/spark/BinaryTensorTensorSPInstruction.java
+++ b/src/main/java/org/tugraz/sysds/runtime/instructions/spark/BinaryTensorTensorSPInstruction.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Graz University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.tugraz.sysds.runtime.instructions.spark;
+
+import org.tugraz.sysds.runtime.controlprogram.context.ExecutionContext;
+import org.tugraz.sysds.runtime.instructions.cp.CPOperand;
+import org.tugraz.sysds.runtime.matrix.operators.Operator;
+
+public class BinaryTensorTensorSPInstruction extends BinarySPInstruction {
+
+	protected BinaryTensorTensorSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode, String istr) {
+		super(SPType.Binary, op, in1, in2, out, opcode, istr);
+	}
+
+	@Override
+	public void processInstruction(ExecutionContext ec) {
+		//common binary matrix-matrix process instruction
+		super.processTensorTensorBinaryInstruction(ec);
+	}
+}

--- a/src/main/java/org/tugraz/sysds/runtime/instructions/spark/ComputationSPInstruction.java
+++ b/src/main/java/org/tugraz/sysds/runtime/instructions/spark/ComputationSPInstruction.java
@@ -89,7 +89,24 @@ public abstract class ComputationSPInstruction extends SPInstruction implements 
 				sec.getDataCharacteristics(output.getName()).set(dcIn1.getRows(), dcIn1.getCols(), dcIn1.getRowsPerBlock(), dcIn1.getRowsPerBlock());
 		}
 	}
-	
+
+	protected void updateBinaryTensorOutputDataCharacteristics(SparkExecutionContext sec) {
+		DataCharacteristics dcIn1 = sec.getDataCharacteristics(input1.getName());
+		DataCharacteristics dcIn2 = sec.getDataCharacteristics(input2.getName());
+		DataCharacteristics dcOut = sec.getDataCharacteristics(output.getName());
+
+		// TODO the dcOut dims will not be accurate here, because set output dimensions currently do only support
+		//  matrix size informations. Changing this requires changes in `Hop` and `OutputParameters`.
+		if(!dcOut.dimsKnown()) {
+			if(!dcIn1.dimsKnown())
+				throw new DMLRuntimeException("The output dimensions are not specified and cannot be inferred from input:" + dcIn1.toString() + " " + dcIn2.toString() + " " + dcOut.toString());
+			else
+				dcOut.set(dcIn1);
+		}
+		// TODO remove this once dcOut dims are accurate if known
+		dcOut.set(dcIn1);
+	}
+
 	protected void updateUnaryAggOutputDataCharacteristics(SparkExecutionContext sec, IndexFunction ixFn) {
 		DataCharacteristics mc1 = sec.getDataCharacteristics(input1.getName());
 		DataCharacteristics mcOut = sec.getDataCharacteristics(output.getName());

--- a/src/main/java/org/tugraz/sysds/runtime/instructions/spark/data/PartitionedBlock.java
+++ b/src/main/java/org/tugraz/sysds/runtime/instructions/spark/data/PartitionedBlock.java
@@ -36,6 +36,7 @@ import org.tugraz.sysds.runtime.controlprogram.caching.CacheBlock;
 import org.tugraz.sysds.runtime.controlprogram.caching.CacheBlockFactory;
 import org.tugraz.sysds.runtime.util.FastBufferedDataInputStream;
 import org.tugraz.sysds.runtime.util.FastBufferedDataOutputStream;
+import org.tugraz.sysds.runtime.util.UtilFunctions;
 
 /**
  * This class is for partitioned matrix/frame blocks, to be used as broadcasts. 
@@ -191,12 +192,9 @@ public class PartitionedBlock<T extends CacheBlock> implements Externalizable
 
 	@SuppressWarnings("unchecked")
 	public T getBlock(int[] ix) {
-		int index = ix[ix.length - 1] - 1;
-		for (int i = ix.length - 2; i >= 0; i--) {
-			index += (ix[i] - 1) * getNumDimBlocks(i + 1);
-		}
+		long index = UtilFunctions.computeBlockNumber(ix, _dims, _blens);
 		index -= _offset;
-		return (T)_partBlocks[index];
+		return (T)_partBlocks[(int) index];
 	}
 
 	public void setBlock(int rowIndex, int colIndex, T block) {

--- a/src/main/java/org/tugraz/sysds/runtime/instructions/spark/data/PartitionedBlock.java
+++ b/src/main/java/org/tugraz/sysds/runtime/instructions/spark/data/PartitionedBlock.java
@@ -1,4 +1,6 @@
 /*
+ * Modifications Copyright 2019 Graz University of Technology
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -44,17 +46,15 @@ import org.tugraz.sysds.runtime.util.FastBufferedDataOutputStream;
  */
 public class PartitionedBlock<T extends CacheBlock> implements Externalizable
 {
-	protected CacheBlock[] _partBlocks = null; 
-	protected long _rlen = -1;
-	protected long _clen = -1;
-	protected int _brlen = -1;
-	protected int _bclen = -1;
+	private static final long serialVersionUID = 1298817743064415129L;
+	protected CacheBlock[] _partBlocks = null;
+	protected long[] _dims = {-1, -1};
+	protected int[] _blens = {-1, -1};
 	protected int _offset = 0;
 	
 	public PartitionedBlock() {
 		//do nothing (required for Externalizable)
 	}
-	
 	
 	@SuppressWarnings("unchecked")
 	public PartitionedBlock(T block, int brlen, int bclen) 
@@ -64,10 +64,8 @@ public class PartitionedBlock<T extends CacheBlock> implements Externalizable
 		int clen = block.getNumColumns();
 		
 		//partitioning input broadcast
-		_rlen = rlen;
-		_clen = clen;
-		_brlen = brlen;
-		_bclen = bclen;
+		_dims = new long[]{rlen, clen};
+		_blens = new int[]{brlen, bclen};
 		int nrblks = getNumRowBlocks();
 		int ncblks = getNumColumnBlocks();
 		int code = CacheBlockFactory.getCode(block);
@@ -78,8 +76,36 @@ public class PartitionedBlock<T extends CacheBlock> implements Externalizable
 				int i = index / ncblks;
 				int j = index % ncblks;
 				T tmp = (T) CacheBlockFactory.newInstance(code);
-				return block.slice(i * _brlen, Math.min((i + 1) * _brlen, rlen) - 1,
-					j * _bclen, Math.min((j + 1) * _bclen, clen) - 1, tmp);
+				return block.slice(i * _blens[0], Math.min((i + 1) * _blens[0], rlen) - 1,
+					j * _blens[1], Math.min((j + 1) * _blens[1], clen) - 1, tmp);
+			});
+		} catch(Exception ex) {
+			throw new RuntimeException("Failed partitioning of broadcast variable input.", ex);
+		}
+
+		_offset = 0;
+	}
+
+	@SuppressWarnings("unchecked")
+	public PartitionedBlock(T block, long[] dims, int[] blens)
+	{
+		//partitioning input broadcast
+		_dims = dims;
+		_blens = blens;
+		int nblks = 1;
+		for (int i = 0; i < dims.length; i++)
+			nblks *= getNumDimBlocks(i);
+		int code = CacheBlockFactory.getCode(block);
+
+		try {
+			_partBlocks = new CacheBlock[nblks];
+			int div = nblks / getNumRowBlocks();
+			Arrays.parallelSetAll(_partBlocks, index -> {
+				int i = index / div;
+				int j = index % div;
+				T tmp = (T) CacheBlockFactory.newInstance(code);
+				return block.slice(i * _blens[0], Math.min((i + 1) * _blens[0], (int)_dims[0]) - 1,
+						j * _blens[1], Math.min((j + 1) * _blens[1], (int)_dims[1]) - 1, tmp);
 			});
 		} catch(Exception ex) {
 			throw new RuntimeException("Failed partitioning of broadcast variable input.", ex);
@@ -91,11 +117,9 @@ public class PartitionedBlock<T extends CacheBlock> implements Externalizable
 	public PartitionedBlock(int rlen, int clen, int brlen, int bclen) 
 	{
 		//partitioning input broadcast
-		_rlen = rlen;
-		_clen = clen;
-		_brlen = brlen;
-		_bclen = bclen;
-		
+		_dims = new long[]{rlen, clen};
+		_blens = new int[]{brlen, bclen};
+
 		int nrblks = getNumRowBlocks();
 		int ncblks = getNumColumnBlocks();
 		_partBlocks = new CacheBlock[nrblks * ncblks];
@@ -104,10 +128,8 @@ public class PartitionedBlock<T extends CacheBlock> implements Externalizable
 	public PartitionedBlock<T> createPartition( int offset, int numBlks)
 	{
 		PartitionedBlock<T> ret = new PartitionedBlock<>();
-		ret._rlen = _rlen;
-		ret._clen = _clen;
-		ret._brlen = _brlen;
-		ret._bclen = _bclen;
+		ret._dims = Arrays.copyOf(_dims, _dims.length);
+		ret._blens = Arrays.copyOf(_blens, _blens.length);
 		ret._partBlocks = new CacheBlock[numBlks];
 		ret._offset = offset;
 		System.arraycopy(_partBlocks, offset, ret._partBlocks, 0, numBlks);
@@ -116,27 +138,39 @@ public class PartitionedBlock<T extends CacheBlock> implements Externalizable
 	}
 	
 	public long getNumRows() {
-		return _rlen;
+		return _dims[0];
 	}
 	
 	public long getNumCols() {
-		return _clen;
+		return _dims[1];
+	}
+
+	public long getDim(int i) {
+		return _dims[i];
 	}
 	
 	public long getNumRowsPerBlock() {
-		return _brlen;
+		return _blens[0];
 	}
 	
 	public long getNumColumnsPerBlock() {
-		return _bclen;
+		return _blens[1];
+	}
+
+	public long getNumDimPerBlock(int i) {
+		return _blens[i];
 	}
 
 	public int getNumRowBlocks() {
-		return (int)Math.ceil((double)_rlen/_brlen);
+		return getNumDimBlocks(0);
 	}
 
 	public int getNumColumnBlocks() {
-		return (int)Math.ceil((double)_clen/_bclen);
+		return getNumDimBlocks(1);
+	}
+
+	public int getNumDimBlocks(int dim) {
+		return (int)Math.ceil((double)_dims[dim]/_blens[dim]);
 	}
 
 	@SuppressWarnings("unchecked")
@@ -153,6 +187,16 @@ public class PartitionedBlock<T extends CacheBlock> implements Externalizable
 		int cix = colIndex - 1;
 		int ix = rix*ncblks+cix - _offset;
 		return (T)_partBlocks[ix];
+	}
+
+	@SuppressWarnings("unchecked")
+	public T getBlock(int[] ix) {
+		int index = ix[ix.length - 1] - 1;
+		for (int i = ix.length - 2; i >= 0; i--) {
+			index += (ix[i] - 1) * getNumDimBlocks(i + 1);
+		}
+		index -= _offset;
+		return (T)_partBlocks[index];
 	}
 
 	public void setBlock(int rowIndex, int colIndex, T block) {
@@ -243,10 +287,9 @@ public class PartitionedBlock<T extends CacheBlock> implements Externalizable
 	private void writeHeaderAndPayload(DataOutput dos) 
 		throws IOException
 	{
-		dos.writeLong(_rlen);
-		dos.writeLong(_clen);
-		dos.writeInt(_brlen);
-		dos.writeInt(_bclen);
+		dos.writeInt(_dims.length);
+		for (long dim : _dims) dos.writeLong(dim);
+		for (int blen : _blens) dos.writeInt(blen);
 		dos.writeInt(_offset);
 		dos.writeInt(_partBlocks.length);
 		dos.writeByte(CacheBlockFactory.getCode(_partBlocks[0]));
@@ -258,11 +301,14 @@ public class PartitionedBlock<T extends CacheBlock> implements Externalizable
 	private int readHeader(DataInput dis) 
 		throws IOException
 	{
-		_rlen = dis.readLong();
-		_clen = dis.readLong();
-		_brlen = dis.readInt();
-		_bclen = dis.readInt();
-		_offset = dis.readInt();		
+		int length = dis.readInt();
+		_dims = new long[length];
+		for (int i = 0; i < length; i++)
+			_dims[i] = dis.readLong();
+		_blens = new int[length];
+		for (int i = 0; i < length; i++)
+			_blens[i] = dis.readInt();
+		_offset = dis.readInt();
 		int len = dis.readInt();
 		int code = dis.readByte();
 		

--- a/src/main/java/org/tugraz/sysds/runtime/instructions/spark/data/PartitionedBroadcast.java
+++ b/src/main/java/org/tugraz/sysds/runtime/instructions/spark/data/PartitionedBroadcast.java
@@ -107,14 +107,10 @@ public class PartitionedBroadcast<T extends CacheBlock> implements Serializable
 	public T getBlock(int[] ix) {
 		int pix = 0;
 		if( _pbc.length > 1 ) { //compute partition index
-			long[] dims = new long[_dc.getNumDims()];
-			int[] blen = new int[_dc.getNumDims()];
-			for (int i = 0; i < dims.length; i++) {
-				dims[i] = _dc.getDim(i);
-				blen[i] = (int) _dc.getBlockSize(i);
-			}
+			long[] dims = _dc.getDims();
+			int[] blen = _dc.getBlockSizes();
 			int numPerPart = computeBlocksPerPartition(dims, blen);
-			long l = blen[blen.length - 1];
+			long l = ix[ix.length - 1];
 			for (int i = blen.length - 2; i >= 0; i--) {
 				l += (ix[i] - 1) * blen[i + 1];
 			}

--- a/src/main/java/org/tugraz/sysds/runtime/instructions/spark/data/PartitionedBroadcast.java
+++ b/src/main/java/org/tugraz/sysds/runtime/instructions/spark/data/PartitionedBroadcast.java
@@ -29,6 +29,7 @@ import org.tugraz.sysds.runtime.matrix.data.OperationsOnMatrixValues;
 import org.tugraz.sysds.runtime.matrix.data.Pair;
 import org.tugraz.sysds.runtime.meta.DataCharacteristics;
 import org.tugraz.sysds.runtime.util.IndexRange;
+import org.tugraz.sysds.runtime.util.UtilFunctions;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -109,12 +110,8 @@ public class PartitionedBroadcast<T extends CacheBlock> implements Serializable
 		if( _pbc.length > 1 ) { //compute partition index
 			long[] dims = _dc.getDims();
 			int[] blen = _dc.getBlockSizes();
-			int numPerPart = computeBlocksPerPartition(dims, blen);
-			long l = ix[ix.length - 1];
-			for (int i = blen.length - 2; i >= 0; i--) {
-				l += (ix[i] - 1) * blen[i + 1];
-			}
-			pix = (int) (l / numPerPart);
+			int numPerPart = computeBlocksPerPartition(dims, _dc.getBlockSizes());
+			pix = (int) (UtilFunctions.computeBlockNumber(ix, dims, blen) / numPerPart);
 		}
 
 		return _pbc[pix].value().getBlock(ix);

--- a/src/main/java/org/tugraz/sysds/runtime/instructions/spark/functions/ReplicateTensorFunction.java
+++ b/src/main/java/org/tugraz/sysds/runtime/instructions/spark/functions/ReplicateTensorFunction.java
@@ -49,9 +49,8 @@ public class ReplicateTensorFunction implements PairFlatMapFunction<Tuple2<Tenso
 		}
 
 		ArrayList<Tuple2<TensorIndexes, TensorBlock>> retVal = new ArrayList<>();
+		long[] indexes = ix.getIndexes();
 		for (int i = 1; i <= _numReplicas; i++) {
-			// create copies so we don't change the other replications
-			long[] indexes = ix.getIndexes().clone();
 			indexes[_byDim] = i;
 			retVal.add(new Tuple2<>(new TensorIndexes(indexes), tb));
 		}

--- a/src/main/java/org/tugraz/sysds/runtime/instructions/spark/functions/ReplicateTensorFunction.java
+++ b/src/main/java/org/tugraz/sysds/runtime/instructions/spark/functions/ReplicateTensorFunction.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 Graz University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.tugraz.sysds.runtime.instructions.spark.functions;
+
+import org.apache.spark.api.java.function.PairFlatMapFunction;
+import org.tugraz.sysds.runtime.data.TensorBlock;
+import org.tugraz.sysds.runtime.data.TensorIndexes;
+import scala.Tuple2;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+
+
+public class ReplicateTensorFunction implements PairFlatMapFunction<Tuple2<TensorIndexes, TensorBlock>, TensorIndexes, TensorBlock> {
+	private static final long serialVersionUID = 7181347334827684965L;
+
+	private int _byDim;
+	private long _numReplicas;
+
+	public ReplicateTensorFunction(int byDim, long numReplicas) {
+		_byDim = byDim;
+		_numReplicas = numReplicas;
+	}
+
+	@Override
+	public Iterator<Tuple2<TensorIndexes, TensorBlock>> call(Tuple2<TensorIndexes, TensorBlock> arg0)
+			throws Exception {
+		TensorIndexes ix = arg0._1();
+		TensorBlock tb = arg0._2();
+
+		//sanity check inputs
+		if (ix.getIndex(_byDim) != 1 || tb.getDim(_byDim) > 1) {
+			throw new Exception("Expected dimension " + _byDim + " to be 1 in ReplicateTensor");
+		}
+
+		ArrayList<Tuple2<TensorIndexes, TensorBlock>> retVal = new ArrayList<>();
+		for (int i = 1; i <= _numReplicas; i++) {
+			// create copies so we don't change the other replications
+			long[] indexes = ix.getIndexes().clone();
+			indexes[_byDim] = i;
+			retVal.add(new Tuple2<>(new TensorIndexes(indexes), tb));
+		}
+		return retVal.iterator();
+	}
+}

--- a/src/main/java/org/tugraz/sysds/runtime/instructions/spark/functions/TensorTensorBinaryOpFunction.java
+++ b/src/main/java/org/tugraz/sysds/runtime/instructions/spark/functions/TensorTensorBinaryOpFunction.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 Graz University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.tugraz.sysds.runtime.instructions.spark.functions;
+
+import org.apache.spark.api.java.function.Function;
+import org.tugraz.sysds.runtime.data.TensorBlock;
+import org.tugraz.sysds.runtime.matrix.operators.BinaryOperator;
+import scala.Tuple2;
+
+public class TensorTensorBinaryOpFunction implements Function<Tuple2<TensorBlock,TensorBlock>, TensorBlock>
+{
+	private static final long serialVersionUID = 4204525225937988112L;
+
+	private BinaryOperator _bop;
+
+	public TensorTensorBinaryOpFunction(BinaryOperator op) {
+		_bop = op;
+	}
+
+	@Override
+	public TensorBlock call(Tuple2<TensorBlock, TensorBlock> arg0)
+			throws Exception 
+	{
+		return arg0._1().binaryOperations(_bop, arg0._2(), null);
+	}
+}

--- a/src/main/java/org/tugraz/sysds/runtime/instructions/spark/functions/TensorTensorBinaryOpPartitionFunction.java
+++ b/src/main/java/org/tugraz/sysds/runtime/instructions/spark/functions/TensorTensorBinaryOpPartitionFunction.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2019 Graz University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.tugraz.sysds.runtime.instructions.spark.functions;
+
+import org.apache.spark.api.java.function.PairFlatMapFunction;
+import org.tugraz.sysds.runtime.data.BasicTensor;
+import org.tugraz.sysds.runtime.data.TensorBlock;
+import org.tugraz.sysds.runtime.data.TensorIndexes;
+import org.tugraz.sysds.runtime.instructions.spark.data.LazyIterableIterator;
+import org.tugraz.sysds.runtime.instructions.spark.data.PartitionedBroadcast;
+import org.tugraz.sysds.runtime.matrix.operators.BinaryOperator;
+import scala.Tuple2;
+
+import java.util.Iterator;
+
+public class TensorTensorBinaryOpPartitionFunction implements PairFlatMapFunction<Iterator<Tuple2<TensorIndexes, TensorBlock>>, TensorIndexes, TensorBlock> {
+
+	private static final long serialVersionUID = 8029096658247920867L;
+	private BinaryOperator _op;
+	private PartitionedBroadcast<TensorBlock> _ptV;
+	private boolean[] _replicateDim;
+
+	public TensorTensorBinaryOpPartitionFunction(BinaryOperator op, PartitionedBroadcast<TensorBlock> binput,
+			boolean[] replicateDim) {
+		_op = op;
+		_ptV = binput;
+		_replicateDim = replicateDim;
+	}
+
+	@Override
+	public LazyIterableIterator<Tuple2<TensorIndexes, TensorBlock>> call(
+			Iterator<Tuple2<TensorIndexes, TensorBlock>> arg0)
+			throws Exception {
+		return new MapBinaryPartitionIterator(arg0);
+	}
+
+	/**
+	 * Lazy mbinary iterator to prevent materialization of entire partition output in-memory.
+	 * The implementation via mapPartitions is required to preserve partitioning information,
+	 * which is important for performance.
+	 */
+	private class MapBinaryPartitionIterator extends LazyIterableIterator<Tuple2<TensorIndexes, TensorBlock>> {
+		public MapBinaryPartitionIterator(Iterator<Tuple2<TensorIndexes, TensorBlock>> in) {
+			super(in);
+		}
+
+		@Override
+		protected Tuple2<TensorIndexes, TensorBlock> computeNext(Tuple2<TensorIndexes, TensorBlock> arg) {
+			//unpack partition key-value pairs
+			TensorIndexes ix = arg._1();
+			TensorBlock in1 = arg._2();
+
+			//get the rhs block
+			int[] index = new int[in1.getNumDims()];
+			for (int i = 0; i < index.length; i++) {
+				if (_replicateDim[i])
+					index[i] = 1;
+				else
+					index[i] = (int) ix.getIndex(i);
+			}
+			TensorBlock in2 = _ptV.getBlock(index);
+
+			//execute the binary operation
+			TensorBlock ret = in1.binaryOperations(_op, in2, new BasicTensor());
+			return new Tuple2<>(ix, ret);
+		}
+	}
+}

--- a/src/main/java/org/tugraz/sysds/runtime/meta/DataCharacteristics.java
+++ b/src/main/java/org/tugraz/sysds/runtime/meta/DataCharacteristics.java
@@ -107,6 +107,10 @@ public abstract class DataCharacteristics implements Serializable {
 		throw new DMLRuntimeException("DataCharacteristics.getDim(int): should never get called in the base class");
 	}
 
+	public long[] getDims() {
+		throw new DMLRuntimeException("DataCharacteristics.getDims(): should never get called in the base class");
+	}
+
 	public TensorCharacteristics setDim(int i, long dim) {
 		throw new DMLRuntimeException("DataCharacteristics.setDim(int, long): should never get called in the base class");
 	}
@@ -115,8 +119,12 @@ public abstract class DataCharacteristics implements Serializable {
 		throw new DMLRuntimeException("DataCharacteristics.setDims(long[]): should never get called in the base class");
 	}
 
-	public long getBlockSize(int i) {
+	public int getBlockSize(int i) {
 		throw new DMLRuntimeException("DataCharacteristics.getBlockSize(int): should never get called in the base class");
+	}
+
+	public int[] getBlockSizes() {
+		throw new DMLRuntimeException("DataCharacteristics.getBlockSizes(): should never get called in the base class");
 	}
 
 	public DataCharacteristics setBlockSize(int blen) {
@@ -132,7 +140,7 @@ public abstract class DataCharacteristics implements Serializable {
 	}
 
 	public long getNumBlocks(int i) {
-		throw new DMLRuntimeException("DataCharacteristics.setNumBlocks(i): should never get called in the base class");
+		throw new DMLRuntimeException("DataCharacteristics.getNumBlocks(i): should never get called in the base class");
 	}
 
 	public void setNonZeros(long nnz) {

--- a/src/main/java/org/tugraz/sysds/runtime/meta/TensorCharacteristics.java
+++ b/src/main/java/org/tugraz/sysds/runtime/meta/TensorCharacteristics.java
@@ -17,6 +17,7 @@
 
 package org.tugraz.sysds.runtime.meta;
 
+import org.tugraz.sysds.runtime.DMLRuntimeException;
 import org.tugraz.sysds.runtime.util.UtilFunctions;
 
 import java.util.Arrays;
@@ -66,12 +67,8 @@ public class TensorCharacteristics extends DataCharacteristics
 
 	@Override
 	public DataCharacteristics set(DataCharacteristics that) {
-		long[] dims = new long[that.getNumDims()];
-		int[] blockSizes = new int[that.getNumDims()];
-		for (int i = 0; i < dims.length; i++) {
-			dims[i] = that.getDim(i);
-			blockSizes[i] = (int)that.getBlockSize(i);
-		}
+		long[] dims = that.getDims().clone();
+		int[] blockSizes = that.getBlockSizes().clone();
 		set(dims, blockSizes, that.getNonZeros());
 		return this;
 	}
@@ -111,6 +108,11 @@ public class TensorCharacteristics extends DataCharacteristics
 	}
 
 	@Override
+	public long[] getDims() {
+		return _dims;
+	}
+
+	@Override
 	public TensorCharacteristics setDim(int i, long dim) {
 		_dims[i] = dim;
 		return this;
@@ -123,8 +125,13 @@ public class TensorCharacteristics extends DataCharacteristics
 	}
 
 	@Override
-	public long getBlockSize(int i) {
+	public int getBlockSize(int i) {
 		return _blkSizes[i];
+	}
+
+	@Override
+	public int[] getBlockSizes() {
+		return _blkSizes;
 	}
 
 	@Override

--- a/src/main/java/org/tugraz/sysds/runtime/util/DataConverter.java
+++ b/src/main/java/org/tugraz/sysds/runtime/util/DataConverter.java
@@ -1017,6 +1017,8 @@ public class DataConverter
 					// we either reached the dimension limit or the colLength if j == 1
 					// so we add border (because of the completely iterated dimension) and increment the next
 					// dimension while setting the current one to 0
+					if (ix[j] != tb.getDim(j))
+						sb.append("...");
 					sb.append(rightBorder);
 					borderCount++;
 					ix[j] = 0;

--- a/src/main/java/org/tugraz/sysds/runtime/util/UtilFunctions.java
+++ b/src/main/java/org/tugraz/sysds/runtime/util/UtilFunctions.java
@@ -156,6 +156,21 @@ public class UtilFunctions
 		return (int)Math.min(blockSize, remain);
 	}
 
+	/**
+	 * Calculates the number of the block this index refers to (basically a linearisation).
+	 * @param ix the dimensional indexes
+	 * @param dims length of dimensions
+	 * @param blen length of blocks
+	 * @return the number of the block
+	 */
+	public static long computeBlockNumber(int[] ix, long[] dims, int[] blen) {
+		long pos = ix[ix.length - 1] - 1;
+		for (int i = ix.length - 2; i >= 0; i--) {
+			pos += (ix[i] - 1) * Math.ceil((double)dims[i + 1] / blen[i + 1]);
+		}
+		return pos;
+	}
+
 	public static ArrayList<Integer> getBalancedBlockSizesDefault(int len, int k, boolean constK) {
 		int nk = constK ? k : roundToNext(Math.min(8*k,len/32), k);
 		return getBalancedBlockSizes(len, nk);

--- a/src/test/java/org/tugraz/sysds/test/component/tensor/TensorUtilTests.java
+++ b/src/test/java/org/tugraz/sysds/test/component/tensor/TensorUtilTests.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 Graz University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.tugraz.sysds.test.component.tensor;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.tugraz.sysds.runtime.util.UtilFunctions;
+
+
+public class TensorUtilTests {
+	@Test
+	public void testBlockNumber() {
+		Assert.assertEquals(5, UtilFunctions.computeBlockNumber(new int[]{3, 2, 1}, new long[]{4000, 133, 1}, new int[]{128, 128, 128}));
+	}
+
+	@Test
+	public void testBlockNumberBegin() {
+		Assert.assertEquals(0, UtilFunctions.computeBlockNumber(new int[]{1, 1, 1}, new long[]{4000, 133000, 9}, new int[]{128, 128, 128}));
+	}
+
+	@Test
+	public void testBlockNumberLast() {
+		Assert.assertEquals(2 * 8 - 1, UtilFunctions.computeBlockNumber(new int[]{1, 2, 8}, new long[]{128, 128 + 1, 8 * 128}, new int[]{128, 128, 128}));
+	}
+}

--- a/src/test/java/org/tugraz/sysds/test/functions/binary/tensor/ElementwiseAdditionTest.java
+++ b/src/test/java/org/tugraz/sysds/test/functions/binary/tensor/ElementwiseAdditionTest.java
@@ -32,35 +32,36 @@ import java.util.Arrays;
 import java.util.Collection;
 
 @RunWith(value = Parameterized.class)
-public class ElementwiseAdditionTest extends AutomatedTestBase
-{
+public class ElementwiseAdditionTest extends AutomatedTestBase {
 	private final static String TEST_DIR = "functions/binary/tensor/";
 	private final static String TEST_NAME = "ElementwiseAdditionTest";
 	private final static String TEST_CLASS_DIR = TEST_DIR + ElementwiseAdditionTest.class.getSimpleName() + "/";
 
-	private String lvalue, rvalue;
-	private int[] dimensions;
+	private String _lvalue, _rvalue;
+	private int[] _dimsLeft, _dimsRight;
 
-	public ElementwiseAdditionTest(int[] dims, String lv, String rv) {
-		dimensions = dims;
-		lvalue = lv;
-		rvalue = rv;
+	public ElementwiseAdditionTest(int[] dimsLeft, int[] dimsRight, String lv, String rv) {
+		_dimsLeft = dimsLeft;
+		_dimsRight = dimsRight;
+		_lvalue = lv;
+		_rvalue = rv;
 	}
-	
+
 	@Parameters
 	public static Collection<Object[]> data() {
-		Object[][] data = new Object[][] {
-				{new int[]{3, 4, 5}, "3", "-2"},
-				{new int[]{1, 1, 1, 1, 1}, "2", "30000000000.0"},
-				{new int[]{4000, 4000}, "3.0", "-2.0"},
-				{new int[]{4000, 4000}, "3.0", "-2"},
-				};
+		Object[][] data = new Object[][]{
+				{new int[]{3, 4, 5}, new int[]{3, 4, 5}, "3", "-2"},
+				{new int[]{1, 1, 1, 1, 1}, new int[]{1, 1, 1, 1, 1}, "2", "30000000000.0"},
+				{new int[]{4000, 4000}, new int[]{4000, 4000}, "3.0", "-2.0"},
+				{new int[]{4000, 4000}, new int[]{4000, 1}, "3.0", "-2.0"},
+				{new int[]{4000, 4000}, new int[]{1, 1}, "3.0", "-2"},
+		};
 		return Arrays.asList(data);
 	}
-	
+
 	@Override
 	public void setUp() {
-		addTestConfiguration(TEST_NAME,new TestConfiguration(TEST_CLASS_DIR, TEST_NAME,new String[]{"A.scalar"}));
+		addTestConfiguration(TEST_NAME, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, new String[]{"A.scalar"}));
 	}
 
 	@Test
@@ -99,10 +100,12 @@ public class ElementwiseAdditionTest extends AutomatedTestBase
 			String HOME = SCRIPT_DIR + TEST_DIR;
 
 			fullDMLScriptName = HOME + TEST_NAME + ".dml";
-			String dimensionsString = Arrays.toString(dimensions).replace("[", "")
+			String ldimString = Arrays.toString(_dimsLeft).replace("[", "")
+					.replace(",", "").replace("]", "");
+			String rdimString = Arrays.toString(_dimsRight).replace("[", "")
 					.replace(",", "").replace("]", "");
 			programArgs = new String[]{"-explain", "-args",
-					dimensionsString, Integer.toString(dimensions.length), lvalue, rvalue, output("A")};
+					ldimString, rdimString, Integer.toString(_dimsLeft.length), _lvalue, _rvalue, output("A")};
 
 			runTest(true, false, null, -1);
 			//TODO test correctness

--- a/src/test/java/org/tugraz/sysds/test/functions/binary/tensor/ElementwiseAdditionTest.java
+++ b/src/test/java/org/tugraz/sysds/test/functions/binary/tensor/ElementwiseAdditionTest.java
@@ -23,6 +23,7 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 import org.tugraz.sysds.api.DMLScript;
 import org.tugraz.sysds.common.Types.ExecMode;
+import org.tugraz.sysds.hops.BinaryOp;
 import org.tugraz.sysds.lops.LopProperties;
 import org.tugraz.sysds.test.AutomatedTestBase;
 import org.tugraz.sysds.test.TestConfiguration;
@@ -69,6 +70,13 @@ public class ElementwiseAdditionTest extends AutomatedTestBase
 
 	@Test
 	public void elementwiseAdditionTestSpark() {
+		BinaryOp.FORCED_BINARY_METHOD = null;
+		testElementwiseAddition(TEST_NAME, LopProperties.ExecType.SPARK);
+	}
+
+	@Test
+	public void elementwiseAdditionTestBroadcastSpark() {
+		BinaryOp.FORCED_BINARY_METHOD = BinaryOp.MMBinaryMethod.MR_BINARY_M;
 		testElementwiseAddition(TEST_NAME, LopProperties.ExecType.SPARK);
 	}
 
@@ -97,6 +105,7 @@ public class ElementwiseAdditionTest extends AutomatedTestBase
 					dimensionsString, Integer.toString(dimensions.length), lvalue, rvalue, output("A")};
 
 			runTest(true, false, null, -1);
+			//TODO test correctness
 		}
 		finally {
 			rtplatform = platformOld;

--- a/src/test/java/org/tugraz/sysds/test/functions/binary/tensor/ElementwiseAdditionTest.java
+++ b/src/test/java/org/tugraz/sysds/test/functions/binary/tensor/ElementwiseAdditionTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2019 Graz University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.tugraz.sysds.test.functions.binary.tensor;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.tugraz.sysds.api.DMLScript;
+import org.tugraz.sysds.common.Types.ExecMode;
+import org.tugraz.sysds.lops.LopProperties;
+import org.tugraz.sysds.test.AutomatedTestBase;
+import org.tugraz.sysds.test.TestConfiguration;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+@RunWith(value = Parameterized.class)
+public class ElementwiseAdditionTest extends AutomatedTestBase
+{
+	private final static String TEST_DIR = "functions/binary/tensor/";
+	private final static String TEST_NAME = "ElementwiseAdditionTest";
+	private final static String TEST_CLASS_DIR = TEST_DIR + ElementwiseAdditionTest.class.getSimpleName() + "/";
+
+	private String lvalue, rvalue;
+	private int[] dimensions;
+
+	public ElementwiseAdditionTest(int[] dims, String lv, String rv) {
+		dimensions = dims;
+		lvalue = lv;
+		rvalue = rv;
+	}
+	
+	@Parameters
+	public static Collection<Object[]> data() {
+		Object[][] data = new Object[][] {
+				{new int[]{3, 4, 5}, "3", "-2"},
+				{new int[]{1, 1, 1, 1, 1}, "2", "30000000000.0"},
+				{new int[]{4000, 4000}, "3.0", "-2.0"},
+				{new int[]{4000, 4000}, "3.0", "-2"},
+				};
+		return Arrays.asList(data);
+	}
+	
+	@Override
+	public void setUp() {
+		addTestConfiguration(TEST_NAME,new TestConfiguration(TEST_CLASS_DIR, TEST_NAME,new String[]{"A.scalar"}));
+	}
+
+	@Test
+	public void elementwiseAdditionTestCP() {
+		testElementwiseAddition(TEST_NAME, LopProperties.ExecType.CP);
+	}
+
+	@Test
+	public void elementwiseAdditionTestSpark() {
+		testElementwiseAddition(TEST_NAME, LopProperties.ExecType.SPARK);
+	}
+
+	private void testElementwiseAddition(String testName, LopProperties.ExecType platform) {
+		ExecMode platformOld = rtplatform;
+		if (platform == LopProperties.ExecType.SPARK) {
+			rtplatform = ExecMode.SPARK;
+		}
+		else {
+			rtplatform = ExecMode.SINGLE_NODE;
+		}
+
+		boolean sparkConfigOld = DMLScript.USE_LOCAL_SPARK_CONFIG;
+		if (rtplatform == ExecMode.SPARK) {
+			DMLScript.USE_LOCAL_SPARK_CONFIG = true;
+		}
+		try {
+			getAndLoadTestConfiguration(TEST_NAME);
+
+			String HOME = SCRIPT_DIR + TEST_DIR;
+
+			fullDMLScriptName = HOME + TEST_NAME + ".dml";
+			String dimensionsString = Arrays.toString(dimensions).replace("[", "")
+					.replace(",", "").replace("]", "");
+			programArgs = new String[]{"-explain", "-args",
+					dimensionsString, Integer.toString(dimensions.length), lvalue, rvalue, output("A")};
+
+			runTest(true, false, null, -1);
+		}
+		finally {
+			rtplatform = platformOld;
+			DMLScript.USE_LOCAL_SPARK_CONFIG = sparkConfigOld;
+		}
+	}
+}

--- a/src/test/java/org/tugraz/sysds/test/functions/binary/tensor/ElementwiseMultiplicationTest.java
+++ b/src/test/java/org/tugraz/sysds/test/functions/binary/tensor/ElementwiseMultiplicationTest.java
@@ -32,35 +32,36 @@ import java.util.Arrays;
 import java.util.Collection;
 
 @RunWith(value = Parameterized.class)
-public class ElementwiseMultiplicationTest extends AutomatedTestBase
-{
+public class ElementwiseMultiplicationTest extends AutomatedTestBase {
 	private final static String TEST_DIR = "functions/binary/tensor/";
 	private final static String TEST_NAME = "ElementwiseMultiplicationTest";
 	private final static String TEST_CLASS_DIR = TEST_DIR + ElementwiseMultiplicationTest.class.getSimpleName() + "/";
 
-	private String lvalue, rvalue;
-	private int[] dimensions;
+	private String _lvalue, _rvalue;
+	private int[] _dimsLeft, _dimsRight;
 
-	public ElementwiseMultiplicationTest(int[] dims, String lv, String rv) {
-		dimensions = dims;
-		lvalue = lv;
-		rvalue = rv;
+	public ElementwiseMultiplicationTest(int[] dimsLeft, int[] dimsRight, String lv, String rv) {
+		_dimsLeft = dimsLeft;
+		_dimsRight = dimsRight;
+		_lvalue = lv;
+		_rvalue = rv;
 	}
-	
+
 	@Parameters
 	public static Collection<Object[]> data() {
-		Object[][] data = new Object[][] {
-				{new int[]{3, 4, 5}, "3", "-2"},
-				{new int[]{1, 1, 1, 1, 1}, "2", "30000000000.0"},
-				{new int[]{4000, 4000}, "3.0", "-2.0"},
-				{new int[]{4000, 4000}, "3.0", "-2"},
-				};
+		Object[][] data = new Object[][]{
+				{new int[]{3, 4, 5}, new int[]{3, 4, 5}, "3", "-2"},
+				{new int[]{1, 1, 1, 1, 1}, new int[]{1, 1, 1, 1, 1}, "2", "30000000000.0"},
+				{new int[]{4000, 4000}, new int[]{4000, 4000}, "3.0", "-2.0"},
+				{new int[]{4000, 4000}, new int[]{4000, 1}, "3.0", "-2.0"},
+				{new int[]{4000, 4000}, new int[]{1, 1}, "3.0", "-2"},
+		};
 		return Arrays.asList(data);
 	}
-	
+
 	@Override
 	public void setUp() {
-		addTestConfiguration(TEST_NAME,new TestConfiguration(TEST_CLASS_DIR, TEST_NAME,new String[]{"A.scalar"}));
+		addTestConfiguration(TEST_NAME, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, new String[]{"A.scalar"}));
 	}
 
 	@Test
@@ -94,15 +95,17 @@ public class ElementwiseMultiplicationTest extends AutomatedTestBase
 			DMLScript.USE_LOCAL_SPARK_CONFIG = true;
 		}
 		try {
-			getAndLoadTestConfiguration(testName);
+			getAndLoadTestConfiguration(TEST_NAME);
 
 			String HOME = SCRIPT_DIR + TEST_DIR;
 
-			fullDMLScriptName = HOME + testName + ".dml";
-			String dimensionsString = Arrays.toString(dimensions).replace("[", "")
+			fullDMLScriptName = HOME + TEST_NAME + ".dml";
+			String ldimString = Arrays.toString(_dimsLeft).replace("[", "")
+					.replace(",", "").replace("]", "");
+			String rdimString = Arrays.toString(_dimsRight).replace("[", "")
 					.replace(",", "").replace("]", "");
 			programArgs = new String[]{"-explain", "-args",
-					dimensionsString, Integer.toString(dimensions.length), lvalue, rvalue, output("A")};
+					ldimString, rdimString, Integer.toString(_dimsLeft.length), _lvalue, _rvalue, output("A")};
 
 			runTest(true, false, null, -1);
 			//TODO test correctness

--- a/src/test/java/org/tugraz/sysds/test/functions/binary/tensor/ElementwiseMultiplicationTest.java
+++ b/src/test/java/org/tugraz/sysds/test/functions/binary/tensor/ElementwiseMultiplicationTest.java
@@ -23,6 +23,7 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 import org.tugraz.sysds.api.DMLScript;
 import org.tugraz.sysds.common.Types.ExecMode;
+import org.tugraz.sysds.hops.BinaryOp;
 import org.tugraz.sysds.lops.LopProperties;
 import org.tugraz.sysds.test.AutomatedTestBase;
 import org.tugraz.sysds.test.TestConfiguration;
@@ -63,16 +64,23 @@ public class ElementwiseMultiplicationTest extends AutomatedTestBase
 	}
 
 	@Test
-	public void elementwiseAdditionTestCP() {
-		testElementwiseAddition(TEST_NAME, LopProperties.ExecType.CP);
+	public void elementwiseMultiplicationTestCP() {
+		testElementwiseMultiplication(TEST_NAME, LopProperties.ExecType.CP);
 	}
 
 	@Test
-	public void elementwiseAdditionTestSpark() {
-		testElementwiseAddition(TEST_NAME, LopProperties.ExecType.SPARK);
+	public void elementwiseMultiplicationTestSpark() {
+		BinaryOp.FORCED_BINARY_METHOD = null;
+		testElementwiseMultiplication(TEST_NAME, LopProperties.ExecType.SPARK);
 	}
 
-	private void testElementwiseAddition(String testName, LopProperties.ExecType platform) {
+	@Test
+	public void elementwiseMultiplicationTestBroadcastSpark() {
+		BinaryOp.FORCED_BINARY_METHOD = BinaryOp.MMBinaryMethod.MR_BINARY_M;
+		testElementwiseMultiplication(TEST_NAME, LopProperties.ExecType.SPARK);
+	}
+
+	private void testElementwiseMultiplication(String testName, LopProperties.ExecType platform) {
 		ExecMode platformOld = rtplatform;
 		if (platform == LopProperties.ExecType.SPARK) {
 			rtplatform = ExecMode.SPARK;
@@ -86,17 +94,18 @@ public class ElementwiseMultiplicationTest extends AutomatedTestBase
 			DMLScript.USE_LOCAL_SPARK_CONFIG = true;
 		}
 		try {
-			getAndLoadTestConfiguration(TEST_NAME);
+			getAndLoadTestConfiguration(testName);
 
 			String HOME = SCRIPT_DIR + TEST_DIR;
 
-			fullDMLScriptName = HOME + TEST_NAME + ".dml";
+			fullDMLScriptName = HOME + testName + ".dml";
 			String dimensionsString = Arrays.toString(dimensions).replace("[", "")
 					.replace(",", "").replace("]", "");
 			programArgs = new String[]{"-explain", "-args",
 					dimensionsString, Integer.toString(dimensions.length), lvalue, rvalue, output("A")};
 
 			runTest(true, false, null, -1);
+			//TODO test correctness
 		}
 		finally {
 			rtplatform = platformOld;

--- a/src/test/java/org/tugraz/sysds/test/functions/binary/tensor/ElementwiseMultiplicationTest.java
+++ b/src/test/java/org/tugraz/sysds/test/functions/binary/tensor/ElementwiseMultiplicationTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2019 Graz University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.tugraz.sysds.test.functions.binary.tensor;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.tugraz.sysds.api.DMLScript;
+import org.tugraz.sysds.common.Types.ExecMode;
+import org.tugraz.sysds.lops.LopProperties;
+import org.tugraz.sysds.test.AutomatedTestBase;
+import org.tugraz.sysds.test.TestConfiguration;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+@RunWith(value = Parameterized.class)
+public class ElementwiseMultiplicationTest extends AutomatedTestBase
+{
+	private final static String TEST_DIR = "functions/binary/tensor/";
+	private final static String TEST_NAME = "ElementwiseMultiplicationTest";
+	private final static String TEST_CLASS_DIR = TEST_DIR + ElementwiseMultiplicationTest.class.getSimpleName() + "/";
+
+	private String lvalue, rvalue;
+	private int[] dimensions;
+
+	public ElementwiseMultiplicationTest(int[] dims, String lv, String rv) {
+		dimensions = dims;
+		lvalue = lv;
+		rvalue = rv;
+	}
+	
+	@Parameters
+	public static Collection<Object[]> data() {
+		Object[][] data = new Object[][] {
+				{new int[]{3, 4, 5}, "3", "-2"},
+				{new int[]{1, 1, 1, 1, 1}, "2", "30000000000.0"},
+				{new int[]{4000, 4000}, "3.0", "-2.0"},
+				{new int[]{4000, 4000}, "3.0", "-2"},
+				};
+		return Arrays.asList(data);
+	}
+	
+	@Override
+	public void setUp() {
+		addTestConfiguration(TEST_NAME,new TestConfiguration(TEST_CLASS_DIR, TEST_NAME,new String[]{"A.scalar"}));
+	}
+
+	@Test
+	public void elementwiseAdditionTestCP() {
+		testElementwiseAddition(TEST_NAME, LopProperties.ExecType.CP);
+	}
+
+	@Test
+	public void elementwiseAdditionTestSpark() {
+		testElementwiseAddition(TEST_NAME, LopProperties.ExecType.SPARK);
+	}
+
+	private void testElementwiseAddition(String testName, LopProperties.ExecType platform) {
+		ExecMode platformOld = rtplatform;
+		if (platform == LopProperties.ExecType.SPARK) {
+			rtplatform = ExecMode.SPARK;
+		}
+		else {
+			rtplatform = ExecMode.SINGLE_NODE;
+		}
+
+		boolean sparkConfigOld = DMLScript.USE_LOCAL_SPARK_CONFIG;
+		if (rtplatform == ExecMode.SPARK) {
+			DMLScript.USE_LOCAL_SPARK_CONFIG = true;
+		}
+		try {
+			getAndLoadTestConfiguration(TEST_NAME);
+
+			String HOME = SCRIPT_DIR + TEST_DIR;
+
+			fullDMLScriptName = HOME + TEST_NAME + ".dml";
+			String dimensionsString = Arrays.toString(dimensions).replace("[", "")
+					.replace(",", "").replace("]", "");
+			programArgs = new String[]{"-explain", "-args",
+					dimensionsString, Integer.toString(dimensions.length), lvalue, rvalue, output("A")};
+
+			runTest(true, false, null, -1);
+		}
+		finally {
+			rtplatform = platformOld;
+			DMLScript.USE_LOCAL_SPARK_CONFIG = sparkConfigOld;
+		}
+	}
+}

--- a/src/test/scripts/functions/binary/tensor/ElementwiseAdditionTest.dml
+++ b/src/test/scripts/functions/binary/tensor/ElementwiseAdditionTest.dml
@@ -16,8 +16,9 @@
 #
 #-------------------------------------------------------------
 
-d = matrix($1, 1, $2);
-A = tensor($3, d);
-B = tensor($4, d);
+d1 = matrix($1, 1, $3);
+d2 = matrix($2, 1, $3);
+A = tensor($4, d1);
+B = tensor($5, d2);
 C = A + B;
 print(toString(C));

--- a/src/test/scripts/functions/binary/tensor/ElementwiseAdditionTest.dml
+++ b/src/test/scripts/functions/binary/tensor/ElementwiseAdditionTest.dml
@@ -1,0 +1,23 @@
+#-------------------------------------------------------------
+#
+# Copyright 2019 Graz University of Technology
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#-------------------------------------------------------------
+
+d = matrix($1, 1, $2);
+A = tensor($3, d);
+B = tensor($4, d);
+C = A + B;
+print(toString(C));

--- a/src/test/scripts/functions/binary/tensor/ElementwiseMultiplicationTest.dml
+++ b/src/test/scripts/functions/binary/tensor/ElementwiseMultiplicationTest.dml
@@ -1,0 +1,23 @@
+#-------------------------------------------------------------
+#
+# Copyright 2019 Graz University of Technology
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#-------------------------------------------------------------
+
+d = matrix($1, 1, $2);
+A = tensor($3, d);
+B = tensor($4, d);
+C = A * B;
+print(toString(C));

--- a/src/test/scripts/functions/binary/tensor/ElementwiseMultiplicationTest.dml
+++ b/src/test/scripts/functions/binary/tensor/ElementwiseMultiplicationTest.dml
@@ -16,8 +16,9 @@
 #
 #-------------------------------------------------------------
 
-d = matrix($1, 1, $2);
-A = tensor($3, d);
-B = tensor($4, d);
+d1 = matrix($1, 1, $3);
+d2 = matrix($2, 1, $3);
+A = tensor($4, d1);
+B = tensor($5, d2);
 C = A * B;
 print(toString(C));


### PR DESCRIPTION
This should support various binary instructions (+, *, - etc.).
The right hand side tensor (currently only tensor-tensor operations are allowed) does not have to completely match the left hand side dimensions, if the dimension is `1` instead. If an dimension is `1` we reuse this dimension over and over again.
Currently only `repartition join`s are used since size information for tensors is missing in `hops`, which we would need to decide which `SPARK` instruction we want to use (`broadcast` or `repartition`). We could decide between `broadcast` and `repartition` on instruction level, but this would deviate from the matrix implementation.