### PR TITLE
Tensor read and write

### DIFF
--- a/src/main/java/org/tugraz/sysds/hops/OptimizerUtils.java
+++ b/src/main/java/org/tugraz/sysds/hops/OptimizerUtils.java
@@ -459,10 +459,7 @@ public class OptimizerUtils
 			return checkSparkCollectMemoryBudget(dc.getRows(), dc.getCols(),
 				dc.getBlocksize(), dc.getNonZerosBound(), memPinned, false);
 		} else {
-			long[] dims = new long[dc.getNumDims()];
-			for (int i = 0; i < dims.length; i++) {
-				dims[i] = dc.getDim(i);
-			}
+			long[] dims = dc.getDims();
 			return checkSparkCollectMemoryBudget(dims, dc.getNonZeros(), memPinned, false);
 		}
 	}
@@ -472,10 +469,7 @@ public class OptimizerUtils
 			return checkSparkCollectMemoryBudget(dc.getRows(), dc.getCols(),
 				dc.getBlocksize(), dc.getNonZerosBound(), memPinned, checkBP);
 		} else {
-			long[] dims = new long[dc.getNumDims()];
-			for (int i = 0; i < dims.length; i++) {
-				dims[i] = dc.getDim(i);
-			}
+			long[] dims = dc.getDims();
 			return checkSparkCollectMemoryBudget(dims, dc.getNonZeros(), memPinned, checkBP);
 		}
 	}

--- a/src/main/java/org/tugraz/sysds/lops/Data.java
+++ b/src/main/java/org/tugraz/sysds/lops/Data.java
@@ -308,7 +308,7 @@ public class Data extends Lop
 		else
 			throw new LopsException(this.printErrorLocation() + "In Data Lop, Unknown operation: " + operation);
 		
-		sb.append( OPERAND_DELIMITOR );	
+		sb.append( OPERAND_DELIMITOR );
 		Lop fnameLop = _inputParams.get(DataExpression.IO_FILENAME);
 		boolean literal = (fnameLop instanceof Data && ((Data)fnameLop).isLiteral());
 		sb.append ( prepOperand(input2, DataType.SCALAR,  ValueType.STRING, literal) ); 
@@ -431,7 +431,7 @@ public class Data extends Lop
 			else if ( oparams.getFormat() == Format.LIBSVM )
 				fmt = "libsvm";
 			else { //binary
-				fmt = ( getDataType() == DataType.FRAME || oparams.getBlocksize() > 0 
+				fmt = ( getDataType() == DataType.FRAME || oparams.getBlocksize() > 0
 					|| oparams.getBlocksize() > 0 ) ? "binaryblock" : "binarycell";
 			}
 			

--- a/src/main/java/org/tugraz/sysds/lops/compile/Dag.java
+++ b/src/main/java/org/tugraz/sysds/lops/compile/Dag.java
@@ -344,9 +344,9 @@ public class Dag<N extends Lop>
 	private static ArrayList<Instruction> generateInstructionsForInputVariables(List<Lop> nodes_v) {
 		ArrayList<Instruction> insts = new ArrayList<>();
 		for(Lop n : nodes_v) {
-			if (n.isDataExecLocation() && !((Data) n).isTransient() 
-					&& ((Data) n).getOperationType() == OperationTypes.READ 
-					&& (n.getDataType() == DataType.MATRIX || n.getDataType() == DataType.FRAME) ) {
+			if (n.isDataExecLocation() && !((Data) n).isTransient()
+					&& ((Data) n).getOperationType() == OperationTypes.READ
+					&& (n.getDataType() == DataType.MATRIX || n.getDataType() == DataType.FRAME || n.getDataType() == DataType.TENSOR)) {
 				if ( !((Data)n).isLiteral() ) {
 					try {
 						String inst_string = n.getInstructions();

--- a/src/main/java/org/tugraz/sysds/lops/compile/Dag.java
+++ b/src/main/java/org/tugraz/sysds/lops/compile/Dag.java
@@ -346,7 +346,7 @@ public class Dag<N extends Lop>
 		for(Lop n : nodes_v) {
 			if (n.isDataExecLocation() && !((Data) n).isTransient()
 					&& ((Data) n).getOperationType() == OperationTypes.READ
-					&& (n.getDataType() == DataType.MATRIX || n.getDataType() == DataType.FRAME || n.getDataType() == DataType.TENSOR)) {
+					&& (n.getDataType() == DataType.MATRIX || n.getDataType() == DataType.FRAME) ) {
 				if ( !((Data)n).isLiteral() ) {
 					try {
 						String inst_string = n.getInstructions();

--- a/src/main/java/org/tugraz/sysds/parser/DataExpression.java
+++ b/src/main/java/org/tugraz/sysds/parser/DataExpression.java
@@ -74,7 +74,6 @@ public class DataExpression extends DataIdentifier
 	public static final String IO_FILENAME = "iofilename";
 	public static final String READROWPARAM = "rows";
 	public static final String READCOLPARAM = "cols";
-	public static final String READDIMSPARAM = "dims";
 	public static final String READNNZPARAM = "nnz";
 	
 	public static final String FORMAT_TYPE = "format";
@@ -86,7 +85,6 @@ public class DataExpression extends DataIdentifier
 	
 	public static final String ROWBLOCKCOUNTPARAM = "rows_in_block";
 	public static final String COLUMNBLOCKCOUNTPARAM = "cols_in_block";
-	public static final String DIMSBLOCKCOUNTPARAM = "dims_in_block";
 	public static final String DATATYPEPARAM = "data_type";
 	public static final String VALUETYPEPARAM = "value_type";
 	public static final String DESCRIPTIONPARAM = "description";
@@ -114,12 +112,12 @@ public class DataExpression extends DataIdentifier
 
 	// Valid parameter names in a metadata file
 	public static final String[] READ_VALID_MTD_PARAM_NAMES =
-			{IO_FILENAME, READROWPARAM, READCOLPARAM, READDIMSPARAM, READNNZPARAM, FORMAT_TYPE,
-					ROWBLOCKCOUNTPARAM, COLUMNBLOCKCOUNTPARAM, DIMSBLOCKCOUNTPARAM, DATATYPEPARAM, VALUETYPEPARAM, SCHEMAPARAM,
-					DESCRIPTIONPARAM, AUTHORPARAM, CREATEDPARAM,
-					// Parameters related to delimited/csv files.
-					DELIM_FILL_VALUE, DELIM_DELIMITER, DELIM_FILL, DELIM_HAS_HEADER_ROW, DELIM_NA_STRINGS
-			};
+		{ IO_FILENAME, READROWPARAM, READCOLPARAM, READNNZPARAM, FORMAT_TYPE,
+			ROWBLOCKCOUNTPARAM, COLUMNBLOCKCOUNTPARAM, DATATYPEPARAM, VALUETYPEPARAM, SCHEMAPARAM, DESCRIPTIONPARAM,
+			AUTHORPARAM, CREATEDPARAM,
+			// Parameters related to delimited/csv files.
+			DELIM_FILL_VALUE, DELIM_DELIMITER, DELIM_FILL, DELIM_HAS_HEADER_ROW, DELIM_NA_STRINGS
+		};
 
 	public static final String[] READ_VALID_PARAM_NAMES = 
 	{	IO_FILENAME, READROWPARAM, READCOLPARAM, FORMAT_TYPE, DATATYPEPARAM, VALUETYPEPARAM, SCHEMAPARAM,
@@ -1060,9 +1058,6 @@ public class DataExpression extends DataIdentifier
 					raiseValidateError("Invalid block dimensions (" + getOutput().getBlocksize() + ") when format=" + getVarParam(FORMAT_TYPE) + " in \"" + this.toString() + "\".", conditional);
 				}
 			
-			}
-			else if (dataTypeString.equalsIgnoreCase(Statement.TENSOR_DATA_TYPE)) {
-				getOutput().setDataType(DataType.TENSOR);
 			}
 			else if ( dataTypeString.equalsIgnoreCase(Statement.SCALAR_DATA_TYPE)) {
 				getOutput().setDataType(DataType.SCALAR);

--- a/src/main/java/org/tugraz/sysds/parser/DataExpression.java
+++ b/src/main/java/org/tugraz/sysds/parser/DataExpression.java
@@ -74,6 +74,7 @@ public class DataExpression extends DataIdentifier
 	public static final String IO_FILENAME = "iofilename";
 	public static final String READROWPARAM = "rows";
 	public static final String READCOLPARAM = "cols";
+	public static final String READDIMSPARAM = "dims";
 	public static final String READNNZPARAM = "nnz";
 	
 	public static final String FORMAT_TYPE = "format";
@@ -85,6 +86,7 @@ public class DataExpression extends DataIdentifier
 	
 	public static final String ROWBLOCKCOUNTPARAM = "rows_in_block";
 	public static final String COLUMNBLOCKCOUNTPARAM = "cols_in_block";
+	public static final String DIMSBLOCKCOUNTPARAM = "dims_in_block";
 	public static final String DATATYPEPARAM = "data_type";
 	public static final String VALUETYPEPARAM = "value_type";
 	public static final String DESCRIPTIONPARAM = "description";
@@ -111,13 +113,13 @@ public class DataExpression extends DataIdentifier
 		{  RAND_BY_ROW, RAND_DIMNAMES, RAND_DATA, RAND_ROWS, RAND_COLS, RAND_DIMS};
 
 	// Valid parameter names in a metadata file
-	public static final String[] READ_VALID_MTD_PARAM_NAMES = 
-		{ IO_FILENAME, READROWPARAM, READCOLPARAM, READNNZPARAM, FORMAT_TYPE,
-			ROWBLOCKCOUNTPARAM, COLUMNBLOCKCOUNTPARAM, DATATYPEPARAM, VALUETYPEPARAM, SCHEMAPARAM, DESCRIPTIONPARAM,
-			AUTHORPARAM, CREATEDPARAM,
-			// Parameters related to delimited/csv files.
-			DELIM_FILL_VALUE, DELIM_DELIMITER, DELIM_FILL, DELIM_HAS_HEADER_ROW, DELIM_NA_STRINGS
-		}; 
+	public static final String[] READ_VALID_MTD_PARAM_NAMES =
+			{IO_FILENAME, READROWPARAM, READCOLPARAM, READDIMSPARAM, READNNZPARAM, FORMAT_TYPE,
+					ROWBLOCKCOUNTPARAM, COLUMNBLOCKCOUNTPARAM, DIMSBLOCKCOUNTPARAM, DATATYPEPARAM, VALUETYPEPARAM, SCHEMAPARAM,
+					DESCRIPTIONPARAM, AUTHORPARAM, CREATEDPARAM,
+					// Parameters related to delimited/csv files.
+					DELIM_FILL_VALUE, DELIM_DELIMITER, DELIM_FILL, DELIM_HAS_HEADER_ROW, DELIM_NA_STRINGS
+			};
 
 	public static final String[] READ_VALID_PARAM_NAMES = 
 	{	IO_FILENAME, READROWPARAM, READCOLPARAM, FORMAT_TYPE, DATATYPEPARAM, VALUETYPEPARAM, SCHEMAPARAM,
@@ -1058,6 +1060,9 @@ public class DataExpression extends DataIdentifier
 					raiseValidateError("Invalid block dimensions (" + getOutput().getBlocksize() + ") when format=" + getVarParam(FORMAT_TYPE) + " in \"" + this.toString() + "\".", conditional);
 				}
 			
+			}
+			else if (dataTypeString.equalsIgnoreCase(Statement.TENSOR_DATA_TYPE)) {
+				getOutput().setDataType(DataType.TENSOR);
 			}
 			else if ( dataTypeString.equalsIgnoreCase(Statement.SCALAR_DATA_TYPE)) {
 				getOutput().setDataType(DataType.SCALAR);

--- a/src/main/java/org/tugraz/sysds/parser/Statement.java
+++ b/src/main/java/org/tugraz/sysds/parser/Statement.java
@@ -41,7 +41,6 @@ public abstract class Statement implements ParseInfo
 	public static final String SETWD 	= "setwd";
 
 	public static final String MATRIX_DATA_TYPE = "matrix";
-	public static final String TENSOR_DATA_TYPE = "tensor";
 	public static final String FRAME_DATA_TYPE = "frame";
 	public static final String SCALAR_DATA_TYPE = "scalar";
 	

--- a/src/main/java/org/tugraz/sysds/parser/Statement.java
+++ b/src/main/java/org/tugraz/sysds/parser/Statement.java
@@ -41,6 +41,7 @@ public abstract class Statement implements ParseInfo
 	public static final String SETWD 	= "setwd";
 
 	public static final String MATRIX_DATA_TYPE = "matrix";
+	public static final String TENSOR_DATA_TYPE = "tensor";
 	public static final String FRAME_DATA_TYPE = "frame";
 	public static final String SCALAR_DATA_TYPE = "scalar";
 	
@@ -249,8 +250,6 @@ public abstract class Statement implements ParseInfo
 	 *            parse information, such as beginning line position, beginning
 	 *            column position, ending line position, ending column position,
 	 *            text, and filename
-	 * @param filename
-	 *            the DML/PYDML filename (if it exists)
 	 */
 	public void setParseInfo(ParseInfo parseInfo) {
 		_beginLine = parseInfo.getBeginLine();

--- a/src/main/java/org/tugraz/sysds/runtime/controlprogram/caching/CacheBlockFactory.java
+++ b/src/main/java/org/tugraz/sysds/runtime/controlprogram/caching/CacheBlockFactory.java
@@ -23,8 +23,7 @@ package org.tugraz.sysds.runtime.controlprogram.caching;
 
 import java.util.ArrayList;
 
-import org.tugraz.sysds.runtime.data.BasicTensor;
-import org.tugraz.sysds.runtime.data.DataTensor;
+import org.tugraz.sysds.runtime.data.TensorBlock;
 import org.tugraz.sysds.runtime.data.TensorIndexes;
 import org.tugraz.sysds.runtime.matrix.data.FrameBlock;
 import org.tugraz.sysds.runtime.matrix.data.MatrixBlock;
@@ -42,8 +41,7 @@ public class CacheBlockFactory
 		switch( code ) {
 			case 0: return new MatrixBlock();
 			case 1: return new FrameBlock();
-			case 2: return new BasicTensor();
-			case 3: return new DataTensor();
+			case 2: return new TensorBlock();
 		}
 		throw new RuntimeException("Unsupported cache block type: "+code);
 	}
@@ -53,10 +51,8 @@ public class CacheBlockFactory
 			return 0;
 		else if (block instanceof FrameBlock)
 			return 1;
-		else if (block instanceof BasicTensor)
+		else if (block instanceof TensorBlock)
 			return 2;
-		else if (block instanceof DataTensor)
-			return 3;
 		throw new RuntimeException("Unsupported cache block type: " + block.getClass().getName());
 	}
 
@@ -65,8 +61,7 @@ public class CacheBlockFactory
 		switch (code) {
 			case 0: return new ArrayList<Pair<MatrixIndexes, MatrixBlock>>();
 			case 1: return new ArrayList<Pair<Long, FrameBlock>>();
-			case 2: return new ArrayList<Pair<TensorIndexes, BasicTensor>>();
-			case 3: return new ArrayList<Pair<TensorIndexes, DataTensor>>();
+			case 2: return new ArrayList<Pair<TensorIndexes, TensorBlock>>();
 		}
 		throw new RuntimeException("Unsupported cache block type: "+code);
 	}

--- a/src/main/java/org/tugraz/sysds/runtime/controlprogram/caching/CacheableData.java
+++ b/src/main/java/org/tugraz/sysds/runtime/controlprogram/caching/CacheableData.java
@@ -80,10 +80,10 @@ public abstract class CacheableData<T extends CacheBlock> extends Data
 	// global constant configuration parameters
 	public static final long    CACHING_THRESHOLD = (long)Math.max(4*1024, //obj not s.t. caching
 		1e-5 * InfrastructureAnalyzer.getLocalMaxMemory());       //if below threshold [in bytes]
-	public static final double CACHING_BUFFER_SIZE = 0.15; 
-	public static final RPolicy CACHING_BUFFER_POLICY = RPolicy.FIFO; 
-	public static final boolean CACHING_BUFFER_PAGECACHE = false; 
-	public static final boolean CACHING_WRITE_CACHE_ON_READ = false;	
+	public static final double CACHING_BUFFER_SIZE = 0.15;
+	public static final RPolicy CACHING_BUFFER_POLICY = RPolicy.FIFO;
+	public static final boolean CACHING_BUFFER_PAGECACHE = false;
+	public static final boolean CACHING_WRITE_CACHE_ON_READ = false;
 	public static final String  CACHING_COUNTER_GROUP_NAME    = "SystemDS Caching Counters";
 	public static final String  CACHING_EVICTION_FILEEXTENSION = ".dat";
 	public static final boolean CACHING_ASYNC_FILECLEANUP = true;
@@ -892,19 +892,18 @@ public abstract class CacheableData<T extends CacheBlock> extends Data
 	{
 		MetaDataFormat iimd = (MetaDataFormat) _metaData;
 		DataCharacteristics dc = iimd.getDataCharacteristics();
-		return readBlobFromHDFS(fname, dc.getRows(), dc.getCols());
+		return readBlobFromHDFS(fname, dc.getDims());
 	}
 
-	protected abstract T readBlobFromHDFS(String fname, long rlen, long clen) 
-		throws IOException;
+	protected abstract T readBlobFromHDFS(String fname, long[] dims) throws IOException;
 
 	protected abstract T readBlobFromRDD(RDDObject rdd, MutableBoolean status)
 		throws IOException;
 
-	protected abstract void writeBlobToHDFS(String fname, String ofmt, int rep, FileFormatProperties fprop) 
+	protected abstract void writeBlobToHDFS(String fname, String ofmt, int rep, FileFormatProperties fprop)
 		throws IOException;
 
-	protected abstract void writeBlobFromRDDtoHDFS(RDDObject rdd, String fname, String ofmt) 
+	protected abstract void writeBlobFromRDDtoHDFS(RDDObject rdd, String fname, String ofmt)
 		throws IOException;
 
 	protected void writeMetaData (String filePathAndName, String outputFormat, FileFormatProperties formatProperties)

--- a/src/main/java/org/tugraz/sysds/runtime/controlprogram/caching/FrameObject.java
+++ b/src/main/java/org/tugraz/sysds/runtime/controlprogram/caching/FrameObject.java
@@ -163,9 +163,10 @@ public class FrameObject extends CacheableData<FrameBlock>
 	}
 
 	@Override
-	protected FrameBlock readBlobFromHDFS(String fname, long rlen, long clen)
+	protected FrameBlock readBlobFromHDFS(String fname, long[] dims)
 		throws IOException 
 	{
+		long clen = dims[1];
 		MetaDataFormat iimd = (MetaDataFormat) _metaData;
 		DataCharacteristics dc = iimd.getDataCharacteristics();
 		

--- a/src/main/java/org/tugraz/sysds/runtime/controlprogram/caching/MatrixObject.java
+++ b/src/main/java/org/tugraz/sysds/runtime/controlprogram/caching/MatrixObject.java
@@ -309,7 +309,7 @@ public class MatrixObject extends CacheableData<MatrixBlock>
 				
 				//read the 
 				if( HDFSTool.existsFileOnHDFS(fname) )
-					mb = readBlobFromHDFS( fname, rows, cols );
+					mb = readBlobFromHDFS( fname, new long[]{rows, cols} );
 				else
 				{
 					mb = new MatrixBlock((int)rows, (int)cols, true);
@@ -415,9 +415,11 @@ public class MatrixObject extends CacheableData<MatrixBlock>
 	
 
 	@Override
-	protected MatrixBlock readBlobFromHDFS(String fname, long rlen, long clen)
+	protected MatrixBlock readBlobFromHDFS(String fname, long[] dims)
 		throws IOException
 	{
+		long rlen = dims[0];
+		long clen = dims[1];
 		MetaDataFormat iimd = (MetaDataFormat) _metaData;
 		DataCharacteristics mc = iimd.getDataCharacteristics();
 		long begin = 0;

--- a/src/main/java/org/tugraz/sysds/runtime/controlprogram/caching/TensorObject.java
+++ b/src/main/java/org/tugraz/sysds/runtime/controlprogram/caching/TensorObject.java
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -24,6 +24,7 @@ package org.tugraz.sysds.runtime.controlprogram.caching;
 
 import org.apache.commons.lang.mutable.MutableBoolean;
 import org.apache.spark.api.java.JavaPairRDD;
+import org.tugraz.sysds.api.DMLScript;
 import org.tugraz.sysds.common.Types.DataType;
 import org.tugraz.sysds.common.Types.ValueType;
 import org.tugraz.sysds.runtime.DMLRuntimeException;
@@ -32,14 +33,18 @@ import org.tugraz.sysds.runtime.data.TensorBlock;
 import org.tugraz.sysds.runtime.data.TensorIndexes;
 import org.tugraz.sysds.runtime.instructions.spark.data.RDDObject;
 import org.tugraz.sysds.runtime.io.FileFormatProperties;
+import org.tugraz.sysds.runtime.matrix.data.InputInfo;
+import org.tugraz.sysds.runtime.matrix.data.OutputInfo;
 import org.tugraz.sysds.runtime.meta.DataCharacteristics;
 import org.tugraz.sysds.runtime.meta.MetaData;
+import org.tugraz.sysds.runtime.meta.MetaDataFormat;
 import org.tugraz.sysds.runtime.meta.TensorCharacteristics;
+import org.tugraz.sysds.runtime.util.DataConverter;
 
 import java.io.IOException;
+import java.util.Arrays;
 
-public class TensorObject extends CacheableData<TensorBlock>
-{
+public class TensorObject extends CacheableData<TensorBlock> {
 	private static final long serialVersionUID = -2843358400200380775L;
 
 	protected TensorObject() {
@@ -55,7 +60,7 @@ public class TensorObject extends CacheableData<TensorBlock>
 		super(DataType.TENSOR, vt);
 		setFileName(fname);
 	}
-	
+
 	public TensorObject(String fname, MetaData meta) {
 		this();
 		setFileName(fname);
@@ -64,7 +69,7 @@ public class TensorObject extends CacheableData<TensorBlock>
 
 	/**
 	 * Copy constructor that copies meta data but NO data.
-	 * 
+	 *
 	 * @param fo frame object
 	 */
 	public TensorObject(TensorObject fo) {
@@ -73,15 +78,12 @@ public class TensorObject extends CacheableData<TensorBlock>
 
 	@Override
 	public void refreshMetaData() {
-		if ( _data == null || _metaData ==null ) //refresh only for existing data
-			throw new DMLRuntimeException("Cannot refresh meta data because there is no data or meta data. "); 
+		if (_data == null || _metaData == null) //refresh only for existing data
+			throw new DMLRuntimeException("Cannot refresh meta data because there is no data or meta data. ");
 
 		//update matrix characteristics
 		DataCharacteristics tc = _metaData.getDataCharacteristics();
-		long[] dims = new long[_data.getNumDims()];
-		for (int i = 0; i < _data.getNumDims(); i++) {
-			dims[i] = _data.getDim(i);
-		}
+		long[] dims = _metaData.getDataCharacteristics().getDims();
 		tc.setDims(dims);
 		tc.setNonZeros(_data.getNonZeros());
 	}
@@ -106,36 +108,82 @@ public class TensorObject extends CacheableData<TensorBlock>
 	}
 
 	@Override
-	protected TensorBlock readBlobFromHDFS(String fname, long rlen, long clen)
-		throws IOException 
-	{
-		//TODO read from HDFS
-		return null;
+	protected TensorBlock readBlobFromHDFS(String fname, long[] dims)
+			throws IOException {
+		MetaDataFormat iimd = (MetaDataFormat) _metaData;
+		DataCharacteristics dc = iimd.getDataCharacteristics();
+		long begin = 0;
+
+		if( LOG.isTraceEnabled() ) {
+			LOG.trace("Reading tensor from HDFS...  " + hashCode() + "  Path: " + fname +
+					", dimensions: " + Arrays.toString(dims));
+			begin = System.currentTimeMillis();
+		}
+
+		int blen = dc.getBlocksize();
+		//read tensor and maintain meta data
+		TensorBlock newData = DataConverter.readTensorFromHDFS(fname, iimd.getInputInfo(), dims, blen, getSchema());
+		setHDFSFileExists(true);
+
+		//sanity check correct output
+		if( newData == null )
+			throw new IOException("Unable to load tensor from file: "+fname);
+
+		if( LOG.isTraceEnabled() )
+			LOG.trace("Reading Completed: " + (System.currentTimeMillis()-begin) + " msec.");
+
+		return newData;
 	}
 
 	@Override
 	@SuppressWarnings("unchecked")
-	protected TensorBlock readBlobFromRDD(RDDObject rdd, MutableBoolean status)
-		throws IOException
-	{
+	protected TensorBlock readBlobFromRDD(RDDObject rdd, MutableBoolean status) {
 		status.setValue(false);
 		TensorCharacteristics tc = (TensorCharacteristics) _metaData.getDataCharacteristics();
 		// TODO correct blocksize;
 		// TODO read from RDD
-		return SparkExecutionContext.toTensorBlock((JavaPairRDD<TensorIndexes, TensorBlock>)rdd.getRDD(), tc);
+		return SparkExecutionContext.toTensorBlock((JavaPairRDD<TensorIndexes, TensorBlock>) rdd.getRDD(), tc);
 	}
 
 	@Override
-	protected void writeBlobToHDFS(String fname, String ofmt, int rep, FileFormatProperties fprop) 
-		throws IOException, DMLRuntimeException 
-	{
-		//TODO write
+	protected void writeBlobToHDFS(String fname, String ofmt, int rep, FileFormatProperties fprop)
+			throws IOException, DMLRuntimeException {
+		long begin = 0;
+		if (LOG.isTraceEnabled()) {
+			LOG.trace(" Writing tensor to HDFS...  " + hashCode() + "  Path: " + fname + ", Format: " +
+					(ofmt != null ? ofmt : "inferred from metadata"));
+			begin = System.currentTimeMillis();
+		}
+
+		MetaDataFormat iimd = (MetaDataFormat) _metaData;
+
+		if (_data != null) {
+			// Get the dimension information from the metadata stored within TensorObject
+			DataCharacteristics dc = iimd.getDataCharacteristics();
+			// Write the tensor to HDFS in requested format
+			OutputInfo oinfo = (ofmt != null ? OutputInfo.stringToOutputInfo(ofmt) :
+					InputInfo.getMatchingOutputInfo(iimd.getInputInfo()));
+
+			//TODO check correct blocking
+			DataConverter.writeTensorToHDFS(_data, fname, oinfo, dc);
+			if( LOG.isTraceEnabled() )
+				LOG.trace("Writing tensor to HDFS ("+fname+") - COMPLETED... " + (System.currentTimeMillis()-begin) + " msec.");
+		}
+		else if (LOG.isTraceEnabled()) {
+			LOG.trace("Writing tensor to HDFS (" + fname + ") - NOTHING TO WRITE (_data == null).");
+		}
+		if( DMLScript.STATISTICS )
+			CacheStatistics.incrementHDFSWrites();
 	}
 
 	@Override
-	protected void writeBlobFromRDDtoHDFS(RDDObject rdd, String fname, String ofmt) 
-		throws IOException, DMLRuntimeException 
-	{
+	protected ValueType[] getSchema() {
+		return _data.getSchema();
+	}
+
+	@Override
+	protected void writeBlobFromRDDtoHDFS(RDDObject rdd, String fname, String ofmt)
+			throws DMLRuntimeException {
 		//TODO rdd write
 	}
 }

--- a/src/main/java/org/tugraz/sysds/runtime/controlprogram/caching/TensorObject.java
+++ b/src/main/java/org/tugraz/sysds/runtime/controlprogram/caching/TensorObject.java
@@ -60,7 +60,7 @@ public class TensorObject extends CacheableData<TensorBlock> {
 		super(DataType.TENSOR, vt);
 		setFileName(fname);
 	}
-
+	
 	public TensorObject(String fname, MetaData meta) {
 		this();
 		setFileName(fname);
@@ -78,7 +78,7 @@ public class TensorObject extends CacheableData<TensorBlock> {
 
 	@Override
 	public void refreshMetaData() {
-		if (_data == null || _metaData == null) //refresh only for existing data
+		if ( _data == null || _metaData == null ) //refresh only for existing data
 			throw new DMLRuntimeException("Cannot refresh meta data because there is no data or meta data. ");
 
 		//update matrix characteristics

--- a/src/main/java/org/tugraz/sysds/runtime/controlprogram/context/ExecutionContext.java
+++ b/src/main/java/org/tugraz/sysds/runtime/controlprogram/context/ExecutionContext.java
@@ -33,7 +33,6 @@ import org.tugraz.sysds.runtime.controlprogram.caching.FrameObject;
 import org.tugraz.sysds.runtime.controlprogram.caching.MatrixObject;
 import org.tugraz.sysds.runtime.controlprogram.caching.MatrixObject.UpdateType;
 import org.tugraz.sysds.runtime.controlprogram.caching.TensorObject;
-import org.tugraz.sysds.runtime.data.BasicTensor;
 import org.tugraz.sysds.runtime.data.TensorBlock;
 import org.tugraz.sysds.runtime.instructions.Instruction;
 import org.tugraz.sysds.runtime.instructions.cp.CPOperand;
@@ -512,7 +511,7 @@ public class ExecutionContext {
 		setMatrixOutput(varName, outputData, flag);
 	}
 
-	public void setTensorOutput(String varName, BasicTensor outputData) {
+	public void setTensorOutput(String varName, TensorBlock outputData) {
 		TensorObject to = getTensorObject(varName);
 		to.acquireModify(outputData);
 		to.release();

--- a/src/main/java/org/tugraz/sysds/runtime/controlprogram/context/SparkExecutionContext.java
+++ b/src/main/java/org/tugraz/sysds/runtime/controlprogram/context/SparkExecutionContext.java
@@ -51,7 +51,6 @@ import org.tugraz.sysds.runtime.controlprogram.caching.FrameObject;
 import org.tugraz.sysds.runtime.controlprogram.caching.MatrixObject;
 import org.tugraz.sysds.runtime.controlprogram.caching.TensorObject;
 import org.tugraz.sysds.runtime.controlprogram.parfor.stat.InfrastructureAnalyzer;
-import org.tugraz.sysds.runtime.data.BasicTensor;
 import org.tugraz.sysds.runtime.data.TensorBlock;
 import org.tugraz.sysds.runtime.data.SparseBlock;
 import org.tugraz.sysds.runtime.data.TensorIndexes;
@@ -913,9 +912,7 @@ public class SparkExecutionContext extends ExecutionContext
 			list = Arrays.asList(new Tuple2<>(new TensorIndexes(ix), src));
 		} else {
 			// TODO rows and columns for matrix characteristics
-			long[] dims = new long[src.getNumDims()];
-			for (int i = 0; i < src.getNumDims(); i++)
-				dims[i] = src.getDim(i);
+			long[] dims = Arrays.stream(src.getDims()).mapToLong(i -> i).toArray();
 			TensorCharacteristics mc = new TensorCharacteristics(dims, src.getNonZeros());
 			list = LongStream.range(0, mc.getNumBlocks()).parallel()
 					.mapToObj(i -> createIndexedTensorBlock(src, mc, i))
@@ -969,11 +966,8 @@ public class SparkExecutionContext extends ExecutionContext
 				offset[i] = (int) (blockIx[i] * blocksize);
 				ix /= tc.getNumBlocks(i);
 			}
-			// TODO: sparse
-			// TODO support DataTensor
-			BasicTensor bt = (BasicTensor) mb;
-			BasicTensor outBlock = new BasicTensor(bt.getValueType(), outDims, false);
-			outBlock = bt.slice(offset, outBlock);
+			TensorBlock outBlock = new TensorBlock(mb.getValueType(), outDims);
+			outBlock = mb.slice(offset, outBlock);
 			//create key-value pair
 			for (int i = 0; i < blockIx.length; i++) {
 				blockIx[i]++;
@@ -1022,8 +1016,7 @@ public class SparkExecutionContext extends ExecutionContext
 	 * @param rdd rdd object
 	 * @param rlen number of rows
 	 * @param clen number of columns
-	 * @param blen number of rows in a block
-	 * @param blen number of columns in a block
+	 * @param blen block length
 	 * @param nnz number of non-zeros
 	 * @return matrix block
 	 */
@@ -1044,8 +1037,7 @@ public class SparkExecutionContext extends ExecutionContext
 	 * @param rdd JavaPairRDD for matrix block
 	 * @param rlen number of rows
 	 * @param clen number of columns
-	 * @param blen number of rows in a block
-	 * @param blen number of columns in a block
+	 * @param blen block length
 	 * @param nnz number of non-zeros
 	 * @return matrix block
 	 */
@@ -1187,26 +1179,21 @@ public class SparkExecutionContext extends ExecutionContext
 	}
 
 	public static TensorBlock toTensorBlock(JavaPairRDD<TensorIndexes, TensorBlock> rdd, DataCharacteristics dc) {
-		// TODO support DataTensors
 		long t0 = DMLScript.STATISTICS ? System.nanoTime() : 0;
 
 		// TODO special case single block
-		int[] idims = new int[dc.getNumDims()];
-		for (int i = 0; i < idims.length; i++) {
-			idims[i] = (int)dc.getDim(i);
-		}
+		int[] idims = dc.getIntDims();
 		// TODO asynchronous allocation
 		List<Tuple2<TensorIndexes, TensorBlock>> list = rdd.collect();
-		ValueType vt = ((BasicTensor) list.get(0)._2).getValueType();
-		BasicTensor out = new BasicTensor(vt, idims);
-		out.allocateDenseBlock();
+		ValueType vt = (list.get(0)._2).getValueType();
+		TensorBlock out = new TensorBlock(vt, idims).allocateBlock();
 
 		//copy blocks one-at-a-time into output matrix block
 		for( Tuple2<TensorIndexes, TensorBlock> keyval : list )
 		{
 			//unpack index-block pair
 			TensorIndexes ix = keyval._1();
-			BasicTensor block = (BasicTensor) keyval._2();
+			TensorBlock block = keyval._2();
 
 			//compute row/column block offsets
 			int[] lower = new int[ix.getNumDims()];

--- a/src/main/java/org/tugraz/sysds/runtime/controlprogram/context/SparkExecutionContext.java
+++ b/src/main/java/org/tugraz/sysds/runtime/controlprogram/context/SparkExecutionContext.java
@@ -912,7 +912,7 @@ public class SparkExecutionContext extends ExecutionContext
 			list = Arrays.asList(new Tuple2<>(new TensorIndexes(ix), src));
 		} else {
 			// TODO rows and columns for matrix characteristics
-			long[] dims = Arrays.stream(src.getDims()).mapToLong(i -> i).toArray();
+			long[] dims = src.getLongDims();
 			TensorCharacteristics mc = new TensorCharacteristics(dims, src.getNonZeros());
 			list = LongStream.range(0, mc.getNumBlocks()).parallel()
 					.mapToObj(i -> createIndexedTensorBlock(src, mc, i))

--- a/src/main/java/org/tugraz/sysds/runtime/data/BasicTensorBlock.java
+++ b/src/main/java/org/tugraz/sysds/runtime/data/BasicTensorBlock.java
@@ -17,92 +17,89 @@
 package org.tugraz.sysds.runtime.data;
 
 import org.apache.commons.lang.NotImplementedException;
-import org.tugraz.sysds.common.Types.BlockType;
 import org.tugraz.sysds.common.Types.ValueType;
 import org.tugraz.sysds.runtime.DMLRuntimeException;
-import org.tugraz.sysds.runtime.controlprogram.caching.CacheBlock;
 import org.tugraz.sysds.runtime.functionobjects.KahanPlus;
 import org.tugraz.sysds.runtime.functionobjects.Plus;
 import org.tugraz.sysds.runtime.functionobjects.ReduceAll;
 import org.tugraz.sysds.runtime.matrix.data.MatrixBlock;
 import org.tugraz.sysds.runtime.matrix.operators.AggregateOperator;
 import org.tugraz.sysds.runtime.matrix.operators.AggregateUnaryOperator;
-import org.tugraz.sysds.runtime.matrix.operators.BinaryOperator;
 import org.tugraz.sysds.runtime.util.UtilFunctions;
 
-import java.io.DataInput;
-import java.io.DataOutput;
-import java.io.Externalizable;
-import java.io.IOException;
-import java.io.ObjectInput;
-import java.io.ObjectOutput;
+import java.io.Serializable;
 
-public class BasicTensor extends TensorBlock implements Externalizable
-{
-	private static final long serialVersionUID = -1887367304030494999L;
+import static org.tugraz.sysds.runtime.data.LibTensorAgg.aggregateBinaryTensor;
+import static org.tugraz.sysds.runtime.data.TensorBlock.DEFAULT_DIMS;
+import static org.tugraz.sysds.runtime.data.TensorBlock.DEFAULT_VTYPE;
+
+public class BasicTensorBlock implements Serializable {
+	private static final long serialVersionUID = -7665685894181661833L;
 
 	public static final double SPARSITY_TURN_POINT = 0.4;
-	public static final ValueType DEFAULT_VTYPE = ValueType.FP64;
 
 	public static final SparseBlock.Type DEFAULT_SPARSEBLOCK = SparseBlock.Type.MCSR;
 
+	protected int[] _dims;
 	//constant value type of tensor block
 	protected ValueType _vt;
 
 	protected boolean _sparse = true;
 	protected long _nnz = 0;
-	
+
 	//matrix data (sparse or dense)
 	protected DenseBlock _denseBlock = null;
 	protected SparseBlock _sparseBlock = null;
-	
-	public BasicTensor() {
+
+	public BasicTensorBlock() {
 		this(DEFAULT_VTYPE, DEFAULT_DIMS.clone(), true, -1);
 	}
 
-	public BasicTensor(ValueType vt, int[] dims) {
+	public BasicTensorBlock(ValueType vt, int[] dims) {
 		this(vt, dims, true, -1);
 	}
-	
-	public BasicTensor(ValueType vt, int[] dims, boolean sp) {
+
+	public BasicTensorBlock(ValueType vt, int[] dims, boolean sp) {
 		this(vt, dims, sp, -1);
 	}
-	
-	public BasicTensor(ValueType vt, int[] dims, boolean sp, long estnnz) {
+
+	public BasicTensorBlock(ValueType vt, int[] dims, boolean sp, long estnnz) {
 		_vt = vt;
 		reset(dims, sp, estnnz, 0);
 	}
-	
-	public BasicTensor(BasicTensor that) {
+
+	public BasicTensorBlock(BasicTensorBlock that) {
 		_vt = that.getValueType();
 		copy(that);
 	}
 
-	public BasicTensor(double val) {
+	public BasicTensorBlock(double val) {
 		_vt = DEFAULT_VTYPE;
 		reset(new int[] {1, 1}, false, 1, val);
 	}
-	
-	public BasicTensor(int[] dims, ValueType vt, double val) {
+
+	public BasicTensorBlock(int[] dims, ValueType vt, double val) {
 		_vt = vt;
 		_dims = dims;
 		reset(dims, false, (val==0) ? 0 : getLength(), val);
 	}
-	
+
+	public long getLength() {
+		return UtilFunctions.prod(_dims);
+	}
+
 	////////
 	// Initialization methods
 	// (reset, init, allocate, etc)
 
-	@Override
 	public void reset() {
 		reset(_dims, _sparse, -1, 0);
 	}
 
-	@Override
 	public void reset(int[] dims) {
 		reset(dims, _sparse, -1, 0);
 	}
-	
+
 	public void reset(int[] dims, long estnnz) {
 		reset(dims, evalSparseFormatInMemory(dims, estnnz), estnnz, 0);
 	}
@@ -110,14 +107,14 @@ public class BasicTensor extends TensorBlock implements Externalizable
 	public void reset(int[] dims, boolean sp) {
 		reset(dims, sp, -1, 0);
 	}
-	
+
 	public void reset(int[] dims, boolean sp, long estnnz) {
 		reset(dims, sp, estnnz, 0);
 	}
-	
+
 	/**
-	 * Internal canonical reset of dense and sparse tensor blocks. 
-	 * 
+	 * Internal canonical reset of dense and sparse tensor blocks.
+	 *
 	 * @param dims    number and size of dimensions
 	 * @param sp      sparse representation
 	 * @param estnnz  estimated number of non-zeros
@@ -130,26 +127,26 @@ public class BasicTensor extends TensorBlock implements Externalizable
 		for( int i=0; i<dims.length; i++ )
 			if( dims[i] < 0 )
 				throw new DMLRuntimeException("Invalid "+i+"th dimensions: "+dims[i]);
-		
+
 		//reset basic meta data
 		_dims = dims;
 		_sparse = sp;
 		_nnz = (val == 0) ? 0 : getLength();
-		
+
 		//reset sparse/dense blocks
 		if( _sparse )
 			resetSparse();
 		else
 			resetDense(val);
 	}
-	
+
 	private void resetSparse() {
 		if(_sparseBlock == null)
 			return;
 		//TODO simplify estimated non-zeros
 		_sparseBlock.reset(-1, getDim(2));
 	}
-	
+
 	private void resetDense(double val) {
 		//handle to dense block allocation and
 		//reset dense block to given value
@@ -159,30 +156,30 @@ public class BasicTensor extends TensorBlock implements Externalizable
 			if( val != 0 ) {
 				allocateDenseBlock(false);
 				_denseBlock.set(val);
-			} else {
+			}
+			else {
 				allocateDenseBlock(true);
 			}
 		}
 	}
 
-	@Override
 	public boolean isAllocated() {
-		return _sparse ? (_sparseBlock!=null) : (_denseBlock!=null);
+		return _sparse ? (_sparseBlock != null) : (_denseBlock != null);
 	}
 
-	public BasicTensor allocateDenseBlock() {
+	public BasicTensorBlock allocateDenseBlock() {
 		allocateDenseBlock(true);
 		return this;
 	}
 
-	public BasicTensor allocateBlock() {
+	public BasicTensorBlock allocateBlock() {
 		if( _sparse )
 			allocateSparseBlock();
 		else
 			allocateDenseBlock();
 		return this;
 	}
-	
+
 	public boolean allocateDenseBlock(boolean clearNNZ) {
 		//allocate block if non-existing or too small (guaranteed to be 0-initialized),
 		// TODO: use _denseBlock.reset instead, since LDRB need to check dimensions for actually available space
@@ -192,12 +189,12 @@ public class BasicTensor extends TensorBlock implements Externalizable
 			_denseBlock = DenseBlockFactory.createDenseBlock(_vt, _dims);
 		else if( _denseBlock.capacity() < limit )
 			_denseBlock.reset(_dims);
-		
+
 		//clear nnz if necessary
 		if( clearNNZ )
 			_nnz = 0;
 		_sparse = false;
-		
+
 		return reset;
 	}
 
@@ -211,32 +208,50 @@ public class BasicTensor extends TensorBlock implements Externalizable
 		boolean reset = _sparseBlock == null || _sparseBlock.numRows()<getDim(0);
 		if( reset ) {
 			_sparseBlock = SparseBlockFactory
-				.createSparseBlock(DEFAULT_SPARSEBLOCK, getDim(0));
+					.createSparseBlock(DEFAULT_SPARSEBLOCK, getDim(0));
 		}
 		//clear nnz if necessary
 		if( clearNNZ )
 			_nnz = 0;
-		
+
 		return reset;
 	}
-	
+
 	////////
 	// Basic meta data
-	
+
 	public ValueType getValueType() {
 		return _vt;
 	}
 
-	@Override
 	public long getNonZeros() {
 		return _nnz;
+	}
+
+	public int getNumRows() {
+		return getDim(0);
+	}
+
+	public int getNumColumns() {
+		return getDim(1);
+	}
+
+	public int getNumDims() {
+		return _dims.length;
+	}
+
+	public int getDim(int i) {
+		return _dims[i];
+	}
+
+	public int[] getDims() {
+		return _dims;
 	}
 
 	public boolean isSparse() {
 		return _sparse;
 	}
 
-	@Override
 	public boolean isEmpty(boolean safe) {
 		boolean ret = false;
 		if( _sparse && _sparseBlock==null )
@@ -252,108 +267,18 @@ public class BasicTensor extends TensorBlock implements Externalizable
 		}
 		return ret;
 	}
-	
+
 	public DenseBlock getDenseBlock() {
 		return _denseBlock;
 	}
-	
+
 	public SparseBlock getSparseBlock() {
 		return _sparseBlock;
 	}
-	
-	////////
-	// Input/Output functions
-	
-	@Override
-	@SuppressWarnings("incomplete-switch")
-	public void readFields(DataInput in) 
-		throws IOException 
-	{
-		//step 1: read header
-		_vt = ValueType.values()[in.readByte()];
-		_dims = new int[in.readInt()];
-		for(int i=0; i<_dims.length; i++)
-			_dims[i] = in.readInt();
-		_nnz = in.readLong();
-	
-		//step 2: read tensor block data
-		switch( BlockType.values()[in.readByte()] ) {
-			case EMPTY_BLOCK:
-				reset(_dims);
-				return;
-			case DENSE_BLOCK: {
-				allocateDenseBlock(false);
-				DenseBlock a = getDenseBlock();
-				int odims = (int) UtilFunctions.prod(_dims, 1);
-				int[] ix = new int[getNumDims()];
-				for( int i=0; i<getNumRows(); i++ ) {
-					ix[0] = i;
-					for (int j = 0; j < odims; j++) {
-						ix[ix.length - 1] = j;
-						switch (_vt) {
-							case FP32: a.set(i, j, in.readFloat()); break;
-							case FP64: a.set(i, j, in.readDouble()); break;
-							case INT32: a.set(ix, in.readInt()); break;
-							case INT64: a.set(ix, in.readLong()); break;
-							case BOOLEAN: a.set(i, j, in.readByte()); break;
-							case STRING: a.set(ix, in.readUTF()); break;
-						}
-					}
-				}
-				break;
-			}
-			case SPARSE_BLOCK:
-			case ULTRA_SPARSE_BLOCK:
-				throw new NotImplementedException();
-		}
-	}
-	
-	@Override
-	@SuppressWarnings("incomplete-switch")
-	public void write(DataOutput out) 
-		throws IOException 
-	{
-		//step 1: write header
-		out.writeByte(_vt.ordinal()); // value type
-		out.writeInt(getNumDims()); // num dims
-		for(int i=0; i<getNumDims(); i++)
-			out.writeInt(getDim(i)); // dim
-		out.writeLong(getNonZeros()); // nnz
-		
-		//step 2: write tensor block data
-		if( isEmpty(false) ) {
-			//empty blocks do not need to materialize row information
-			out.writeByte(BlockType.EMPTY_BLOCK.ordinal());
-		}
-		else if( !isSparse() ) {
-			out.writeByte(BlockType.DENSE_BLOCK.ordinal());
-			DenseBlock a = getDenseBlock();
-			int odims = (int) UtilFunctions.prod(_dims, 1);
-			int[] ix = new int[getNumDims()];
-			for( int i=0; i<getNumRows(); i++ ) {
-				ix[0] = i;
-				for (int j = 0; j < odims; j++) {
-					ix[ix.length - 1] = j;
-					switch (_vt) {
-						case FP32: out.writeFloat((float) a.get(i, j)); break;
-						case FP64: out.writeDouble(a.get(i, j)); break;
-						case INT32: out.writeInt((int) a.getLong(ix)); break;
-						case INT64: out.writeLong(a.getLong(ix)); break;
-						case BOOLEAN: out.writeBoolean(a.get(i, j) != 0); break;
-						case STRING: out.writeUTF(a.getString(ix)); break;
-					}
-				}
-			}
-		}
-		else {
-			throw new NotImplementedException();
-		}
-	}
-	
+
 	////////
 	// Basic modification
 
-	@Override
 	public Object get(int[] ix) {
 		if (_sparse) {
 			// TODO: Implement sparse
@@ -364,63 +289,63 @@ public class BasicTensor extends TensorBlock implements Externalizable
 				case FP64:
 					return _denseBlock.get(ix);
 				case FP32:
-					return (float)_denseBlock.get(ix);
+					return (float) _denseBlock.get(ix);
 				case INT64:
 					return _denseBlock.getLong(ix);
 				case INT32:
-					return (int)_denseBlock.getLong(ix);
+					return (int) _denseBlock.getLong(ix);
 				case BOOLEAN:
 					return _denseBlock.get(ix) != 0;
 				case STRING:
 					return _denseBlock.getString(ix);
 				default:
-					throw new DMLRuntimeException("Unsupported value type: "+_vt);
+					throw new DMLRuntimeException("Unsupported value type: " + _vt);
 			}
 		}
 	}
 
-	@Override
 	public double get(int r, int c) {
 		if (getNumDims() != 2)
-			throw new DMLRuntimeException("HomogTensor.get(int,int) dimension mismatch: expected=2 actual=" + getNumDims());
+			throw new DMLRuntimeException("BasicTensor.get(int,int) dimension mismatch: expected=2 actual=" + getNumDims());
 		if (_sparse) {
 			// TODO: Implement sparse
 			throw new NotImplementedException();
 			//return _sparseBlock.get(ix);
-		} else {
+		}
+		else {
 			return _denseBlock.get(r, c);
 		}
 	}
 
-	@Override
 	public void set(int[] ix, Object v) {
 		if (_sparse) {
 			throw new NotImplementedException();
-		} else {
+		}
+		else if (v != null) {
 			if (v instanceof Double)
-				_denseBlock.set(ix, (Double)v);
+				_denseBlock.set(ix, (Double) v);
 			else if (v instanceof Float)
-				_denseBlock.set(ix, (Float)v);
+				_denseBlock.set(ix, (Float) v);
 			else if (v instanceof Long)
-				_denseBlock.set(ix, (Long)v);
+				_denseBlock.set(ix, (Long) v);
 			else if (v instanceof Integer)
-				_denseBlock.set(ix, (Integer)v);
+				_denseBlock.set(ix, (Integer) v);
 			else if (v instanceof Boolean)
-				_denseBlock.set(ix, ((Boolean)v) ? 1.0 : 0.0);
+				_denseBlock.set(ix, ((Boolean) v) ? 1.0 : 0.0);
 			else if (v instanceof String)
-				_denseBlock.set(ix, (String)v);
+				_denseBlock.set(ix, (String) v);
 			else
 				throw new DMLRuntimeException("BasicTensor.set(int[],Object) is not implemented for the given Object");
 		}
 	}
 
-	@Override
 	public void set(int r, int c, double v) {
 		if (getNumDims() != 2)
-			throw new DMLRuntimeException("HomogTensor.set(int,int,double) dimension mismatch: expected=2 actual=" + getNumDims());
+			throw new DMLRuntimeException("BasicTensor.set(int,int,double) dimension mismatch: expected=2 actual=" + getNumDims());
 		if (_sparse) {
 			throw new NotImplementedException();
-		} else {
+		}
+		else {
 			_denseBlock.set(r, c, v);
 		}
 	}
@@ -428,78 +353,95 @@ public class BasicTensor extends TensorBlock implements Externalizable
 	public void set(double v) {
 		if (_sparse) {
 			throw new NotImplementedException();
-		} else {
+		}
+		else {
 			_denseBlock.set(v);
 		}
 	}
 
-	public void set(String str) {
+	public void set(Object v) {
 		if (_sparse) {
 			throw new NotImplementedException();
-		} else {
-			_denseBlock.set(str);
+		}
+		else {
+			if (v instanceof Double)
+				_denseBlock.set((Double) v);
+			else if (v instanceof Float)
+				_denseBlock.set((Float) v);
+			else if (v instanceof Long)
+				_denseBlock.set((Long) v);
+			else if (v instanceof Integer)
+				_denseBlock.set((Integer) v);
+			else if (v instanceof Boolean)
+				_denseBlock.set(((Boolean) v) ? 1.0 : 0.0);
+			else if (v instanceof String)
+				_denseBlock.set((String) v);
+			else
+				throw new DMLRuntimeException("BasicTensor.set(Object) is not implemented for the given Object");
 		}
 	}
 
-	public void set(BasicTensor other) {
-		if (_sparse) {
+	public void set(BasicTensorBlock other) {
+		if (_sparse)
 			throw new NotImplementedException();
-		} else {
-			if (other.isSparse()) {
+		else {
+			if (other.isSparse())
 				throw new NotImplementedException();
-			} else {
+			else
 				_denseBlock.set(0, _dims[0], 0, _denseBlock.getCumODims(0), other.getDenseBlock());
-			}
 		}
 	}
 
 	public void set(MatrixBlock other) {
 		if (_sparse) {
 			throw new NotImplementedException();
-		} else {
+		}
+		else {
 			if (other.isInSparseFormat()) {
 				if (other.isEmpty()) {
 					_denseBlock.set(0);
-				} else {
+				}
+				else {
 					// TODO implement sparse set instead of converting to dense
 					other.sparseToDense();
 					_denseBlock.set(0, _dims[0], 0, _denseBlock.getCumODims(0), other.getDenseBlock());
 				}
-			} else {
+			}
+			else {
 				_denseBlock.set(0, _dims[0], 0, _denseBlock.getCumODims(0), other.getDenseBlock());
 			}
 		}
 	}
 
-	public void copy(BasicTensor that) {
+	public void copy(BasicTensorBlock that) {
 		_dims = that._dims.clone();
 		_sparse = that._sparse;
 		_nnz = that._nnz;
-		if( that.isAllocated() ) {
-			if( !_sparse )
+		if (that.isAllocated()) {
+			if (!_sparse)
 				copyDenseToDense(that);
 			else // TODO copy sparse to dense, dense to dense or sparse to dense
 				throw new NotImplementedException();
 		}
 	}
 
-	public BasicTensor copyShallow(BasicTensor that) {
+	public BasicTensorBlock copyShallow(BasicTensorBlock that) {
 		_dims = that._dims.clone();
 		_sparse = that._sparse;
 		_nnz = that._nnz;
-		if( !_sparse )
+		if (!_sparse)
 			_denseBlock = that._denseBlock;
 		else
 			_sparseBlock = that._sparseBlock;
 		return this;
 	}
 
-	private void copyDenseToDense(BasicTensor that) {
+	private void copyDenseToDense(BasicTensorBlock that) {
 		_nnz = that._nnz;
 
 		//plain reset to 0 for empty input
-		if( that.isEmpty(false) ) {
-			if(_denseBlock!=null)
+		if (that.isEmpty(false)) {
+			if (_denseBlock != null)
 				_denseBlock.reset(that._dims);
 			return;
 		}
@@ -514,7 +456,7 @@ public class BasicTensor extends TensorBlock implements Externalizable
 	 * @param upper upper index of elements to copy (exclusive)
 	 * @param src source tensor
 	 */
-	public void copy(int[] lower, int[] upper, BasicTensor src) {
+	public void copy(int[] lower, int[] upper, BasicTensorBlock src) {
 		// TODO consider sparse
 		if (src.isEmpty(false)) {
 			return;
@@ -537,8 +479,6 @@ public class BasicTensor extends TensorBlock implements Externalizable
 
 	////////
 	// Size estimation and format decisions
-	
-	
 	private boolean evalSparseFormatInMemory(int[] dims, long estnnz) {
 		// TODO Auto-generated method stub
 		return false;
@@ -546,7 +486,14 @@ public class BasicTensor extends TensorBlock implements Externalizable
 
 	///////
 	// Aggregations
-	public BasicTensor aggregateUnaryOperations(AggregateUnaryOperator op, TensorBlock result) {
+
+	/**
+	 * Aggregate a unary operation on this tensor.
+	 * @param op the operation to apply
+	 * @param result the result tensor
+	 * @return the result tensor
+	 */
+	public BasicTensorBlock aggregateUnaryOperations(AggregateUnaryOperator op, BasicTensorBlock result) {
 		// TODO allow to aggregate along a dimension?
 		// TODO performance
 		if (op.aggOp.increOp.fn instanceof KahanPlus) {
@@ -558,183 +505,28 @@ public class BasicTensor extends TensorBlock implements Externalizable
 			dim1 = 2;
 		}
 		//prepare result matrix block
-		BasicTensor res;
-		if(result==null || checkType(result)._vt != _vt)
-			res = new BasicTensor(_vt, new int[]{dim0, dim1}, false);
-		else {
-			res = (BasicTensor) result;
-			res.reset(new int[]{dim0, dim1}, false);
-		}
+		if (result == null || result._vt != _vt)
+			result = new BasicTensorBlock(_vt, new int[]{dim0, dim1}, false);
+		else
+			result.reset(new int[]{dim0, dim1}, false);
 
-		if( LibTensorAgg.isSupportedUnaryAggregateOperator(op) )
+		if (LibTensorAgg.isSupportedUnaryAggregateOperator(op))
 			if (op.indexFn instanceof ReduceAll)
-				LibTensorAgg.aggregateUnaryTensor(this, res, op);
+				LibTensorAgg.aggregateUnaryTensor(this, result, op);
 			else
 				throw new DMLRuntimeException("Only ReduceAll UnaryAggregationOperators are supported for tensor");
 		else
 			throw new DMLRuntimeException("Current UnaryAggregationOperator not supported for tensor");
-		return res;
+		return result;
 	}
 
-	public void incrementalAggregate(AggregateOperator aggOp, TensorBlock partialResult) {
-		if(!aggOp.correctionExists) {
-			if(aggOp.increOp.fn instanceof Plus) {
-				LibTensorAgg.aggregateBinaryTensor((BasicTensor) partialResult, this, aggOp);
+	public void incrementalAggregate(AggregateOperator aggOp, BasicTensorBlock partialResult) {
+		if (!aggOp.correctionExists) {
+			if (aggOp.increOp.fn instanceof Plus) {
+				aggregateBinaryTensor(partialResult, this, aggOp);
 			}
 		}
 		else
-			throw new DMLRuntimeException("Correction not supported. correctionLocation: "+aggOp.correctionLocation);
-	}
-
-	@Override
-	public TensorBlock binaryOperations(BinaryOperator op, TensorBlock thatValue, TensorBlock result) {
-		if( !LibTensorBincell.isValidDimensionsBinary(this, thatValue) ) {
-			throw new RuntimeException("Block sizes are not matched for binary cell operations");
-		}
-		//prepare result matrix block
-		BasicTensor that = checkType(thatValue);
-		ValueType vt = resultValueType(_vt, that._vt);
-		BasicTensor res;
-		if (result == null || checkType(result)._vt != vt)
-			res = new BasicTensor(vt, _dims, false);
-		else {
-			res = (BasicTensor) result;
-			res.reset(_dims, false);
-		}
-
-		LibTensorBincell.bincellOp(this, (BasicTensor) thatValue, res, op);
-
-		return res;
-	}
-
-	@Override
-	protected BasicTensor checkType(TensorBlock that) {
-		if (that instanceof BasicTensor)
-			return (BasicTensor) that;
-		else
-			throw new DMLRuntimeException("BasicTensor.checkType(TensorBlock) given TensorBlock was no BasicTensor");
-	}
-
-	@Override
-	public long getInMemorySize() {
-		// TODO Auto-generated method stub
-		return 0;
-	}
-
-	@Override
-	public long getExactSerializedSize() {
-		//header size (vt, num dims, dims, nnz, type)
-		long size = 4 * (1+_dims.length) + 8 + 2;
-		//serialized representation
-		if( !isSparse() ) {
-			switch( _vt ) {
-				case INT32:
-				case FP32:
-					size += 4 * getLength(); break;
-				case INT64:
-				case FP64: 
-					size += 8 * getLength(); break;
-				case BOOLEAN:
-					//TODO perf bits instead of bytes
-					size += getLength(); break;
-					//size += Math.ceil((double)getLength() / 64); break;
-				case STRING:
-				case UNKNOWN:
-					throw new NotImplementedException();
-			}
-		}
-		else {
-			throw new NotImplementedException();
-		}
-		return size;
-	}
-
-	@Override
-	public boolean isShallowSerialize() {
-		// TODO Auto-generated method stub
-		return false;
-	}
-
-	@Override
-	public boolean isShallowSerialize(boolean inclConvert) {
-		return !isSparse();
-	}
-
-	@Override
-	public void toShallowSerializeBlock() {
-		// TODO Auto-generated method stub
-
-	}
-
-	@Override
-	public void compactEmptyBlock() {
-		// TODO Auto-generated method stub
-
-	}
-
-	@Override
-	public CacheBlock slice(int rl, int ru, int cl, int cu, CacheBlock block) {
-		if (!(block instanceof BasicTensor))
-			throw new DMLRuntimeException("BasicTensor.slice(int,int,int,int,CacheBlock) CacheBlock was no BasicTensor");
-		BasicTensor bt = (BasicTensor) block;
-		
-		int[] dims = _dims.clone();
-		dims[0] = ru - rl + 1;
-		dims[1] = cu - cl + 1;
-		bt.reset(_dims, false);
-		
-		int[] offsets = new int[dims.length];
-		offsets[0] = rl;
-		offsets[1] = cl;
-		
-		return slice(offsets, bt);
-	}
-
-	/**
-	 * Slice the current block and write into the outBlock. The offsets determines where the slice starts,
-	 * the length of the blocks is given by the outBlock dimensions.
-	 * @param offsets offsets where the slice starts
-	 * @param outBlock sliced result block
-	 * @return the sliced result block
-	 */
-	public BasicTensor slice(int[] offsets, BasicTensor outBlock) {
-		// TODO change signature to use upper lower instead of offsets and size of outBlock
-		// TODO perf
-		int[] srcIx = offsets.clone();
-		int[] destIx = new int[offsets.length];
-		for (int l = 0; l < outBlock.getLength(); l++) {
-			outBlock.set(destIx, get(srcIx));
-			int i = outBlock.getNumDims() - 1;
-			destIx[i]++;
-			//calculating next index
-			while (destIx[i] == outBlock.getDim(i)) {
-				destIx[i] = 0;
-				srcIx[i] = offsets[i];
-				i--;
-				if (i < 0) {
-					//we are finished
-					return outBlock;
-				}
-				destIx[i]++;
-				srcIx[i]++;
-			}
-		}
-		return outBlock;
-	}
-
-	@Override
-	public void merge(CacheBlock that, boolean appendOnly) {
-		// TODO Auto-generated method stub
-
-	}
-
-	@Override
-	public void writeExternal(ObjectOutput out) throws IOException {
-		write(out);
-	}
-
-	@Override
-	public void readExternal(ObjectInput in) throws IOException {
-		readFields(in);
+			throw new DMLRuntimeException("Correction not supported. correctionLocation: " + aggOp.correctionLocation);
 	}
 }

--- a/src/main/java/org/tugraz/sysds/runtime/data/DataTensorBlock.java
+++ b/src/main/java/org/tugraz/sysds/runtime/data/DataTensorBlock.java
@@ -19,33 +19,39 @@ package org.tugraz.sysds.runtime.data;
 import org.apache.commons.lang.math.IntRange;
 import org.tugraz.sysds.common.Types.ValueType;
 import org.tugraz.sysds.runtime.DMLRuntimeException;
-import org.tugraz.sysds.runtime.controlprogram.caching.CacheBlock;
-import org.tugraz.sysds.runtime.matrix.operators.AggregateOperator;
-import org.tugraz.sysds.runtime.matrix.operators.AggregateUnaryOperator;
-import org.tugraz.sysds.runtime.matrix.operators.BinaryOperator;
 
-import java.io.DataInput;
-import java.io.DataOutput;
-import java.io.IOException;
+import java.io.Serializable;
 import java.util.Arrays;
+import java.util.stream.IntStream;
 
-public class DataTensor extends TensorBlock {
+import static org.tugraz.sysds.runtime.data.TensorBlock.DEFAULT_DIMS;
+
+public class DataTensorBlock implements Serializable {
+	private static final long serialVersionUID = 3410679389807309521L;
+
 	private static final int VALID_VALUE_TYPES_LENGTH = ValueType.values().length - 1;
 
-	private BasicTensor[] _colsdata = new BasicTensor[VALID_VALUE_TYPES_LENGTH];
-	private ValueType[] _schema = null;
-	private int[] _colsToIx = null;
-	private int[][] _ixToCols = null;
+	protected int[] _dims;
+	protected BasicTensorBlock[] _colsdata = new BasicTensorBlock[VALID_VALUE_TYPES_LENGTH];
+	protected ValueType[] _schema = null;
+	/**
+	 * Contains the (column) index in `_colsdata` for a certain column of the `DataTensor`. Which `_colsdata` to use is specified by the `_schema`
+	 */
+	protected int[] _colsToIx = null;
+	/**
+	 * Contains the column of `DataTensor` an `_colsdata` (column) index corresponds to.
+	 */
+	protected int[][] _ixToCols = null;
 
-	public DataTensor() {
+	public DataTensorBlock() {
 		this(new ValueType[0], DEFAULT_DIMS);
 	}
 
-	public DataTensor(int ncols, ValueType vt) {
+	public DataTensorBlock(int ncols, ValueType vt) {
 		this(vt, new int[]{0, ncols});
 	}
 
-	public DataTensor(ValueType[] schema) {
+	public DataTensorBlock(ValueType[] schema) {
 		_dims = new int[]{0, schema.length};
 		_schema = schema;
 		_colsToIx = new int[_schema.length];
@@ -65,7 +71,7 @@ public class DataTensor extends TensorBlock {
 		}
 	}
 
-	public DataTensor(ValueType[] schema, int[] dims) {
+	public DataTensorBlock(ValueType[] schema, int[] dims) {
 		_dims = dims;
 		_schema = schema;
 		_colsToIx = new int[_schema.length];
@@ -86,7 +92,7 @@ public class DataTensor extends TensorBlock {
 		reset();
 	}
 
-	public DataTensor(ValueType vt, int[] dims) {
+	public DataTensorBlock(ValueType vt, int[] dims) {
 		_dims = dims;
 		_schema = new ValueType[getDim(1)];
 		Arrays.fill(_schema, vt);
@@ -96,16 +102,16 @@ public class DataTensor extends TensorBlock {
 		reset();
 	}
 
-	public DataTensor(ValueType[] schema, int[] dims, String[][] data) {
+	public DataTensorBlock(ValueType[] schema, int[] dims, String[][] data) {
 		this(schema, dims);
 		allocateBlock();
 		for (int i = 0; i < schema.length; i++) {
 			int[] ix = new int[dims.length];
 			ix[1] = _colsToIx[i];
-			BasicTensor current = _colsdata[schema[i].ordinal()];
+			BasicTensorBlock current = _colsdata[schema[i].ordinal()];
 			for (int j = 0; j < data[i].length; j++) {
 				current.set(ix, data[i][j]);
-				current.getNextIndexes(ix);
+				TensorBlock.getNextIndexes(_dims, ix);
 				if (ix[1] != _colsToIx[i]) {
 					// We want to stay in the current column
 					if (ix[1] == 0)
@@ -119,26 +125,35 @@ public class DataTensor extends TensorBlock {
 		}
 	}
 
-	public DataTensor(double val) {
+	public DataTensorBlock(double val) {
 		_dims = new int[]{1, 1};
 		_schema = new ValueType[]{ValueType.FP64};
-		_colsToIx = new int[] {0};
+		_colsToIx = new int[]{0};
 		_ixToCols = new int[VALID_VALUE_TYPES_LENGTH][];
-		_ixToCols[ValueType.FP64.ordinal()] = new int[] {0};
-		_colsdata = new BasicTensor[VALID_VALUE_TYPES_LENGTH];
-		_colsdata[ValueType.FP64.ordinal()] = new BasicTensor(val);
+		_ixToCols[ValueType.FP64.ordinal()] = new int[]{0};
+		_colsdata = new BasicTensorBlock[VALID_VALUE_TYPES_LENGTH];
+		_colsdata[ValueType.FP64.ordinal()] = new BasicTensorBlock(val);
 	}
 
-	public DataTensor(DataTensor that) {
+	public DataTensorBlock(DataTensorBlock that) {
 		copy(that);
 	}
 
-	@Override
+	public DataTensorBlock(BasicTensorBlock that) {
+		_dims = that._dims;
+		_schema = new ValueType[_dims[1]];
+		Arrays.fill(_schema, that._vt);
+		_colsToIx = IntStream.range(0, _dims[1]).toArray();
+		_ixToCols = new int[VALID_VALUE_TYPES_LENGTH][];
+		_ixToCols[that._vt.ordinal()] = IntStream.range(0, _dims[1]).toArray();
+		_colsdata = new BasicTensorBlock[VALID_VALUE_TYPES_LENGTH];
+		_colsdata[that._vt.ordinal()] = that;
+	}
+
 	public void reset() {
 		reset(_dims);
 	}
 
-	@Override
 	public void reset(int[] dims) {
 		if (dims.length < 2)
 			throw new DMLRuntimeException("DataTensor.reset(int[]) invalid number of tensor dimensions: " + dims.length);
@@ -185,25 +200,24 @@ public class DataTensor extends TensorBlock {
 		// typeIxCounter now has the length of the BasicTensors
 		if (_colsdata == null) {
 			allocateBlock();
-		} else {
+		}
+		else {
 			for (int i = 0; i < _colsdata.length; i++) {
 				if (_colsdata[i] != null) {
 					_colsdata[i].reset(toInternalDims(dims, typeIxCounter[i]));
 				}
 				else if (typeIxCounter[i] != 0) {
 					int[] colDims = toInternalDims(_dims, typeIxCounter[i]);
-					_colsdata[i] = new BasicTensor(ValueType.values()[i], colDims, false);
+					_colsdata[i] = new BasicTensorBlock(ValueType.values()[i], colDims, false);
 					_colsdata[i].allocateBlock();
 				}
 			}
 		}
 	}
 
-	@Override
-	public DataTensor allocateBlock() {
+	public DataTensorBlock allocateBlock() {
 		if (_colsdata == null)
-			// -1 because of unknown
-			_colsdata = new BasicTensor[VALID_VALUE_TYPES_LENGTH];
+			_colsdata = new BasicTensorBlock[VALID_VALUE_TYPES_LENGTH];
 		int[] colDataColumnLength = new int[_colsdata.length];
 		for (ValueType valueType : _schema)
 			colDataColumnLength[valueType.ordinal()]++;
@@ -211,48 +225,64 @@ public class DataTensor extends TensorBlock {
 			if (colDataColumnLength[i] != 0) {
 				int[] dims = toInternalDims(_dims, colDataColumnLength[i]);
 				// TODO sparse
-				_colsdata[i] = new BasicTensor(ValueType.values()[i], dims, false);
+				_colsdata[i] = new BasicTensorBlock(ValueType.values()[i], dims, false);
 				_colsdata[i].allocateBlock();
 			}
 		}
 		return this;
 	}
 
-	@Override
 	public boolean isAllocated() {
 		if (_colsdata == null)
 			return false;
-		for (BasicTensor block : _colsdata) {
+		for (BasicTensorBlock block : _colsdata) {
 			if (block != null && block.isAllocated())
 				return true;
 		}
 		return false;
 	}
 
-	@Override
 	public boolean isEmpty(boolean safe) {
 		if (!isAllocated()) {
 			return true;
 		}
-		for (BasicTensor tb : _colsdata) {
+		for (BasicTensorBlock tb : _colsdata) {
 			if (tb != null && !tb.isEmpty(safe))
 				return false;
 		}
 		return true;
 	}
 
-	@Override
 	public long getNonZeros() {
-		// TODO non zero for DataTensor
 		if (!isAllocated()) {
 			return 0;
 		}
 		long nnz = 0;
-		for (BasicTensor bt : _colsdata) {
+		for (BasicTensorBlock bt : _colsdata) {
 			if (bt != null)
 				nnz += bt.getNonZeros();
 		}
 		return nnz;
+	}
+
+	public int getNumRows() {
+		return getDim(0);
+	}
+
+	public int getNumColumns() {
+		return getDim(1);
+	}
+
+	public int getNumDims() {
+		return _dims.length;
+	}
+
+	public int getDim(int i) {
+		return _dims[i];
+	}
+
+	public int[] getDims() {
+		return _dims;
 	}
 
 	public ValueType[] getSchema() {
@@ -263,169 +293,79 @@ public class DataTensor extends TensorBlock {
 		return _schema[col];
 	}
 
-	@Override
 	public Object get(int[] ix) {
 		int columns = ix[1];
 		int[] internalIx = toInternalIx(ix, _colsToIx[columns]);
 		return _colsdata[_schema[columns].ordinal()].get(internalIx);
 	}
 
-	@Override
 	public double get(int r, int c) {
 		if (getNumDims() != 2)
 			throw new DMLRuntimeException("DataTensor.get(int,int) dimension mismatch: expected=2 actual=" + getNumDims());
 		return _colsdata[_schema[c].ordinal()].get(r, _colsToIx[c]);
 	}
 
-	@Override
+	public void set(Object v) {
+		for (BasicTensorBlock bt : _colsdata)
+			bt.set(v);
+	}
+
 	public void set(int[] ix, Object v) {
 		int columns = ix[1];
 		int[] internalIx = toInternalIx(ix, _colsToIx[columns]);
 		_colsdata[_schema[columns].ordinal()].set(internalIx, v);
 	}
 
-	@Override
 	public void set(int r, int c, double v) {
 		if (getNumDims() != 2)
 			throw new DMLRuntimeException("DataTensor.set(int,int,double) dimension mismatch: expected=2 actual=" + getNumDims());
 		_colsdata[_schema[c].ordinal()].set(r, _colsToIx[c], v);
 	}
 
-	@Override
-	public TensorBlock aggregateUnaryOperations(AggregateUnaryOperator op, TensorBlock result) {
-		// TODO aggregateUnaryOperations for DataTensor
-		throw new DMLRuntimeException("DataTensor.aggregateUnaryOperations is not implemented yet.");
-	}
-
-	@Override
-	public void incrementalAggregate(AggregateOperator aggOp, TensorBlock partialResult) {
-		// TODO incrementalAggregate for DataTensor
-		throw new DMLRuntimeException("DataTensor.incrementalAggregate is not implemented yet.");
-	}
-
-	@Override
-	public TensorBlock binaryOperations(BinaryOperator op, TensorBlock thatValue, TensorBlock result) {
-		// TODO binaryOperations for DataTensor
-		throw new DMLRuntimeException("DataTensor.binaryOperations is not implemented yet.");
-	}
-
-	@Override
-	protected DataTensor checkType(TensorBlock that) {
-		if (that instanceof DataTensor)
-			return (DataTensor) that;
-		else
-			throw new DMLRuntimeException("BasicTensor.checkType(TensorBlock) given TensorBlock was no BasicTensor");
-	}
-
-	public void copy(DataTensor that) {
+	public void copy(DataTensorBlock that) {
 		_dims = that._dims.clone();
 		_schema = that._schema.clone();
 		_colsToIx = that._colsToIx.clone();
+		_ixToCols = new int[that._ixToCols.length][];
+		for (int i = 0; i < _ixToCols.length; i++)
+			if (that._ixToCols[i] != null)
+				_ixToCols[i] = that._ixToCols[i].clone();
 		if (that.isAllocated()) {
 			if (that.isEmpty(false)) {
 				return;
 			}
 			for (int i = 0; i < _colsdata.length; i++) {
 				if (that._colsdata[i] != null) {
-					_colsdata[i] = new BasicTensor(that._colsdata[i]);
+					_colsdata[i] = new BasicTensorBlock(that._colsdata[i]);
 				}
 			}
 		}
 	}
 
-	@Override
-	public long getInMemorySize() {
-		// TODO in memory size
-		return 0;
-	}
-
-	@Override
-	public long getExactSerializedSize() {
-		//header size (num dims, dims)
-		long size = 4 * (1 + _dims.length) + getDim(1) * (1 + 4);
-		//colsdata serialized representation
-		for (BasicTensor bt : _colsdata) {
-			size += 1; // flag
-			if (bt != null)
-				size += bt.getExactSerializedSize();
+	public void copy(int[] lower, int[] upper, DataTensorBlock src) {
+		int[] subLower = lower.clone();
+		if (upper[1] == 0) {
+			upper[1] = getDim(1);
+			upper[0]--;
 		}
-		return size;
-	}
-
-	@Override
-	public boolean isShallowSerialize() {
-		// TODO is shallow serialize
-		return false;
-	}
-
-	@Override
-	public boolean isShallowSerialize(boolean inclConvert) {
-		// TODO is shallow serialize
-		return false;
-	}
-
-	@Override
-	public void toShallowSerializeBlock() {
-		// TODO to shallow serialize block
-	}
-
-	@Override
-	public void compactEmptyBlock() {
-		// TODO compact empty block
-	}
-
-	@Override
-	public CacheBlock slice(int rl, int ru, int cl, int cu, CacheBlock block) {
-		// TODO slice
-		return null;
-	}
-
-	@Override
-	public void merge(CacheBlock that, boolean appendOnly) {
-		// TODO merge
-	}
-
-	@Override
-	public void write(DataOutput out) throws IOException {
-		//step 1: write dims
-		out.writeInt(getNumDims()); // num dims
-		for (int i = 0; i < getNumDims(); i++)
-			out.writeInt(getDim(i)); // dim
-		//step 2: write schema and colIndexes
-		for (int i = 0; i < getDim(1); i++) {
-			out.writeByte(_schema[i].ordinal());
-			out.writeInt(_colsToIx[i]);
-		}
-		//step 3: write basic tensors
-		for (BasicTensor colsdatum : _colsdata) {
-			//present flag
-			if (colsdatum == null)
-				out.writeBoolean(false);
-			else {
-				out.writeBoolean(true);
-				colsdatum.write(out);
+		int[] subUpper = upper.clone();
+		for (int i = 0; i < VALID_VALUE_TYPES_LENGTH; i++) {
+			if (src._colsdata[i] == null)
+				continue;
+			// TODO binary search
+			for (int j = 0; j < src._ixToCols[i].length; j++) {
+				if (src._ixToCols[i][j] >= lower[1]) {
+					subLower[1] = src._ixToCols[i][j];
+					break;
+				}
 			}
-		}
-	}
-
-	@Override
-	public void readFields(DataInput in) throws IOException {
-		//step 1: read dims
-		_dims = new int[in.readInt()];
-		for (int i = 0; i < _dims.length; i++)
-			_dims[i] = in.readInt();
-		_schema = new ValueType[getDim(1)];
-		_colsToIx = new int[getDim(1)];
-		for (int i = 0; i < getDim(1); i++) {
-			_schema[i] = ValueType.values()[in.readByte()];
-			_colsToIx[i] = in.readInt();
-		}
-		_colsdata = new BasicTensor[VALID_VALUE_TYPES_LENGTH];
-		for (int i = 0; i < _colsdata.length; i++) {
-			if (in.readBoolean()) {
-				_colsdata[i] = new BasicTensor();
-				_colsdata[i].readFields(in);
+			for (int j = src._ixToCols[i].length - 1; j >= 0; j--) {
+				if (src._ixToCols[i][j] < upper[1]) {
+					subUpper[1] = src._ixToCols[i][j] + 1;
+					break;
+				}
 			}
+			_colsdata[i].copy(subLower, subUpper, src._colsdata[i]);
 		}
 	}
 

--- a/src/main/java/org/tugraz/sysds/runtime/data/DataTensorBlock.java
+++ b/src/main/java/org/tugraz/sysds/runtime/data/DataTensorBlock.java
@@ -352,19 +352,8 @@ public class DataTensorBlock implements Serializable {
 		for (int i = 0; i < VALID_VALUE_TYPES_LENGTH; i++) {
 			if (src._colsdata[i] == null)
 				continue;
-			// TODO binary search
-			for (int j = 0; j < src._ixToCols[i].length; j++) {
-				if (src._ixToCols[i][j] >= lower[1]) {
-					subLower[1] = src._ixToCols[i][j];
-					break;
-				}
-			}
-			for (int j = src._ixToCols[i].length - 1; j >= 0; j--) {
-				if (src._ixToCols[i][j] < upper[1]) {
-					subUpper[1] = src._ixToCols[i][j] + 1;
-					break;
-				}
-			}
+			subLower[1] = lower[1];
+			subUpper[1] = lower[1] + src._colsdata[i].getNumColumns();
 			_colsdata[i].copy(subLower, subUpper, src._colsdata[i]);
 		}
 	}

--- a/src/main/java/org/tugraz/sysds/runtime/data/DenseBlock.java
+++ b/src/main/java/org/tugraz/sysds/runtime/data/DenseBlock.java
@@ -513,6 +513,9 @@ public abstract class DenseBlock implements Serializable
 							data[ix1 + ix] = db.getString(otherIx);
 							getNextIndexes(otherIx);
 						}
+						otherIx[0] = i - rl + 1;
+						otherIx[1] = 0;
+						Arrays.fill(otherIx, 2, otherIx.length, 0);
 					}
 				}
 				rl = 0;

--- a/src/main/java/org/tugraz/sysds/runtime/data/DenseBlockBool.java
+++ b/src/main/java/org/tugraz/sysds/runtime/data/DenseBlockBool.java
@@ -165,7 +165,7 @@ public class DenseBlockBool extends DenseBlockDRB
 		for (int r = rl; r < ru; r++) {
 			for (int c = cl; c < cu; c++) {
 				int i = r * _odims[0] + c;
-				_data.set(i, db.get(r, c) != 0);
+				_data.set(i, db.get(r - rl, c - cl) != 0);
 			}
 		}
 		return this;

--- a/src/main/java/org/tugraz/sysds/runtime/data/DenseBlockString.java
+++ b/src/main/java/org/tugraz/sysds/runtime/data/DenseBlockString.java
@@ -158,12 +158,14 @@ public class DenseBlockString extends DenseBlockDRB {
 
 	@Override
 	public double get(int r, int c) {
-		return Double.parseDouble(_data[pos(r, c)]);
+		String s = _data[pos(r, c)];
+		return s == null || s.isEmpty() ? 0 : Double.parseDouble(s);
 	}
 
 	@Override
 	public double get(int[] ix) {
-		return Double.parseDouble(_data[pos(ix)]);
+		String s = _data[pos(ix)];
+		return s == null || s.isEmpty() ? 0 : Double.parseDouble(s);
 	}
 
 	@Override
@@ -179,6 +181,7 @@ public class DenseBlockString extends DenseBlockDRB {
 
 	@Override
 	public long getLong(int[] ix) {
-		return Long.parseLong(_data[pos(ix)]);
+		String s = _data[pos(ix)];
+		return s == null || s.isEmpty() ? 0 : Long.parseLong(s);
 	}
 }

--- a/src/main/java/org/tugraz/sysds/runtime/data/LibTensorBincell.java
+++ b/src/main/java/org/tugraz/sysds/runtime/data/LibTensorBincell.java
@@ -39,7 +39,7 @@ public class LibTensorBincell {
 	 * @param ret result tensor
 	 * @param op  binary operator
 	 */
-	public static void bincellOp(BasicTensor m1, BasicTensor m2, BasicTensor ret, BinaryOperator op) {
+	public static void bincellOp(TensorBlock m1, TensorBlock m2, TensorBlock ret, BinaryOperator op) {
 		// TODO separate implementations for matching dims and broadcasting
 		// TODO perf (empty, sparse safe, etc.)
 		int[] ix1 = new int[ret.getNumDims()];

--- a/src/main/java/org/tugraz/sysds/runtime/data/LibTensorReorg.java
+++ b/src/main/java/org/tugraz/sysds/runtime/data/LibTensorReorg.java
@@ -39,17 +39,14 @@ public class LibTensorReorg {
 	 * @param dims dimensions
 	 * @return output tensor
 	 */
-	public static BasicTensor reshape(BasicTensor in, BasicTensor out, int[] dims) {
+	public static BasicTensorBlock reshape(BasicTensorBlock in, BasicTensorBlock out, int[] dims) {
 		long length = 1;
 		for (int dim : dims) {
 			length *= dim;
 		}
-		int[] inDims = new int[in.getNumDims()];
+		int[] inDims = in.getDims();
 		//check validity
 		if(in.getLength() != length) {
-			for (int i = 0; i < in.getNumDims(); i++) {
-				inDims[i] = in.getDim(i);
-			}
 			throw new DMLRuntimeException("Reshape tensor requires consistent numbers of input/output cells (" +
 					Arrays.toString(inDims) + ", " + Arrays.toString(dims) + ").");
 		}
@@ -84,7 +81,7 @@ public class LibTensorReorg {
 		return out;
 	}
 
-	private static void reshapeDense(BasicTensor in, BasicTensor out, int[] dims) {
+	private static void reshapeDense(BasicTensorBlock in, BasicTensorBlock out, int[] dims) {
 		//reshape empty block
 		if( in._denseBlock == null )
 			return;

--- a/src/main/java/org/tugraz/sysds/runtime/data/TensorBlock.java
+++ b/src/main/java/org/tugraz/sysds/runtime/data/TensorBlock.java
@@ -17,28 +17,159 @@
 
 package org.tugraz.sysds.runtime.data;
 
+import org.apache.commons.lang.NotImplementedException;
+import org.tugraz.sysds.common.Types.BlockType;
 import org.tugraz.sysds.common.Types.ValueType;
 import org.tugraz.sysds.runtime.DMLRuntimeException;
 import org.tugraz.sysds.runtime.controlprogram.caching.CacheBlock;
-import org.tugraz.sysds.runtime.matrix.operators.AggregateOperator;
-import org.tugraz.sysds.runtime.matrix.operators.AggregateUnaryOperator;
+import org.tugraz.sysds.runtime.io.IOUtilFunctions;
+import org.tugraz.sysds.runtime.matrix.data.MatrixBlock;
 import org.tugraz.sysds.runtime.matrix.operators.BinaryOperator;
 import org.tugraz.sysds.runtime.util.UtilFunctions;
 
-public abstract class TensorBlock implements CacheBlock
-{
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.Arrays;
+
+public class TensorBlock implements CacheBlock, Externalizable {
+	private static final long serialVersionUID = -8768054067319422277L;
+	
+	private enum SERIALIZED_TYPES {
+		EMPTY, BASIC, DATA
+	}
+	
 	public static final int[] DEFAULT_DIMS = new int[]{0, 0};
+	public static final ValueType DEFAULT_VTYPE = ValueType.FP64;
 
-	//min 2 dimensions to preserve proper matrix semantics
-	protected int[] _dims; //[2,inf)
+	private int[] _dims;
+	private boolean _basic = true;
 
-	public abstract void reset();
+	private DataTensorBlock _dataTensor = null;
+	private BasicTensorBlock _basicTensor = null;
 
-	public abstract void reset(int[] dims);
+	public TensorBlock() {
+		this(DEFAULT_DIMS, true);
+	}
 
-	public abstract boolean isAllocated();
+	public TensorBlock(int[] dims, boolean basic) {
+		_dims = dims;
+		_basic = basic;
+	}
 
-	public abstract TensorBlock allocateBlock();
+	public TensorBlock(ValueType vt, int[] dims) {
+		this(dims, true);
+		_basicTensor = new BasicTensorBlock(vt, dims, false);
+	}
+
+	public TensorBlock(ValueType[] schema, int[] dims) {
+		this(dims, false);
+		_dataTensor = new DataTensorBlock(schema, dims);
+	}
+
+	public TensorBlock(double value) {
+		_dims = new int[]{1, 1};
+		_basicTensor = new BasicTensorBlock(value);
+	}
+
+	public TensorBlock(BasicTensorBlock basicTensor) {
+		this(basicTensor._dims, true);
+		_basicTensor = basicTensor;
+	}
+
+	public TensorBlock(DataTensorBlock dataTensor) {
+		this(dataTensor._dims, false);
+		_dataTensor = dataTensor;
+	}
+
+	public TensorBlock(TensorBlock that) {
+		copy(that);
+	}
+
+	public void reset() {
+		if (_basic) {
+			if (_basicTensor == null)
+				_basicTensor = new BasicTensorBlock(DEFAULT_VTYPE, _dims, false);
+			_basicTensor.reset();
+		}
+		else {
+			if (_dataTensor == null)
+				_dataTensor = new DataTensorBlock(DEFAULT_VTYPE, _dims);
+			_dataTensor.reset();
+		}
+	}
+
+	public void reset(int[] dims) {
+		_dims = dims;
+		if (_basic) {
+			if (_basicTensor == null)
+				_basicTensor = new BasicTensorBlock(DEFAULT_VTYPE, _dims, false);
+			_basicTensor.reset(dims);
+		}
+		else {
+			if (_dataTensor == null)
+				_dataTensor = new DataTensorBlock(DEFAULT_VTYPE, _dims);
+			_dataTensor.reset(dims);
+		}
+	}
+
+	public boolean isBasic() {
+		return _basic;
+	}
+
+	public boolean isAllocated() {
+		if (_basic)
+			return _basicTensor != null && _basicTensor.isAllocated();
+		else
+			return _dataTensor != null && _dataTensor.isAllocated();
+	}
+
+	public TensorBlock allocateBlock() {
+		if (_basic) {
+			if (_basicTensor == null)
+				_basicTensor = new BasicTensorBlock(DEFAULT_VTYPE, _dims, false);
+			_basicTensor.allocateBlock();
+		}
+		else {
+			if (_dataTensor == null)
+				_dataTensor = new DataTensorBlock(DEFAULT_VTYPE, _dims);
+			_dataTensor.allocateBlock();
+		}
+		return this;
+	}
+
+	public BasicTensorBlock getBasicTensor() {
+		return _basicTensor;
+	}
+
+	public DataTensorBlock getDataTensor() {
+		return _dataTensor;
+	}
+
+	public ValueType getValueType() {
+		if (_basic)
+			return _basicTensor == null ? DEFAULT_VTYPE : _basicTensor.getValueType();
+		else
+			return null;
+	}
+
+	public ValueType[] getSchema() {
+		if (_basic)
+			return null;
+		else {
+			if (_dataTensor == null) {
+				//TODO perf, do not fill, instead save schema
+				ValueType[] schema = new ValueType[getDim(1)];
+				Arrays.fill(schema, DEFAULT_VTYPE);
+				return schema;
+			}
+			else
+				return _dataTensor.getSchema();
+		}
+	}
 
 	public int getNumDims() {
 		return _dims.length;
@@ -52,22 +183,80 @@ public abstract class TensorBlock implements CacheBlock
 		return getDim(1);
 	}
 
+	@Override
+	public long getInMemorySize() {
+		// TODO Auto-generated method stub
+		return 0;
+	}
+
+	@Override
+	public boolean isShallowSerialize() {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
+	@Override
+	public boolean isShallowSerialize(boolean inclConvert) {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
+	@Override
+	public void toShallowSerializeBlock() {
+		// TODO Auto-generated method stub
+	}
+
+	@Override
+	public void compactEmptyBlock() {
+		// TODO Auto-generated method stub
+	}
+
+	@Override
+	public CacheBlock slice(int rl, int ru, int cl, int cu, CacheBlock block) {
+		if( !(block instanceof TensorBlock) )
+			throw new RuntimeException("TensorBlock.slice(int,int,int,int,CacheBlock) CacheBlock was no TensorBlock");
+		TensorBlock tb = (TensorBlock) block;
+		int[] dims = new int[_dims.length];
+		dims[0] = ru - rl + 1;
+		dims[1] = cu - cl + 1;
+		System.arraycopy(_dims, 2, dims, 2, _dims.length - 2);
+		tb.reset(dims);
+		int[] offsets = new int[dims.length];
+		offsets[0] = rl;
+		offsets[1] = cl;
+		return slice(offsets, tb);
+	}
+
+	@Override
+	public void merge(CacheBlock that, boolean appendOnly) {
+		// TODO Auto-generated method stub
+	}
+
 	public int getDim(int i) {
 		return _dims[i];
+	}
+
+	public int[] getDims() {
+		return _dims;
+	}
+
+	public long[] getLongDims() {
+		return Arrays.stream(_dims).mapToLong(i -> i).toArray();
 	}
 
 	/**
 	 * Calculates the next index array. Note that if the given index array was the last element, the next index will
 	 * be the first one.
 	 *
+	 * @param dims the dims array for which we have to decide the next index
 	 * @param ix the index array which will be incremented to the next index array
 	 */
-	public void getNextIndexes(int[] ix) {
+	public static void getNextIndexes(int[] dims, int[] ix) {
 		int i = ix.length - 1;
 		ix[i]++;
 		//calculating next index
-		if (ix[i] == getDim(i)) {
-			while (ix[i] == getDim(i)) {
+		if (ix[i] == dims[i]) {
+			while (ix[i] == dims[i]) {
 				ix[i] = 0;
 				i--;
 				if (i < 0) {
@@ -77,6 +266,16 @@ public abstract class TensorBlock implements CacheBlock
 				ix[i]++;
 			}
 		}
+	}
+
+	/**
+	 * Calculates the next index array. Note that if the given index array was the last element, the next index will
+	 * be the first one.
+	 *
+	 * @param ix the index array which will be incremented to the next index array
+	 */
+	public void getNextIndexes(int[] ix) {
+		getNextIndexes(_dims, ix);
 	}
 
 	public boolean isVector() {
@@ -97,44 +296,388 @@ public abstract class TensorBlock implements CacheBlock
 		return isEmpty(false);
 	}
 
-	public abstract boolean isEmpty(boolean safe);
+	public boolean isEmpty(boolean safe) {
+		if (_basic)
+			return _basicTensor == null || _basicTensor.isEmpty(safe);
+		else
+			return _dataTensor == null || _dataTensor.isEmpty(safe);
+	}
 
-	public abstract long getNonZeros();
+	public long getNonZeros() {
+		if (!isAllocated())
+			return 0;
+		if (_basic)
+			return _basicTensor.getNonZeros();
+		else
+			return _dataTensor.getNonZeros();
+	}
 
-	public abstract Object get(int[] ix);
+	public Object get(int[] ix) {
+		if (_basic && _basicTensor != null)
+			return _basicTensor.get(ix);
+		else if (_dataTensor != null)
+			return _dataTensor.get(ix);
+		return 0.0;
+	}
 
-	public abstract double get(int r, int c);
+	public double get(int r, int c) {
+		if (_basic && _basicTensor != null)
+			return _basicTensor.get(r, c);
+		else if (_dataTensor != null)
+			return _dataTensor.get(r, c);
+		return 0.0;
+	}
 
+	public void set(Object v) {
+		if (_basic) {
+			if (_basicTensor == null)
+				_basicTensor = new BasicTensorBlock(DEFAULT_VTYPE, _dims, false);
+			_basicTensor.set(v);
+		}
+		else {
+			if (_dataTensor == null)
+				_dataTensor = new DataTensorBlock(getSchema(), _dims);
+			_dataTensor.set(v);
+		}
+	}
+
+	public void set(MatrixBlock other) {
+		if (_basic)
+			_basicTensor.set(other);
+		else
+			throw new DMLRuntimeException("TensorBlock.set(MatrixBlock) is not yet implemented for heterogeneous tensors");
+	}
+	
 	/**
 	 * Set a cell to the value given as an `Object`. The type is inferred by either the `schema` or `valueType`, depending
 	 * if the `TensorBlock` is a `BasicTensor` or `DataTensor`.
 	 * @param ix indexes in each dimension, starting with 0
 	 * @param v value to set
 	 */
-	public abstract void set(int[] ix, Object v);
-
+	public void set(int[] ix, Object v) {
+		if (_basic) {
+			if (_basicTensor == null)
+				_basicTensor = new BasicTensorBlock(DEFAULT_VTYPE, _dims, false);
+			_basicTensor.set(ix, v);
+		}
+		else {
+			if (_dataTensor == null)
+				_dataTensor = new DataTensorBlock(getSchema(), _dims);
+			_dataTensor.set(ix, v);
+		}
+	}
+	
 	/**
 	 * Set a cell in a 2-dimensional tensor.
 	 * @param r row of the cell
 	 * @param c column of the cell
 	 * @param v value to set
 	 */
-	public abstract void set(int r, int c, double v);
+	public void set(int r, int c, double v) {
+		if (_basic) {
+			if (_basicTensor == null)
+				_basicTensor = new BasicTensorBlock(DEFAULT_VTYPE, _dims, false);
+			_basicTensor.set(r, c, v);
+		}
+		else {
+			if (_dataTensor == null)
+				_dataTensor = new DataTensorBlock(getSchema(), _dims);
+			_dataTensor.set(r, c, v);
+		}
+	}
 
 	/**
-	 * Aggregate a unary operation on this tensor.
-	 * @param op the operation to apply
-	 * @param result the result tensor
-	 * @return the result tensor
+	 * Slice the current block and write into the outBlock. The offsets determines where the slice starts,
+	 * the length of the blocks is given by the outBlock dimensions.
+	 *
+	 * @param offsets  offsets where the slice starts
+	 * @param outBlock sliced result block
+	 * @return the sliced result block
 	 */
-	public abstract TensorBlock aggregateUnaryOperations(AggregateUnaryOperator op, TensorBlock result);
+	public TensorBlock slice(int[] offsets, TensorBlock outBlock) {
+		// TODO perf
+		int[] srcIx = offsets.clone();
+		int[] destIx = new int[offsets.length];
+		for (int l = 0; l < outBlock.getLength(); l++) {
+			outBlock.set(destIx, get(srcIx));
+			int i = outBlock.getNumDims() - 1;
+			destIx[i]++;
+			srcIx[i]++;
+			//calculating next index
+			while (destIx[i] == outBlock.getDim(i)) {
+				destIx[i] = 0;
+				srcIx[i] = offsets[i];
+				i--;
+				if (i < 0) {
+					//we are finished
+					return outBlock;
+				}
+				destIx[i]++;
+				srcIx[i]++;
+			}
+		}
+		return outBlock;
+	}
 
-	public abstract void incrementalAggregate(AggregateOperator aggOp, TensorBlock partialResult);
+	public TensorBlock copy(TensorBlock src) {
+		_dims = src._dims.clone();
+		_basic = src._basic;
+		if (_basic) {
+			_dataTensor = null;
+			_basicTensor = src._basicTensor == null ? null : new BasicTensorBlock(src._basicTensor);
+		}
+		else {
+			_basicTensor = null;
+			_dataTensor = src._dataTensor == null ? null : new DataTensorBlock(src._dataTensor);
+		}
+		return this;
+	}
 
-	public abstract TensorBlock binaryOperations(BinaryOperator op, TensorBlock thatValue, TensorBlock result);
+	public TensorBlock copy(int[] lower, int[] upper, TensorBlock src) {
+		if (_basic) {
+			if (src._basic) {
+				_basicTensor.copy(lower, upper, src._basicTensor);
+			}
+			else {
+				throw new DMLRuntimeException("Copying `DataTensor` into `BasicTensor` is not a safe operation.");
+			}
+		}
+		else {
+			if (src._basic) {
+				// TODO perf
+				_dataTensor.copy(lower, upper, new DataTensorBlock(src._basicTensor));
+			}
+			else {
+				_dataTensor.copy(lower, upper, src._dataTensor);
+			}
+		}
+		return this;
+	}
 
-	protected abstract TensorBlock checkType(TensorBlock that);
+	// `getExactSerializedSize()`, `write(DataOutput)` and `readFields(DataInput)` have to match in their serialized
+	// form definition
+	@Override
+	public long getExactSerializedSize() {
+		// header size (_basic, _dims.length + _dims[*], type)
+		long size = 1 + 4 * (1 + _dims.length) + 1;
+		if (isAllocated()) {
+			if (_basic) {
+				size += 1 + getExactBlockDataSerializedSize(_basicTensor);
+			}
+			else {
+				size += _dataTensor._schema.length;
+				for (BasicTensorBlock bt : _dataTensor._colsdata) {
+					if (bt != null)
+						size += getExactBlockDataSerializedSize(bt);
+				}
+			}
+		}
+		return size;
+	}
 
+	public long getExactBlockDataSerializedSize(BasicTensorBlock bt) {
+		// nnz, BlockType
+		long size = 8 + 1;
+		if (!bt.isSparse()) {
+			switch (bt._vt) {
+				case INT32:
+				case FP32:
+					size += 4 * getLength(); break;
+				case INT64:
+				case FP64:
+					size += 8 * getLength(); break;
+				case BOOLEAN:
+					//TODO perf bits instead of bytes
+					size += getLength(); break;
+					//size += Math.ceil((double)getLength() / 64); break;
+				case STRING:
+					int[] ix = new int[bt._dims.length];
+					for (int i = 0; i < bt.getLength(); i++) {
+						String s = (String) bt.get(ix);
+						size += IOUtilFunctions.getUTFSize(s == null ? "" : s);
+						getNextIndexes(bt.getDims(), ix);
+					}
+					break;
+				case UNKNOWN:
+					throw new NotImplementedException();
+			}
+		}
+		else {
+			throw new NotImplementedException();
+		}
+		return size;
+	}
+
+	@Override
+	public void write(DataOutput out) throws IOException {
+		//step 1: write header (_basic, dims length, dims)
+		out.writeBoolean(_basic);
+		out.writeInt(_dims.length);
+		for (int dim : _dims)
+			out.writeInt(dim);
+
+		//step 2: write block type
+		//step 3: if tensor allocated write its data
+		if (!isAllocated())
+			out.writeByte(SERIALIZED_TYPES.EMPTY.ordinal());
+		else if (_basic) {
+			out.writeByte(SERIALIZED_TYPES.BASIC.ordinal());
+			out.writeByte(_basicTensor.getValueType().ordinal());
+			writeBlockData(out, _basicTensor);
+		}
+		else {
+			out.writeByte(SERIALIZED_TYPES.DATA.ordinal());
+			//write schema and colIndexes
+			for (int i = 0; i < getDim(1); i++)
+				out.writeByte(_dataTensor._schema[i].ordinal());
+			for (BasicTensorBlock bt : _dataTensor._colsdata) {
+				//present flag
+				if (bt != null)
+					writeBlockData(out, bt);
+			}
+		}
+	}
+
+	public void writeBlockData(DataOutput out, BasicTensorBlock bt) throws IOException {
+		out.writeLong(bt.getNonZeros()); // nnz
+		if (bt.isEmpty(false)) {
+			//empty blocks do not need to materialize row information
+			out.writeByte(BlockType.EMPTY_BLOCK.ordinal());
+		}
+		else if (!bt.isSparse()) {
+			out.writeByte(BlockType.DENSE_BLOCK.ordinal());
+			DenseBlock a = bt.getDenseBlock();
+			int odims = (int) UtilFunctions.prod(bt._dims, 1);
+			int[] ix = new int[bt._dims.length];
+			for (int i = 0; i < bt._dims[0]; i++) {
+				ix[0] = i;
+				for (int j = 0; j < odims; j++) {
+					ix[ix.length - 1] = j;
+					switch (bt._vt) {
+						case FP32: out.writeFloat((float) a.get(i, j)); break;
+						case FP64: out.writeDouble(a.get(i, j)); break;
+						case INT32: out.writeInt((int) a.getLong(ix)); break;
+						case INT64: out.writeLong(a.getLong(ix)); break;
+						case BOOLEAN: out.writeBoolean(a.get(i, j) != 0); break;
+						case STRING:
+							String s = a.getString(ix);
+							out.writeUTF(s == null ? "" : s);
+							break;
+					}
+				}
+			}
+		}
+		else {
+			throw new NotImplementedException();
+		}
+	}
+
+	@Override
+	public void readFields(DataInput in) throws IOException {
+		//step 1: read header (_basic, dims length, dims)
+		_basic = in.readBoolean();
+		_dims = new int[in.readInt()];
+		for (int i = 0; i < _dims.length; i++)
+			_dims[i] = in.readInt();
+
+		//step 2: read block type
+		//step 3: if tensor allocated read its data
+		switch (SERIALIZED_TYPES.values()[in.readByte()]) {
+			case EMPTY:
+				break;
+			case BASIC:
+				_basicTensor = new BasicTensorBlock(ValueType.values()[in.readByte()], _dims, false);
+				readBlockData(in, _basicTensor);
+				break;
+			case DATA:
+				//read schema and colIndexes
+				ValueType[] schema = new ValueType[getDim(1)];
+				for (int i = 0; i < getDim(1); i++)
+					schema[i] = ValueType.values()[in.readByte()];
+				_dataTensor = new DataTensorBlock(schema, _dims);
+				for (int i = 0; i < _dataTensor._colsdata.length; i++) {
+					//present flag
+					if (_dataTensor._colsdata[i] != null)
+						readBlockData(in, _dataTensor._colsdata[i]);
+				}
+				break;
+		}
+	}
+
+	protected void readBlockData(DataInput in, BasicTensorBlock bt) throws IOException {
+		bt._nnz = in.readLong();
+		switch (BlockType.values()[in.readByte()]) {
+			case EMPTY_BLOCK:
+				reset(bt._dims);
+				return;
+			case DENSE_BLOCK: {
+				bt.allocateDenseBlock(false);
+				DenseBlock a = bt.getDenseBlock();
+				int odims = (int) UtilFunctions.prod(bt._dims, 1);
+				int[] ix = new int[bt._dims.length];
+				for (int i = 0; i < bt._dims[0]; i++) {
+					ix[0] = i;
+					for (int j = 0; j < odims; j++) {
+						ix[ix.length - 1] = j;
+						switch (bt._vt) {
+							case FP32:
+								a.set(i, j, in.readFloat());
+								break;
+							case FP64:
+								a.set(i, j, in.readDouble());
+								break;
+							case INT32:
+								a.set(ix, in.readInt());
+								break;
+							case INT64:
+								a.set(ix, in.readLong());
+								break;
+							case BOOLEAN:
+								a.set(i, j, in.readByte());
+								break;
+							case STRING:
+								// FIXME readUTF is not supported for CacheDataInput
+								a.set(ix, in.readUTF());
+								break;
+						}
+					}
+				}
+				break;
+			}
+			case SPARSE_BLOCK:
+			case ULTRA_SPARSE_BLOCK:
+				throw new NotImplementedException();
+		}
+	}
+
+	@Override
+	public void writeExternal(ObjectOutput out) throws IOException {
+		write(out);
+	}
+
+	@Override
+	public void readExternal(ObjectInput in) throws IOException {
+		readFields(in);
+	}
+	
+	public TensorBlock binaryOperations(BinaryOperator op, TensorBlock thatValue, TensorBlock result) {
+		if( !LibTensorBincell.isValidDimensionsBinary(this, thatValue) )
+			throw new RuntimeException("Block sizes are not matched for binary cell operations");
+		if (!_basic || !thatValue.isBasic())
+			throw new RuntimeException("Binary operations on tensors only supported for BasicTensors at the moment");
+		//prepare result matrix block
+		ValueType vt = TensorBlock.resultValueType(getValueType(), thatValue.getValueType());
+		if (result == null || result.getValueType() != vt)
+			result = new TensorBlock(vt, _dims);
+		else {
+			result.reset(_dims);
+		}
+		
+		LibTensorBincell.bincellOp(this, thatValue, result, op);
+		
+		return result;
+	}
+	
 	public static ValueType resultValueType(ValueType in1, ValueType in2) {
 		// TODO reconsider with operation types
 		if (in1 == ValueType.UNKNOWN || in2 == ValueType.UNKNOWN)

--- a/src/main/java/org/tugraz/sysds/runtime/instructions/cp/AggregateUnaryCPInstruction.java
+++ b/src/main/java/org/tugraz/sysds/runtime/instructions/cp/AggregateUnaryCPInstruction.java
@@ -27,7 +27,8 @@ import org.tugraz.sysds.common.Types.ExecMode;
 import org.tugraz.sysds.runtime.DMLRuntimeException;
 import org.tugraz.sysds.runtime.controlprogram.caching.CacheableData;
 import org.tugraz.sysds.runtime.controlprogram.context.ExecutionContext;
-import org.tugraz.sysds.runtime.data.BasicTensor;
+import org.tugraz.sysds.runtime.data.BasicTensorBlock;
+import org.tugraz.sysds.runtime.data.TensorBlock;
 import org.tugraz.sysds.runtime.functionobjects.Builtin;
 import org.tugraz.sysds.runtime.instructions.InstructionUtils;
 import org.tugraz.sysds.runtime.lineage.LineageItem;
@@ -175,16 +176,16 @@ public class AggregateUnaryCPInstruction extends UnaryCPInstruction
 				} 
 				else if (input1.getDataType() == DataType.TENSOR) {
 					// TODO support DataTensor
-					BasicTensor basicTensor = (BasicTensor) ec.getTensorInput(input1.getName());
+					BasicTensorBlock basicTensor = ec.getTensorInput(input1.getName()).getBasicTensor();
 
-					BasicTensor resultBlock = basicTensor.aggregateUnaryOperations(au_op, new BasicTensor());
+					BasicTensorBlock resultBlock = basicTensor.aggregateUnaryOperations(au_op, new BasicTensorBlock());
 
 					ec.releaseTensorInput(input1.getName());
 					if(output.getDataType() == DataType.SCALAR)
 						ec.setScalarOutput(output_name, ScalarObjectFactory.createScalarObject(
 							input1.getValueType(), resultBlock.get(new int[]{0, 0})));
 					else
-						ec.setTensorOutput(output_name, resultBlock);
+						ec.setTensorOutput(output_name, new TensorBlock(resultBlock));
 				}
 				else {
 					throw new DMLRuntimeException(opcode + " only supported on matrix or tensor.");

--- a/src/main/java/org/tugraz/sysds/runtime/instructions/cp/BinaryTensorTensorCPInstruction.java
+++ b/src/main/java/org/tugraz/sysds/runtime/instructions/cp/BinaryTensorTensorCPInstruction.java
@@ -18,7 +18,6 @@
 package org.tugraz.sysds.runtime.instructions.cp;
 
 import org.tugraz.sysds.runtime.controlprogram.context.ExecutionContext;
-import org.tugraz.sysds.runtime.data.BasicTensor;
 import org.tugraz.sysds.runtime.data.TensorBlock;
 import org.tugraz.sysds.runtime.matrix.operators.BinaryOperator;
 import org.tugraz.sysds.runtime.matrix.operators.Operator;
@@ -38,7 +37,7 @@ public class BinaryTensorTensorCPInstruction extends BinaryCPInstruction {
 
 		// Perform computation using input tensors, and produce the result tensor
 		BinaryOperator bop = (BinaryOperator) _optr;
-		BasicTensor retBlock = (BasicTensor) (inBlock1.binaryOperations (bop, inBlock2, null));
+		TensorBlock retBlock = inBlock1.binaryOperations(bop, inBlock2, null);
 		
 		// Release the memory occupied by input matrices
 		ec.releaseTensorInput(input1.getName(), input2.getName());

--- a/src/main/java/org/tugraz/sysds/runtime/instructions/cp/DataGenCPInstruction.java
+++ b/src/main/java/org/tugraz/sysds/runtime/instructions/cp/DataGenCPInstruction.java
@@ -30,7 +30,7 @@ import org.tugraz.sysds.lops.DataGen;
 import org.tugraz.sysds.lops.Lop;
 import org.tugraz.sysds.runtime.DMLRuntimeException;
 import org.tugraz.sysds.runtime.controlprogram.context.ExecutionContext;
-import org.tugraz.sysds.runtime.data.BasicTensor;
+import org.tugraz.sysds.runtime.data.TensorBlock;
 import org.tugraz.sysds.runtime.instructions.InstructionUtils;
 import org.tugraz.sysds.runtime.lineage.LineageItem;
 import org.tugraz.sysds.runtime.matrix.data.LibMatrixDatagen;
@@ -248,7 +248,7 @@ public class DataGenCPInstruction extends UnaryCPInstruction {
 	public void processInstruction( ExecutionContext ec )
 	{
 		MatrixBlock soresBlock = null;
-		BasicTensor basicTensor = null;
+		TensorBlock tensorBlock = null;
 		ScalarObject soresScalar = null;
 		
 		//process specific datagen operator
@@ -269,14 +269,14 @@ public class DataGenCPInstruction extends UnaryCPInstruction {
 				LOG.trace("Process DataGenCPInstruction rand with seed = "+lSeed+".");
 
 			if (output.isTensor()) {
+				// TODO data tensor
 				int[] tDims = DataConverter.getTensorDimensions(ec, dims);
-				basicTensor = new BasicTensor(output.getValueType(), tDims);
-				basicTensor.allocateDenseBlock();
+				tensorBlock = new TensorBlock(output.getValueType(), tDims).allocateBlock();
 				if (minValueStr.equals(maxValueStr)) {
 					if (minMaxAreDoubles)
-						basicTensor.set(minValue);
+						tensorBlock.set(minValue);
 					else if (output.getValueType() == ValueType.STRING || output.getValueType() == ValueType.BOOLEAN)
-							basicTensor.set(minValueStr);
+							tensorBlock.set(minValueStr);
 					else {
 						throw new DMLRuntimeException("Rand instruction cannot fill numeric "
 							+ "tensor with non numeric elements.");
@@ -284,15 +284,15 @@ public class DataGenCPInstruction extends UnaryCPInstruction {
 				}
 				else {
 					// TODO random fill tensor
-					lrows = basicTensor.getDim(0);
+					lrows = tensorBlock.getDim(0);
 					lcols = 1;
-					for (int d = 1; d < basicTensor.getNumDims(); d++) {
-						lcols *= basicTensor.getDim(d);
+					for (int d = 1; d < tensorBlock.getNumDims(); d++) {
+						lcols *= tensorBlock.getDim(d);
 					}
 					RandomMatrixGenerator rgen = LibMatrixDatagen.createRandomMatrixGenerator(
 							pdf, (int) lrows, (int) lcols, blocksize, sparsity, minValue, maxValue, pdfParams);
 					soresBlock = MatrixBlock.randOperations(rgen, lSeed, numThreads);
-					basicTensor.set(soresBlock);
+					tensorBlock.set(soresBlock);
 				}
 			} else {
 				RandomMatrixGenerator rgen = LibMatrixDatagen.createRandomMatrixGenerator(
@@ -344,7 +344,7 @@ public class DataGenCPInstruction extends UnaryCPInstruction {
 			ec.setMatrixOutput(output.getName(), soresBlock);
 		} else if(output.isTensor()) {
 			// TODO memory optimization
-			ec.setTensorOutput(output.getName(), basicTensor);
+			ec.setTensorOutput(output.getName(), tensorBlock);
 		} else if( output.isScalar() )
 			ec.setScalarOutput(output.getName(), soresScalar);
 	}

--- a/src/main/java/org/tugraz/sysds/runtime/instructions/cp/ParameterizedBuiltinCPInstruction.java
+++ b/src/main/java/org/tugraz/sysds/runtime/instructions/cp/ParameterizedBuiltinCPInstruction.java
@@ -39,7 +39,7 @@ import org.tugraz.sysds.runtime.controlprogram.caching.FrameObject;
 import org.tugraz.sysds.runtime.controlprogram.caching.MatrixObject;
 import org.tugraz.sysds.runtime.controlprogram.caching.TensorObject;
 import org.tugraz.sysds.runtime.controlprogram.context.ExecutionContext;
-import org.tugraz.sysds.runtime.data.BasicTensor;
+import org.tugraz.sysds.runtime.data.TensorBlock;
 import org.tugraz.sysds.runtime.functionobjects.ParameterizedBuiltin;
 import org.tugraz.sysds.runtime.functionobjects.ValueFunction;
 import org.tugraz.sysds.runtime.instructions.InstructionUtils;
@@ -331,7 +331,7 @@ public class ParameterizedBuiltinCPInstruction extends ComputationCPInstruction 
 				out = DataConverter.toString(matrix, sparse, separator, lineseparator, rows, cols, decimal);
 			}
 			else if( data instanceof TensorObject ) {
-				BasicTensor tensor = (BasicTensor) data.acquireRead();
+				TensorBlock tensor = (TensorBlock) data.acquireRead();
 				// TODO improve truncation to check all dimensions
 				warnOnTrunction(tensor, rows, cols);
 				out = DataConverter.toString(tensor, sparse, separator,
@@ -376,10 +376,10 @@ public class ParameterizedBuiltinCPInstruction extends ComputationCPInstruction 
 		}
 	}
 
-	private void warnOnTrunction(BasicTensor data, int rows, int cols) {
+	private void warnOnTrunction(TensorBlock data, int rows, int cols) {
 		//warn on truncation because users might not be aware and use toString for verification
-		if( (getParam("rows")==null && data.getNumRows()>rows)
-			|| (getParam("cols")==null && data.getNumColumns()>cols) )
+		if( (getParam("rows")==null && data.getDim(0)>rows)
+			|| (getParam("cols")==null && data.getDim(1)>cols) )
 		{
 			StringBuilder sb = new StringBuilder();
 			IntStream.range(0, data.getNumDims()).forEach((i) -> {

--- a/src/main/java/org/tugraz/sysds/runtime/instructions/cp/ReshapeCPInstruction.java
+++ b/src/main/java/org/tugraz/sysds/runtime/instructions/cp/ReshapeCPInstruction.java
@@ -26,7 +26,7 @@ import org.tugraz.sysds.common.Types.ValueType;
 import org.tugraz.sysds.runtime.DMLRuntimeException;
 import org.tugraz.sysds.runtime.controlprogram.context.ExecutionContext;
 import org.tugraz.sysds.runtime.data.LibTensorReorg;
-import org.tugraz.sysds.runtime.data.BasicTensor;
+import org.tugraz.sysds.runtime.data.TensorBlock;
 import org.tugraz.sysds.runtime.instructions.InstructionUtils;
 import org.tugraz.sysds.runtime.matrix.data.LibMatrixReorg;
 import org.tugraz.sysds.runtime.matrix.data.MatrixBlock;
@@ -68,20 +68,20 @@ public class ReshapeCPInstruction extends UnaryCPInstruction {
 	public void processInstruction(ExecutionContext ec) {
 		if (output.getDataType() == Types.DataType.TENSOR) {
 			int[] dims = DataConverter.getTensorDimensions(ec, _opDims);
-			BasicTensor out = new BasicTensor(output.getValueType(), dims);
+			TensorBlock out = new TensorBlock(output.getValueType(), dims);
 			if (input1.getDataType() == Types.DataType.TENSOR) {
 				//get Tensor-data from tensor (reshape)
 				// TODO support DataTensor
-				BasicTensor data = (BasicTensor) ec.getTensorInput(input1.getName());
-				LibTensorReorg.reshape(data, out, dims);
+				TensorBlock data = ec.getTensorInput(input1.getName());
+				LibTensorReorg.reshape(data.getBasicTensor(), out.getBasicTensor(), dims);
 				ec.releaseTensorInput(input1.getName());
 			}
 			else if (input1.getDataType() == Types.DataType.MATRIX) {
-				out.allocateDenseBlock();
+				out.allocateBlock();
 				//get Tensor-data from matrix
 				MatrixBlock data = ec.getMatrixInput(input1.getName());
 				// TODO metadata operation
-				out.set(data);
+				out.getBasicTensor().set(data);
 				ec.releaseMatrixInput(input1.getName());
 			}
 			else {

--- a/src/main/java/org/tugraz/sysds/runtime/instructions/spark/AggregateUnarySPInstruction.java
+++ b/src/main/java/org/tugraz/sysds/runtime/instructions/spark/AggregateUnarySPInstruction.java
@@ -31,7 +31,7 @@ import org.tugraz.sysds.lops.PartialAggregate.CorrectionLocationType;
 import org.tugraz.sysds.runtime.DMLRuntimeException;
 import org.tugraz.sysds.runtime.controlprogram.context.ExecutionContext;
 import org.tugraz.sysds.runtime.controlprogram.context.SparkExecutionContext;
-import org.tugraz.sysds.runtime.data.BasicTensor;
+import org.tugraz.sysds.runtime.data.BasicTensorBlock;
 import org.tugraz.sysds.runtime.data.TensorBlock;
 import org.tugraz.sysds.runtime.data.TensorIndexes;
 import org.tugraz.sysds.runtime.instructions.InstructionUtils;
@@ -168,7 +168,7 @@ public class AggregateUnarySPInstruction extends UnarySPInstruction {
 			//this also includes implicit maintenance of data characteristics
 			// TODO generalize to drop depending on location of correction
 			// TODO support DataTensor
-			BasicTensor out4 = new BasicTensor(((BasicTensor)out3).getValueType(), new int[]{1, 1}, false);
+			TensorBlock out4 = new TensorBlock(out3.getValueType(), new int[]{1, 1});
 			out4.set(0, 0, out3.get(0, 0));
 			sec.setTensorOutput(output.getName(), out4);
 		}
@@ -272,12 +272,12 @@ public class AggregateUnarySPInstruction extends UnarySPInstruction {
 		}
 
 		@Override
-		public BasicTensor call(Tuple2<TensorIndexes, TensorBlock> arg0 )
+		public TensorBlock call(Tuple2<TensorIndexes, TensorBlock> arg0 )
 				throws Exception
 		{
 			//unary aggregate operation (always keep the correction)
 			// TODO support DataTensor
-			return ((BasicTensor)arg0._2).aggregateUnaryOperations(_op, new BasicTensor());
+			return new TensorBlock(arg0._2.getBasicTensor().aggregateUnaryOperations(_op, new BasicTensorBlock()));
 		}
 	}
 
@@ -330,14 +330,14 @@ public class AggregateUnarySPInstruction extends UnarySPInstruction {
 				throws Exception
 		{
 			// TODO support DataTensor
-			BasicTensor blkOut = new BasicTensor();
+			BasicTensorBlock blkOut = new BasicTensorBlock();
 
 			//unary aggregate operation
-			((BasicTensor)arg0).aggregateUnaryOperations(_op, blkOut);
+			arg0.getBasicTensor().aggregateUnaryOperations(_op, blkOut);
 
 			//always drop correction since no aggregation
 			// TODO generalize to drop depending on location of correction
-			BasicTensor out = new BasicTensor(blkOut.getValueType(), new int[]{1, 1}, false);
+			TensorBlock out = new TensorBlock(blkOut.getValueType(), new int[]{1, 1});
 			out.set(0, 0, blkOut.get(0, 0));
 
 			//output new tuple

--- a/src/main/java/org/tugraz/sysds/runtime/instructions/spark/functions/CopyTensorBlockFunction.java
+++ b/src/main/java/org/tugraz/sysds/runtime/instructions/spark/functions/CopyTensorBlockFunction.java
@@ -21,13 +21,13 @@
 package org.tugraz.sysds.runtime.instructions.spark.functions;
 
 import org.apache.spark.api.java.function.Function;
-import org.tugraz.sysds.runtime.data.BasicTensor;
+import org.tugraz.sysds.runtime.data.BasicTensorBlock;
 
 /**
  * General purpose copy function for binary block rdds. This function can be used in
  * mapValues (copy tensor blocks). It supports both deep and shallow copies of values.
  */
-public class CopyTensorBlockFunction implements Function<BasicTensor, BasicTensor> {
+public class CopyTensorBlockFunction implements Function<BasicTensorBlock, BasicTensorBlock> {
 	private static final long serialVersionUID = 707987326466592670L;
 	private boolean _deepCopy;
 
@@ -40,10 +40,10 @@ public class CopyTensorBlockFunction implements Function<BasicTensor, BasicTenso
 	}
 
 	@Override
-	public BasicTensor call(BasicTensor arg0)
+	public BasicTensorBlock call(BasicTensorBlock arg0)
 			throws Exception {
 		if (_deepCopy)
-			return new BasicTensor(arg0);
+			return new BasicTensorBlock(arg0);
 		else
 			return arg0;
 	}

--- a/src/main/java/org/tugraz/sysds/runtime/instructions/spark/functions/CopyTensorBlockPairFunction.java
+++ b/src/main/java/org/tugraz/sysds/runtime/instructions/spark/functions/CopyTensorBlockPairFunction.java
@@ -21,7 +21,7 @@
 package org.tugraz.sysds.runtime.instructions.spark.functions;
 
 import org.apache.spark.api.java.function.PairFlatMapFunction;
-import org.tugraz.sysds.runtime.data.BasicTensor;
+import org.tugraz.sysds.runtime.data.BasicTensorBlock;
 import org.tugraz.sysds.runtime.data.TensorIndexes;
 import org.tugraz.sysds.runtime.instructions.spark.data.LazyIterableIterator;
 import scala.Tuple2;
@@ -33,7 +33,7 @@ import java.util.Iterator;
  * mapToPair (copy tensor indexes and blocks). It supports both deep and shallow copies
  * of key/value pairs.
  */
-public class CopyTensorBlockPairFunction implements PairFlatMapFunction<Iterator<Tuple2<TensorIndexes, BasicTensor>>, TensorIndexes, BasicTensor> {
+public class CopyTensorBlockPairFunction implements PairFlatMapFunction<Iterator<Tuple2<TensorIndexes, BasicTensorBlock>>, TensorIndexes, BasicTensorBlock> {
 
 	private static final long serialVersionUID = 605514365345997070L;
 	private boolean _deepCopy;
@@ -47,24 +47,24 @@ public class CopyTensorBlockPairFunction implements PairFlatMapFunction<Iterator
 	}
 
 	@Override
-	public LazyIterableIterator<Tuple2<TensorIndexes, BasicTensor>> call(Iterator<Tuple2<TensorIndexes, BasicTensor>> arg0)
+	public LazyIterableIterator<Tuple2<TensorIndexes, BasicTensorBlock>> call(Iterator<Tuple2<TensorIndexes, BasicTensorBlock>> arg0)
 			throws Exception {
 		return new CopyBlockPairIterator(arg0);
 	}
 
-	private class CopyBlockPairIterator extends LazyIterableIterator<Tuple2<TensorIndexes, BasicTensor>> {
-		public CopyBlockPairIterator(Iterator<Tuple2<TensorIndexes, BasicTensor>> iter) {
+	private class CopyBlockPairIterator extends LazyIterableIterator<Tuple2<TensorIndexes, BasicTensorBlock>> {
+		public CopyBlockPairIterator(Iterator<Tuple2<TensorIndexes, BasicTensorBlock>> iter) {
 			super(iter);
 		}
 
 		@Override
-		protected Tuple2<TensorIndexes, BasicTensor> computeNext(Tuple2<TensorIndexes, BasicTensor> arg) {
+		protected Tuple2<TensorIndexes, BasicTensorBlock> computeNext(Tuple2<TensorIndexes, BasicTensorBlock> arg) {
 			if (_deepCopy) {
 				TensorIndexes ix = new TensorIndexes(arg._1());
-				BasicTensor block;
+				BasicTensorBlock block;
 				// TODO: always create deep copies in more memory-efficient CSR representation
 				//  if block is already in sparse format
-				block = new BasicTensor(arg._2());
+				block = new BasicTensorBlock(arg._2());
 				return new Tuple2<>(ix, block);
 			} else {
 				return arg;

--- a/src/main/java/org/tugraz/sysds/runtime/instructions/spark/functions/TensorTensorBinaryOpPartitionFunction.java
+++ b/src/main/java/org/tugraz/sysds/runtime/instructions/spark/functions/TensorTensorBinaryOpPartitionFunction.java
@@ -18,7 +18,6 @@
 package org.tugraz.sysds.runtime.instructions.spark.functions;
 
 import org.apache.spark.api.java.function.PairFlatMapFunction;
-import org.tugraz.sysds.runtime.data.BasicTensor;
 import org.tugraz.sysds.runtime.data.TensorBlock;
 import org.tugraz.sysds.runtime.data.TensorIndexes;
 import org.tugraz.sysds.runtime.instructions.spark.data.LazyIterableIterator;
@@ -76,7 +75,7 @@ public class TensorTensorBinaryOpPartitionFunction implements PairFlatMapFunctio
 			TensorBlock in2 = _ptV.getBlock(index);
 
 			//execute the binary operation
-			TensorBlock ret = in1.binaryOperations(_op, in2, new BasicTensor());
+			TensorBlock ret = in1.binaryOperations(_op, in2, new TensorBlock());
 			return new Tuple2<>(ix, ret);
 		}
 	}

--- a/src/main/java/org/tugraz/sysds/runtime/instructions/spark/utils/RDDAggregateUtils.java
+++ b/src/main/java/org/tugraz/sysds/runtime/instructions/spark/utils/RDDAggregateUtils.java
@@ -1,4 +1,6 @@
 /*
+ * Modifications Copyright 2019 Graz University of Technology
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -25,7 +27,6 @@ import org.apache.spark.api.java.function.Function;
 import org.apache.spark.api.java.function.Function2;
 import org.tugraz.sysds.lops.PartialAggregate.CorrectionLocationType;
 import org.tugraz.sysds.runtime.DMLRuntimeException;
-import org.tugraz.sysds.runtime.data.BasicTensor;
 import org.tugraz.sysds.runtime.data.TensorBlock;
 import org.tugraz.sysds.runtime.data.TensorIndexes;
 import org.tugraz.sysds.runtime.functionobjects.KahanPlus;
@@ -176,7 +177,7 @@ public class RDDAggregateUtils
 		//reduce-all aggregate via fold instead of reduce to allow
 		//for update in-place w/o deep copy of left-hand-side blocks
 		return in.fold(
-				new BasicTensor(),
+				new TensorBlock(),
 				new AggregateSingleTensorBlockFunction(aop) );
 	}
 	public static JavaPairRDD<MatrixIndexes, MatrixBlock> aggByKeyStable( JavaPairRDD<MatrixIndexes, MatrixBlock> in,
@@ -679,7 +680,7 @@ public class RDDAggregateUtils
 
 			//aggregate second input (in-place)
 			// TODO support DataTensor
-			((BasicTensor)arg0).incrementalAggregate(_op, (BasicTensor)arg1);
+			arg0.getBasicTensor().incrementalAggregate(_op, arg1.getBasicTensor());
 
 			return arg0;
 		}

--- a/src/main/java/org/tugraz/sysds/runtime/instructions/spark/utils/SparkUtils.java
+++ b/src/main/java/org/tugraz/sysds/runtime/instructions/spark/utils/SparkUtils.java
@@ -34,7 +34,7 @@ import org.tugraz.sysds.lops.Checkpoint;
 import org.tugraz.sysds.runtime.controlprogram.context.SparkExecutionContext;
 import org.tugraz.sysds.runtime.controlprogram.parfor.stat.InfrastructureAnalyzer;
 import org.tugraz.sysds.runtime.data.IndexedTensorBlock;
-import org.tugraz.sysds.runtime.data.BasicTensor;
+import org.tugraz.sysds.runtime.data.BasicTensorBlock;
 import org.tugraz.sysds.runtime.data.TensorBlock;
 import org.tugraz.sysds.runtime.data.TensorIndexes;
 import org.tugraz.sysds.runtime.instructions.spark.functions.CopyBinaryCellFunction;
@@ -175,8 +175,8 @@ public class SparkUtils
 	 * @param in tensor as {@code JavaPairRDD<TensorIndexes,HomogTensor>}
 	 * @return tensor as {@code JavaPairRDD<TensorIndexes,HomogTensor>}
 	 */
-	public static JavaPairRDD<TensorIndexes, BasicTensor> copyBinaryBlockTensor(
-			JavaPairRDD<TensorIndexes, BasicTensor> in) {
+	public static JavaPairRDD<TensorIndexes, BasicTensorBlock> copyBinaryBlockTensor(
+			JavaPairRDD<TensorIndexes, BasicTensorBlock> in) {
 		return copyBinaryBlockTensor(in, true);
 	}
 
@@ -188,8 +188,8 @@ public class SparkUtils
 	 * @param deep if true, perform deep copy
 	 * @return tensor as {@code JavaPairRDD<TensorIndexes,HomogTensor>}
 	 */
-	public static JavaPairRDD<TensorIndexes, BasicTensor> copyBinaryBlockTensor(
-			JavaPairRDD<TensorIndexes, BasicTensor> in, boolean deep) {
+	public static JavaPairRDD<TensorIndexes, BasicTensorBlock> copyBinaryBlockTensor(
+			JavaPairRDD<TensorIndexes, BasicTensorBlock> in, boolean deep) {
 		if (!deep) //pass through of indexes and blocks
 			return in.mapValues(new CopyTensorBlockFunction(false));
 		else //requires key access, so use mappartitions

--- a/src/main/java/org/tugraz/sysds/runtime/io/ReaderTextCell.java
+++ b/src/main/java/org/tugraz/sysds/runtime/io/ReaderTextCell.java
@@ -166,7 +166,7 @@ public class ReaderTextCell extends MatrixReader
 	}
 	
 	protected static IJV parseCell(String line, FastStringTokenizer st, IJV cell, FileFormatPropertiesMM mmProps) {
-		st.reset( line.toString() ); //reinit tokenizer
+		st.reset( line ); //reinit tokenizer
 		int row = st.nextInt() - 1;
 		int col = st.nextInt() - 1;
 		double value = (mmProps == null) ? st.nextDouble() : 

--- a/src/main/java/org/tugraz/sysds/runtime/io/TensorReader.java
+++ b/src/main/java/org/tugraz/sysds/runtime/io/TensorReader.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 Graz University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.tugraz.sysds.runtime.io;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.tugraz.sysds.common.Types.ValueType;
+import org.tugraz.sysds.runtime.DMLRuntimeException;
+import org.tugraz.sysds.runtime.data.TensorBlock;
+import org.tugraz.sysds.runtime.util.HDFSTool;
+
+import java.io.EOFException;
+import java.io.IOException;
+
+public abstract class TensorReader {
+	public abstract TensorBlock readTensorFromHDFS(String fname, long[] dims, int blen, ValueType[] schema)
+			throws IOException, DMLRuntimeException;
+
+	protected static void checkValidInputFile(FileSystem fs, Path path)
+			throws IOException {
+		//check non-existing file
+		if (!fs.exists(path))
+			throw new IOException("File " + path.toString() + " does not exist on HDFS/LFS.");
+
+		//check for empty file
+		if (HDFSTool.isFileEmpty(fs, path))
+			throw new EOFException("Empty input file " + path.toString() + ".");
+	}
+}

--- a/src/main/java/org/tugraz/sysds/runtime/io/TensorReaderBinaryBlock.java
+++ b/src/main/java/org/tugraz/sysds/runtime/io/TensorReaderBinaryBlock.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2019 Graz University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.tugraz.sysds.runtime.io;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.SequenceFile;
+import org.apache.hadoop.mapred.JobConf;
+import org.tugraz.sysds.common.Types.ValueType;
+import org.tugraz.sysds.conf.ConfigurationManager;
+import org.tugraz.sysds.runtime.DMLRuntimeException;
+import org.tugraz.sysds.runtime.data.TensorBlock;
+import org.tugraz.sysds.runtime.data.TensorIndexes;
+import org.tugraz.sysds.runtime.util.UtilFunctions;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+public class TensorReaderBinaryBlock extends TensorReader {
+	@Override
+	public TensorBlock readTensorFromHDFS(String fname, long[] dims,
+			int blen, ValueType[] schema) throws IOException, DMLRuntimeException {
+		//prepare file access
+		JobConf job = new JobConf(ConfigurationManager.getCachedJobConf());
+		Path path = new Path(fname);
+		FileSystem fs = IOUtilFunctions.getFileSystem(path, job);
+
+		//check existence and non-empty file
+		checkValidInputFile(fs, path);
+
+		//core read
+		return readBinaryBlockTensorFromHDFS(path, job, fs, dims, blen, schema);
+	}
+
+	private TensorBlock readBinaryBlockTensorFromHDFS(Path path, JobConf job, FileSystem fs, long[] dims,
+			int blen, ValueType[] schema) throws IOException {
+		int[] idims = Arrays.stream(dims).mapToInt(i -> (int) i).toArray();
+		TensorBlock ret;
+		if (schema.length == 1)
+			ret = new TensorBlock(schema[0], idims).allocateBlock();
+		else
+			ret = new TensorBlock(schema, idims).allocateBlock();
+		TensorIndexes key = new TensorIndexes();
+		// TODO reuse blocks
+
+		for (Path lpath : IOUtilFunctions.getSequenceFilePaths(fs, path)) {
+			SequenceFile.Reader reader = new SequenceFile.Reader(job, SequenceFile.Reader.file(lpath));
+			TensorBlock value = new TensorBlock();
+
+			try {
+				while (reader.next(key, value)) {
+					if (value.isEmpty(false))
+						continue;
+
+					int[] lower = new int[dims.length];
+					int[] upper = new int[lower.length];
+					UtilFunctions.getBlockBounds(key, dims, blen, lower, upper);
+
+					ret.copy(lower, upper, value);
+				}
+			}
+			finally {
+				IOUtilFunctions.closeSilently(reader);
+			}
+		}
+		return ret;
+	}
+}

--- a/src/main/java/org/tugraz/sysds/runtime/io/TensorReaderBinaryBlock.java
+++ b/src/main/java/org/tugraz/sysds/runtime/io/TensorReaderBinaryBlock.java
@@ -69,7 +69,7 @@ public class TensorReaderBinaryBlock extends TensorReader {
 
 					int[] lower = new int[dims.length];
 					int[] upper = new int[lower.length];
-					UtilFunctions.getBlockBounds(key, dims, blen, lower, upper);
+					UtilFunctions.getBlockBounds(key, value.getLongDims(), blen, lower, upper);
 
 					ret.copy(lower, upper, value);
 				}

--- a/src/main/java/org/tugraz/sysds/runtime/io/TensorReaderFactory.java
+++ b/src/main/java/org/tugraz/sysds/runtime/io/TensorReaderFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 Graz University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.tugraz.sysds.runtime.io;
+
+import org.tugraz.sysds.runtime.DMLRuntimeException;
+import org.tugraz.sysds.runtime.matrix.data.InputInfo;
+
+public class TensorReaderFactory {
+
+	public static TensorReader createTensorReader(InputInfo iinfo) {
+		TensorReader reader;
+
+		if (iinfo == InputInfo.TextCellInputInfo) {
+			reader = new TensorReaderTextCell();
+		}
+		else if (iinfo == InputInfo.BinaryBlockInputInfo) {
+			reader = new TensorReaderBinaryBlock();
+		}
+		else {
+			throw new DMLRuntimeException("Failed to create tensor reader for unknown output info: "
+					+ InputInfo.inputInfoToString(iinfo));
+		}
+		return reader;
+	}
+}

--- a/src/main/java/org/tugraz/sysds/runtime/io/TensorReaderTextCell.java
+++ b/src/main/java/org/tugraz/sysds/runtime/io/TensorReaderTextCell.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2019 Graz University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.tugraz.sysds.runtime.io;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapred.FileInputFormat;
+import org.apache.hadoop.mapred.InputSplit;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.RecordReader;
+import org.apache.hadoop.mapred.Reporter;
+import org.apache.hadoop.mapred.TextInputFormat;
+import org.tugraz.sysds.common.Types.ValueType;
+import org.tugraz.sysds.conf.ConfigurationManager;
+import org.tugraz.sysds.runtime.DMLRuntimeException;
+import org.tugraz.sysds.runtime.data.TensorBlock;
+import org.tugraz.sysds.runtime.util.FastStringTokenizer;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+public class TensorReaderTextCell extends TensorReader {
+
+	@Override
+	public TensorBlock readTensorFromHDFS(String fname, long[] dims,
+			int blen, ValueType[] schema) throws IOException, DMLRuntimeException {
+		//prepare file access
+		JobConf job = new JobConf(ConfigurationManager.getCachedJobConf());
+		Path path = new Path(fname);
+		FileSystem fs = IOUtilFunctions.getFileSystem(path, job);
+
+		//check existence and non-empty file
+		checkValidInputFile(fs, path);
+
+		//allocate output matrix block
+		return readTextCellTensorFromHDFS(path, job, dims, schema);
+	}
+
+	private TensorBlock readTextCellTensorFromHDFS(Path path, JobConf job, long[] dims, ValueType[] schema) throws IOException {
+		FileInputFormat.addInputPath(job, path);
+		TextInputFormat informat = new TextInputFormat();
+		informat.configure(job);
+		InputSplit[] splits = informat.getSplits(job, 1);
+
+		LongWritable key = new LongWritable();
+		Text value = new Text();
+		int[] idims = Arrays.stream(dims).mapToInt(i -> (int) i).toArray();
+		TensorBlock ret;
+		if (schema.length == 1)
+			ret = new TensorBlock(schema[0], idims).allocateBlock();
+		else
+			ret = new TensorBlock(schema, idims).allocateBlock();
+
+		try {
+			FastStringTokenizer st = new FastStringTokenizer(' ');
+			
+			int[] ix = new int[dims.length];
+			for (InputSplit split : splits) {
+				RecordReader<LongWritable, Text> reader = informat.getRecordReader(split, job, Reporter.NULL);
+				try {
+					while (reader.next(key, value)) {
+						st.reset(value.toString());
+						for (int i = 0; i < ix.length; i++) {
+							ix[i] = st.nextInt() - 1;
+						}
+						ret.set(ix, st.nextToken());
+					}
+				}
+				finally {
+					IOUtilFunctions.closeSilently(reader);
+				}
+			}
+		}
+		catch (Exception ex) {
+			throw new IOException("Unable to read tensor in text cell format.", ex);
+		}
+		return ret;
+	}
+}

--- a/src/main/java/org/tugraz/sysds/runtime/io/TensorWriter.java
+++ b/src/main/java/org/tugraz/sysds/runtime/io/TensorWriter.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 Graz University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.tugraz.sysds.runtime.io;
+
+import org.tugraz.sysds.runtime.data.TensorBlock;
+
+import java.io.IOException;
+
+public abstract class TensorWriter {
+	public abstract void writeTensorToHDFS(TensorBlock src, String fname, long[] dims, int blen) throws IOException;
+}

--- a/src/main/java/org/tugraz/sysds/runtime/io/TensorWriterBinaryBlock.java
+++ b/src/main/java/org/tugraz/sysds/runtime/io/TensorWriterBinaryBlock.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2019 Graz University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.tugraz.sysds.runtime.io;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.SequenceFile;
+import org.apache.hadoop.mapred.JobConf;
+import org.tugraz.sysds.conf.ConfigurationManager;
+import org.tugraz.sysds.runtime.data.TensorBlock;
+import org.tugraz.sysds.runtime.data.TensorIndexes;
+import org.tugraz.sysds.runtime.matrix.mapred.MRJobConfiguration;
+import org.tugraz.sysds.runtime.util.HDFSTool;
+
+import java.io.IOException;
+
+public class TensorWriterBinaryBlock extends TensorWriter {
+	//TODO replication
+
+	@Override
+	public void writeTensorToHDFS(TensorBlock src, String fname, long[] dims, int blen) throws IOException {
+		//prepare file access
+		JobConf job = new JobConf(ConfigurationManager.getCachedJobConf());
+		Path path = new Path(fname);
+		FileSystem fs = IOUtilFunctions.getFileSystem(path, job);
+
+		//if the file already exists on HDFS, remove it.
+		HDFSTool.deleteFileIfExistOnHDFS(fname);
+
+		//set up preferred custom serialization framework for binary block format
+		if (MRJobConfiguration.USE_BINARYBLOCK_SERIALIZATION)
+			MRJobConfiguration.addBinaryBlockSerializationFramework(job);
+
+		//core write sequential
+		writeBinaryBlockMatrixToHDFS(path, job, fs, src, dims, blen);
+
+		IOUtilFunctions.deleteCrcFilesFromLocalFileSystem(fs, path);
+	}
+
+	@SuppressWarnings("deprecation")
+	private void writeBinaryBlockMatrixToHDFS(Path path, JobConf job, FileSystem fs, TensorBlock src, long[] dims,
+			int blen) throws IOException {
+		SequenceFile.Writer writer = new SequenceFile.Writer(fs, job, path, TensorIndexes.class, TensorBlock.class);
+
+		try {
+			// bound check
+			for (int i = 0; i < dims.length; i++) {
+				if (src.getDim(i) > dims[i])
+					throw new IOException("TensorBlock dimension " + i + " range [1:" + src.getDim(i) +
+							"] out of range [1:" + dims[i] + "].");
+			}
+			long numBlocks = 1;
+			for (long dim : dims) {
+				numBlocks *= Math.max((long) Math.ceil((double) dim / blen), 1);
+			}
+
+			for (int i = 0; i < numBlocks; i++) {
+				int[] offsets = new int[dims.length];
+				long blockIndex = i;
+				long[] tix = new long[dims.length];
+				int[] blockDims = new int[dims.length];
+				for (int j = dims.length - 1; j >= 0; j--) {
+					long numDimBlocks = Math.max((long) Math.ceil((double)src.getDim(j) / blen), 1);
+					tix[j] = 1 + (blockIndex % numDimBlocks);
+					blockIndex /= numDimBlocks;
+					offsets[j] = ((int) tix[j] - 1) * blen;
+					blockDims[j] = (tix[j] * blen < src.getDim(j)) ? blen : src.getDim(j) - offsets[j];
+				}
+				TensorIndexes indx = new TensorIndexes(tix);
+				TensorBlock block;
+				if (!src.isBasic())
+					block = new TensorBlock(src.getSchema(), blockDims).allocateBlock();
+				else
+					block = new TensorBlock(src.getValueType(), blockDims).allocateBlock();
+
+				//copy submatrix to block
+				src.slice(offsets, block);
+
+				writer.append(indx, block);
+			}
+		}
+		finally {
+			IOUtilFunctions.closeSilently(writer);
+		}
+	}
+}

--- a/src/main/java/org/tugraz/sysds/runtime/io/TensorWriterFactory.java
+++ b/src/main/java/org/tugraz/sysds/runtime/io/TensorWriterFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 Graz University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.tugraz.sysds.runtime.io;
+
+import org.tugraz.sysds.runtime.DMLRuntimeException;
+import org.tugraz.sysds.runtime.matrix.data.OutputInfo;
+
+public class TensorWriterFactory {
+
+	public static TensorWriter createTensorWriter(OutputInfo oinfo) {
+		TensorWriter writer;
+
+		if (oinfo == OutputInfo.TextCellOutputInfo) {
+			writer = new TensorWriterTextCell();
+		}
+		else if (oinfo == OutputInfo.BinaryBlockOutputInfo) {
+			writer = new TensorWriterBinaryBlock();
+		}
+		else {
+			throw new DMLRuntimeException("Failed to create tensor writer for unknown output info: "
+					+ OutputInfo.outputInfoToString(oinfo));
+		}
+		return writer;
+	}
+}

--- a/src/main/java/org/tugraz/sysds/runtime/io/TensorWriterTextCell.java
+++ b/src/main/java/org/tugraz/sysds/runtime/io/TensorWriterTextCell.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2019 Graz University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.tugraz.sysds.runtime.io;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapred.JobConf;
+import org.tugraz.sysds.conf.ConfigurationManager;
+import org.tugraz.sysds.runtime.data.TensorBlock;
+import org.tugraz.sysds.runtime.util.HDFSTool;
+import org.tugraz.sysds.runtime.util.UtilFunctions;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+
+public class TensorWriterTextCell extends TensorWriter {
+	@Override
+	public void writeTensorToHDFS(TensorBlock src, String fname, long[] dims, int blen) throws IOException {
+		//validity check matrix dimensions
+		if (src.getNumDims() != dims.length)
+			throw new IOException("Tensor number of dimensions mismatch with metadata: " + src.getNumDims() + " vs " + dims.length);
+		for (int i = 0; i < dims.length; i++) {
+			if (dims[i] != src.getDim(i))
+				throw new IOException("Tensor dimension (" + (i + 1) + ") mismatch with metadata: " + src.getDim(i) + " vs " + dims[i]);
+		}
+
+		//prepare file access
+		JobConf job = new JobConf(ConfigurationManager.getCachedJobConf());
+		Path path = new Path(fname);
+		FileSystem fs = IOUtilFunctions.getFileSystem(path, job);
+
+		//if the file already exists on HDFS, remove it.
+		HDFSTool.deleteFileIfExistOnHDFS(fname);
+
+		//core write
+		writeTextCellTensorToHDFS(path, fs, src, dims);
+
+		IOUtilFunctions.deleteCrcFilesFromLocalFileSystem(fs, path);
+	}
+
+	private static void writeTextCellTensorToHDFS(Path path, FileSystem fs, TensorBlock src,
+			long[] dims) throws IOException {
+		try (BufferedWriter br = new BufferedWriter(new OutputStreamWriter(fs.create(path, true)))) {
+			//for obj reuse and preventing repeated buffer re-allocations
+			StringBuilder sb = new StringBuilder();
+
+			int[] ix = new int[dims.length];
+			for (long i = 0; i < src.getLength(); i++) {
+				Object obj = src.get(ix);
+				boolean skip;
+				if (!src.isBasic())
+					skip = UtilFunctions.objectToDouble(src.getSchema()[ix[1]], obj) == 0.0;
+				else
+					skip = UtilFunctions.objectToDouble(src.getValueType(), obj) == 0.0;
+				if (!skip) {
+					for (int j : ix)
+						sb.append(j + 1).append(' ');
+					sb.append(src.get(ix)).append('\n');
+					br.write(sb.toString());
+					sb.setLength(0);
+				}
+				src.getNextIndexes(ix);
+			}
+
+			//handle empty result
+			if (src.isEmpty(false)) {
+				for (int i = 0; i < dims.length; i++)
+					sb.append(0).append(' ');
+				sb.append(0).append('\n');
+				br.write(sb.toString());
+			}
+		}
+	}
+}

--- a/src/main/java/org/tugraz/sysds/runtime/meta/DataCharacteristics.java
+++ b/src/main/java/org/tugraz/sysds/runtime/meta/DataCharacteristics.java
@@ -103,7 +103,15 @@ public abstract class DataCharacteristics implements Serializable {
 	}
 
 	public long[] getDims() {
-		throw new DMLRuntimeException("DataCharacteristics.getDims(): should never get called in the base class");
+		return getLongDims();
+	}
+
+	public long[] getLongDims() {
+		throw new DMLRuntimeException("DataCharacteristics.getLongDims(): should never get called in the base class");
+	}
+
+	public int[] getIntDims() {
+		throw new DMLRuntimeException("DataCharacteristics.getIntDims(): should never get called in the base class");
 	}
 
 	public TensorCharacteristics setDim(int i, long dim) {

--- a/src/main/java/org/tugraz/sysds/runtime/meta/MatrixCharacteristics.java
+++ b/src/main/java/org/tugraz/sysds/runtime/meta/MatrixCharacteristics.java
@@ -23,6 +23,7 @@
 package org.tugraz.sysds.runtime.meta;
 
 import org.tugraz.sysds.hops.OptimizerUtils;
+import org.tugraz.sysds.runtime.DMLRuntimeException;
 import org.tugraz.sysds.runtime.matrix.data.MatrixBlock;
 
 import java.util.Arrays;
@@ -133,6 +134,30 @@ public class MatrixCharacteristics extends DataCharacteristics
 	}
 	
 	@Override
+	public long getDim(int i) {
+		if (i == 0)
+			return numRows;
+		else if (i == 1)
+			return numColumns;
+		throw new DMLRuntimeException("Matrices have only 2 dimensions");
+	}
+	
+	@Override
+	public long[] getLongDims() {
+		return new long[]{numRows, numColumns};
+	}
+	
+	@Override
+	public int[] getIntDims() {
+		return new int[]{(int) numRows, (int) numColumns};
+	}
+	
+	@Override
+	public int getNumDims() {
+		return 2;
+	}
+	
+	@Override
 	public void setNonZeros(long nnz) {
 		ubNnz = false;
 		nonZero = nnz;
@@ -193,7 +218,7 @@ public class MatrixCharacteristics extends DataCharacteristics
 
 	@Override
 	public boolean mightHaveEmptyBlocks() {
-		long singleBlk = Math.max(Math.min(numRows, _blocksize),1) 
+		long singleBlk = Math.max(Math.min(numRows, _blocksize),1)
 				* Math.max(Math.min(numColumns, _blocksize),1);
 		return !nnzKnown() || numRows==0 || numColumns==0
 			|| (nonZero < numRows*numColumns - singleBlk);

--- a/src/main/java/org/tugraz/sysds/runtime/meta/TensorCharacteristics.java
+++ b/src/main/java/org/tugraz/sysds/runtime/meta/TensorCharacteristics.java
@@ -26,6 +26,7 @@ public class TensorCharacteristics extends DataCharacteristics
 {
 	private static final long serialVersionUID = 8300479822915546000L;
 
+	// TODO move block size to `ConfigurationManager`
 	public static final int[] DEFAULT_BLOCK_SIZE = {1024, 128, 32, 16, 8, 8};
 	private long[] _dims;
 	private long _nnz = -1;
@@ -103,8 +104,13 @@ public class TensorCharacteristics extends DataCharacteristics
 	}
 
 	@Override
-	public long[] getDims() {
+	public long[] getLongDims() {
 		return _dims;
+	}
+
+	@Override
+	public int[] getIntDims() {
+		return Arrays.stream(getLongDims()).mapToInt(i -> (int) i).toArray();
 	}
 
 	@Override

--- a/src/main/java/org/tugraz/sysds/runtime/util/DataConverter.java
+++ b/src/main/java/org/tugraz/sysds/runtime/util/DataConverter.java
@@ -31,9 +31,9 @@ import org.tugraz.sysds.runtime.DMLRuntimeException;
 import org.tugraz.sysds.runtime.controlprogram.context.ExecutionContext;
 import org.tugraz.sysds.runtime.data.DenseBlock;
 import org.tugraz.sysds.runtime.data.DenseBlockFactory;
-import org.tugraz.sysds.runtime.data.DataTensor;
+import org.tugraz.sysds.runtime.data.DataTensorBlock;
 import org.tugraz.sysds.runtime.data.SparseBlock;
-import org.tugraz.sysds.runtime.data.BasicTensor;
+import org.tugraz.sysds.runtime.data.BasicTensorBlock;
 import org.tugraz.sysds.runtime.data.TensorBlock;
 import org.tugraz.sysds.runtime.instructions.cp.BooleanObject;
 import org.tugraz.sysds.runtime.instructions.cp.CPOperand;
@@ -46,6 +46,10 @@ import org.tugraz.sysds.runtime.io.MatrixReaderFactory;
 import org.tugraz.sysds.runtime.io.MatrixWriter;
 import org.tugraz.sysds.runtime.io.MatrixWriterFactory;
 import org.tugraz.sysds.runtime.io.ReadProperties;
+import org.tugraz.sysds.runtime.io.TensorReader;
+import org.tugraz.sysds.runtime.io.TensorReaderFactory;
+import org.tugraz.sysds.runtime.io.TensorWriter;
+import org.tugraz.sysds.runtime.io.TensorWriterFactory;
 import org.tugraz.sysds.runtime.matrix.data.CTableMap;
 import org.tugraz.sysds.runtime.matrix.data.FrameBlock;
 import org.tugraz.sysds.runtime.matrix.data.IJV;
@@ -98,7 +102,15 @@ public class DataConverter
 		writer.writeMatrixToHDFS(mat, dir, dc.getRows(), dc.getCols(), dc.getBlocksize(), dc.getNonZeros(), diag);
 	}
 
-	public static MatrixBlock readMatrixFromHDFS(String dir, InputInfo inputinfo, long rlen, long clen, int blen, boolean localFS) 
+	public static void writeTensorToHDFS(TensorBlock tensor, String dir, OutputInfo outputinfo, DataCharacteristics dc)
+			throws IOException {
+		TensorWriter writer = TensorWriterFactory.createTensorWriter(outputinfo);
+		long[] dims = dc.getDims();
+		int blen = dc.getBlocksize();
+		writer.writeTensorToHDFS(tensor, dir, dims, blen);
+	}
+
+	public static MatrixBlock readMatrixFromHDFS(String dir, InputInfo inputinfo, long rlen, long clen, int blen, boolean localFS)
 		throws IOException
 	{	
 		ReadProperties prop = new ReadProperties();
@@ -113,7 +125,7 @@ public class DataConverter
 		return readMatrixFromHDFS(prop);
 	}
 
-	public static MatrixBlock readMatrixFromHDFS(String dir, InputInfo inputinfo, long rlen, long clen, int blen) 
+	public static MatrixBlock readMatrixFromHDFS(String dir, InputInfo inputinfo, long rlen, long clen, int blen)
 		throws IOException
 	{	
 		ReadProperties prop = new ReadProperties();
@@ -127,7 +139,7 @@ public class DataConverter
 		return readMatrixFromHDFS(prop);
 	}
 
-	public static MatrixBlock readMatrixFromHDFS(String dir, InputInfo inputinfo, long rlen, long clen, int blen, long expectedNnz) 
+	public static MatrixBlock readMatrixFromHDFS(String dir, InputInfo inputinfo, long rlen, long clen, int blen, long expectedNnz)
 		throws IOException
 	{
 		ReadProperties prop = new ReadProperties();
@@ -143,7 +155,7 @@ public class DataConverter
 	}
 
 	public static MatrixBlock readMatrixFromHDFS(String dir, InputInfo inputinfo, long rlen, long clen, 
-			int blen, long expectedNnz, boolean localFS) 
+			int blen, long expectedNnz, boolean localFS)
 		throws IOException
 	{
 		ReadProperties prop = new ReadProperties();
@@ -160,7 +172,7 @@ public class DataConverter
 	}
 
 	public static MatrixBlock readMatrixFromHDFS(String dir, InputInfo inputinfo, long rlen, long clen, 
-			int blen, long expectedNnz, FileFormatProperties formatProperties) 
+			int blen, long expectedNnz, FileFormatProperties formatProperties)
 	throws IOException
 	{
 		ReadProperties prop = new ReadProperties();
@@ -174,6 +186,20 @@ public class DataConverter
 		prop.formatProperties = formatProperties;
 		
 		return readMatrixFromHDFS(prop);
+	}
+
+	public static TensorBlock readTensorFromHDFS(String dir, InputInfo inputinfo, long[] dims, int blen,
+			ValueType[] schema) throws IOException {
+		TensorBlock ret;
+		try {
+			TensorReader reader = TensorReaderFactory.createTensorReader(inputinfo);
+			ret = reader.readTensorFromHDFS(dir, dims, blen, schema);
+		}
+		catch(DMLRuntimeException rex)
+		{
+			throw new IOException(rex);
+		}
+		return ret;
 	}
 	
 	/**
@@ -735,16 +761,11 @@ public class DataConverter
 	
 	public static TensorBlock convertToTensorBlock(MatrixBlock mb, ValueType vt, boolean toBasicTensor) {
 		TensorBlock ret;
-		if (toBasicTensor) {
-			BasicTensor bt = new BasicTensor(vt, new int[] {mb.getNumRows(), mb.getNumColumns()});
-			bt.allocateDenseBlock(true);
-			ret = bt;
-		}
-		else {
-			DataTensor dt = new DataTensor(vt, new int[] {mb.getNumRows(), mb.getNumColumns()});
-			dt.allocateBlock();
-			ret = dt;
-		}
+		if (toBasicTensor)
+			ret = new TensorBlock(new BasicTensorBlock(vt, new int[] {mb.getNumRows(), mb.getNumColumns()}, false));
+		else
+			ret = new TensorBlock(new DataTensorBlock(vt, new int[] {mb.getNumRows(), mb.getNumColumns()}));
+		ret.allocateBlock();
 		if( mb.getNonZeros() > 0 ) {
 			if( mb.isInSparseFormat() ) {
 				Iterator<IJV> iter = mb.getSparseBlockIterator();
@@ -972,8 +993,8 @@ public class DataConverter
 		return sb.toString();
 	}
 
-	public static String toString(BasicTensor mb) {
-		return toString(mb, false, " ", "\n", "[", "]", mb.getNumRows(), mb.getNumColumns(), 3);
+	public static String toString(TensorBlock tb) {
+		return toString(tb, false, " ", "\n", "[", "]", tb.getDim(0), tb.getDim(1), 3);
 	}
 
 	/**
@@ -990,13 +1011,13 @@ public class DataConverter
 	 * @param decimal number of decimal places to print, -1 for default
 	 * @return tensor as a string
 	 */
-	public static String toString(BasicTensor tb, boolean sparse, String separator, String lineseparator,
+	public static String toString(TensorBlock tb, boolean sparse, String separator, String lineseparator,
 	                              String leftBorder, String rightBorder, int rowsToPrint, int colsToPrint, int decimal){
 		StringBuilder sb = new StringBuilder();
 
 		// Setup number of rows and columns to print
-		int rlen = tb.getNumRows();
-		int clen = tb.getNumColumns();
+		int rlen = tb.getDim(0);
+		int clen = tb.getDim(1);
 		int rowLength = rlen;
 		int colLength = clen;
 		if (rowsToPrint >= 0)
@@ -1022,7 +1043,7 @@ public class DataConverter
 					concatenateTensorValue(tb, sb, df, ix);
 					sb.append(lineseparator);
 				}
-				tb.getNextIndexes(ix);
+				TensorBlock.getNextIndexes(tb.getDims(), ix);
 				if (ix[0] >= rowLength) {
 					break;
 				}
@@ -1083,7 +1104,7 @@ public class DataConverter
 	 * @param df DecimalFormat with the correct settings for double or float values
 	 * @param ix the index of the TensorBlock value
 	 */
-	private static void concatenateTensorValue(BasicTensor tb, StringBuilder sb, DecimalFormat df, int[] ix) {
+	private static void concatenateTensorValue(TensorBlock tb, StringBuilder sb, DecimalFormat df, int[] ix) {
 		switch (tb.getValueType()) {
 			case FP32:
 				Float valuef = (Float) tb.get(ix);
@@ -1279,7 +1300,7 @@ public class DataConverter
 	public static double[] toDouble(String[] data) {
 		double[] ret = new double[data.length];
 		for(int i=0; i<data.length; i++)
-			ret[i] = Double.parseDouble(data[i]);
+			ret[i] = data[i] == null || data[i].isEmpty() ? 0 : Double.parseDouble(data[i]);
 		return ret;
 	}
 

--- a/src/main/java/org/tugraz/sysds/runtime/util/HDFSTool.java
+++ b/src/main/java/org/tugraz/sysds/runtime/util/HDFSTool.java
@@ -447,8 +447,8 @@ public class HDFSTool
 
 		return mtd.toString(4); // indent with 4 spaces	
 	}
-	
-	public static double[][] readMatrixFromHDFS(String dir, InputInfo inputinfo, long rlen, long clen, int blen) 
+
+	public static double[][] readMatrixFromHDFS(String dir, InputInfo inputinfo, long rlen, long clen, int blen)
 		throws IOException, DMLRuntimeException
 	{
 		MatrixReader reader = MatrixReaderFactory.createMatrixReader(inputinfo);
@@ -457,7 +457,7 @@ public class HDFSTool
 		return DataConverter.convertToDoubleMatrix(mb);
 	}
 	
-	public static double[] readColumnVectorFromHDFS(String dir, InputInfo inputinfo, long rlen, long clen, int blen) 
+	public static double[] readColumnVectorFromHDFS(String dir, InputInfo inputinfo, long rlen, long clen, int blen)
 		throws IOException, DMLRuntimeException
 	{
 		MatrixReader reader = MatrixReaderFactory.createMatrixReader(inputinfo);

--- a/src/main/java/org/tugraz/sysds/runtime/util/UtilFunctions.java
+++ b/src/main/java/org/tugraz/sysds/runtime/util/UtilFunctions.java
@@ -34,6 +34,7 @@ import org.apache.commons.math3.random.RandomDataGenerator;
 import org.tugraz.sysds.common.Types.ValueType;
 import org.tugraz.sysds.runtime.DMLRuntimeException;
 import org.tugraz.sysds.runtime.data.SparseBlock;
+import org.tugraz.sysds.runtime.data.TensorIndexes;
 import org.tugraz.sysds.runtime.matrix.data.FrameBlock;
 import org.tugraz.sysds.runtime.matrix.data.MatrixIndexes;
 import org.tugraz.sysds.runtime.matrix.data.Pair;
@@ -729,5 +730,21 @@ public class UtilFunctions
 		for(int i=off; i<arr.length; i++)
 			ret *= arr[i];
 		return ret;
+	}
+
+	public static void getBlockBounds(TensorIndexes ix, long[] dims, int blen, int[] lower, int[] upper) {
+		for (int i = 0; i < dims.length; i++) {
+			lower[i] = (int) (ix.getIndex(i) - 1) * blen;
+			upper[i] = (int) (lower[i] + dims[i] - 1);
+		}
+		upper[upper.length - 1]++;
+		for (int i = upper.length - 1; i > 0; i--) {
+			if (upper[i] == dims[i]) {
+				upper[i] = 0;
+				upper[i - 1]++;
+			}
+			else
+				break;
+		}
 	}
 }

--- a/src/test/java/org/tugraz/sysds/test/TestUtils.java
+++ b/src/test/java/org/tugraz/sysds/test/TestUtils.java
@@ -53,7 +53,9 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.SequenceFile;
+import org.junit.Assert;
 import org.tugraz.sysds.common.Types.ValueType;
+import org.tugraz.sysds.runtime.data.TensorBlock;
 import org.tugraz.sysds.runtime.io.FrameWriter;
 import org.tugraz.sysds.runtime.io.FrameWriterFactory;
 import org.tugraz.sysds.runtime.io.IOUtilFunctions;
@@ -354,6 +356,27 @@ public class TestUtils
 		} catch (IOException e) {
 			fail("unable to read file: " + e.getMessage());
 		}
+	}
+	
+	public static void compareTensorBlocks(TensorBlock tb1, TensorBlock tb2) {
+		Assert.assertEquals(tb1.getValueType(), tb2.getValueType());
+		Assert.assertArrayEquals(tb1.getSchema(), tb2.getSchema());
+		Assert.assertEquals(tb1.getNumRows(), tb2.getNumRows());
+		Assert.assertEquals(tb1.getNumColumns(), tb2.getNumColumns());
+		for (int i = 0; i < tb1.getNumRows(); i++)
+			for (int j = 0; j < tb1.getNumColumns(); j++)
+				Assert.assertEquals(Double.valueOf(tb1.get(i, j)),
+						Double.valueOf(tb2.get(i, j)));
+	}
+	
+	public static TensorBlock createBasicTensor(ValueType vt, int rows, int cols, double sparsity) {
+		return DataConverter.convertToTensorBlock(TestUtils.round(
+				MatrixBlock.randOperations(rows, cols, sparsity, 0, 10, "uniform", 7)), vt, true);
+	}
+	
+	public static TensorBlock createDataTensor(ValueType vt, int rows, int cols, double sparsity) {
+		return DataConverter.convertToTensorBlock(TestUtils.round(
+				MatrixBlock.randOperations(rows, cols, sparsity, 0, 10, "uniform", 7)), vt, false);
 	}
 
 	/**

--- a/src/test/java/org/tugraz/sysds/test/component/tensor/TensorConstructionTest.java
+++ b/src/test/java/org/tugraz/sysds/test/component/tensor/TensorConstructionTest.java
@@ -19,8 +19,9 @@ package org.tugraz.sysds.test.component.tensor;
 import org.junit.Assert;
 import org.junit.Test;
 import org.tugraz.sysds.common.Types.ValueType;
-import org.tugraz.sysds.runtime.data.DataTensor;
-import org.tugraz.sysds.runtime.data.BasicTensor;
+import org.tugraz.sysds.runtime.data.DataTensorBlock;
+import org.tugraz.sysds.runtime.data.BasicTensorBlock;
+import org.tugraz.sysds.runtime.data.TensorBlock;
 
 import java.util.Arrays;
 
@@ -28,31 +29,29 @@ import java.util.Arrays;
 public class TensorConstructionTest {
 	@Test
 	public void testMetaDefaultBasicTensor() {
-		BasicTensor tb = new BasicTensor();
+		BasicTensorBlock tb = new BasicTensorBlock();
 		Assert.assertEquals(ValueType.FP64, tb.getValueType());
 		Assert.assertEquals(2, tb.getNumDims());
 		Assert.assertEquals(0, tb.getNumRows());
 		Assert.assertEquals(0, tb.getNumColumns());
 		Assert.assertEquals(0, tb.getNonZeros());
 		Assert.assertTrue(tb.isSparse());
-		Assert.assertFalse(tb.isMatrix());
 	}
 
 	@Test
 	public void testMetaValueBasicTensor() {
-		BasicTensor tb = new BasicTensor(7.3);
+		BasicTensorBlock tb = new BasicTensorBlock(7.3);
 		Assert.assertEquals(ValueType.FP64, tb.getValueType());
 		Assert.assertEquals(2, tb.getNumDims());
 		Assert.assertEquals(1, tb.getNumRows());
 		Assert.assertEquals(1, tb.getNumColumns());
 		Assert.assertEquals(1, tb.getNonZeros());
 		Assert.assertFalse(tb.isSparse());
-		Assert.assertFalse(tb.isMatrix());
 	}
 
 	@Test
 	public void testMetaTypedBasicTensor() {
-		BasicTensor tb = new BasicTensor(ValueType.INT64, new int[]{11, 12, 13});
+		BasicTensorBlock tb = new BasicTensorBlock(ValueType.INT64, new int[]{11, 12, 13});
 		Assert.assertEquals(ValueType.INT64, tb.getValueType());
 		Assert.assertEquals(3, tb.getNumDims());
 		Assert.assertEquals(11, tb.getNumRows());
@@ -60,12 +59,11 @@ public class TensorConstructionTest {
 		Assert.assertEquals(13, tb.getDim(2));
 		Assert.assertEquals(0, tb.getNonZeros());
 		Assert.assertTrue(tb.isSparse());
-		Assert.assertFalse(tb.isMatrix());
 	}
 
 	@Test
 	public void testMetaTypedBasicTensor2() {
-		BasicTensor tb = new BasicTensor(ValueType.INT64, new int[]{11, 12, 13}, false);
+		BasicTensorBlock tb = new BasicTensorBlock(ValueType.INT64, new int[]{11, 12, 13}, false);
 		Assert.assertEquals(ValueType.INT64, tb.getValueType());
 		Assert.assertEquals(3, tb.getNumDims());
 		Assert.assertEquals(11, tb.getNumRows());
@@ -73,12 +71,11 @@ public class TensorConstructionTest {
 		Assert.assertEquals(13, tb.getDim(2));
 		Assert.assertEquals(0, tb.getNonZeros());
 		Assert.assertFalse(tb.isSparse());
-		Assert.assertFalse(tb.isMatrix());
 	}
 
 	@Test
 	public void testMetaTypedBasicTensor3() {
-		BasicTensor tb = new BasicTensor(ValueType.BOOLEAN, new int[]{11, 12}, true);
+		BasicTensorBlock tb = new BasicTensorBlock(ValueType.BOOLEAN, new int[]{11, 12}, true);
 		Assert.assertEquals(ValueType.BOOLEAN, tb.getValueType());
 		Assert.assertEquals(2, tb.getNumDims());
 		Assert.assertEquals(11, tb.getNumRows());
@@ -86,36 +83,33 @@ public class TensorConstructionTest {
 		Assert.assertEquals(12, tb.getDim(1));
 		Assert.assertEquals(0, tb.getNonZeros());
 		Assert.assertTrue(tb.isSparse());
-		Assert.assertTrue(tb.isMatrix());
 	}
 
 	@Test
 	public void testMetaCopyDefaultBasicTensor() {
-		BasicTensor tb = new BasicTensor(new BasicTensor());
+		BasicTensorBlock tb = new BasicTensorBlock(new BasicTensorBlock());
 		Assert.assertEquals(ValueType.FP64, tb.getValueType());
 		Assert.assertEquals(2, tb.getNumDims());
 		Assert.assertEquals(0, tb.getNumRows());
 		Assert.assertEquals(0, tb.getNumColumns());
 		Assert.assertEquals(0, tb.getNonZeros());
 		Assert.assertTrue(tb.isSparse());
-		Assert.assertFalse(tb.isMatrix());
 	}
 
 	@Test
 	public void testMetaCopyValueBasicTensor() {
-		BasicTensor tb = new BasicTensor(new BasicTensor(7.3));
+		BasicTensorBlock tb = new BasicTensorBlock(new BasicTensorBlock(7.3));
 		Assert.assertEquals(ValueType.FP64, tb.getValueType());
 		Assert.assertEquals(2, tb.getNumDims());
 		Assert.assertEquals(1, tb.getNumRows());
 		Assert.assertEquals(1, tb.getNumColumns());
 		Assert.assertEquals(1, tb.getNonZeros());
 		Assert.assertFalse(tb.isSparse());
-		Assert.assertFalse(tb.isMatrix());
 	}
 
 	@Test
 	public void testMetaCopyTypedBasicTensor() {
-		BasicTensor tb = new BasicTensor(new BasicTensor(ValueType.INT64, new int[]{11, 12, 13}));
+		BasicTensorBlock tb = new BasicTensorBlock(new BasicTensorBlock(ValueType.INT64, new int[]{11, 12, 13}));
 		Assert.assertEquals(ValueType.INT64, tb.getValueType());
 		Assert.assertEquals(3, tb.getNumDims());
 		Assert.assertEquals(11, tb.getNumRows());
@@ -123,12 +117,11 @@ public class TensorConstructionTest {
 		Assert.assertEquals(13, tb.getDim(2));
 		Assert.assertEquals(0, tb.getNonZeros());
 		Assert.assertTrue(tb.isSparse());
-		Assert.assertFalse(tb.isMatrix());
 	}
 
 	@Test
 	public void testMetaCopyTypedBasicTensor2() {
-		BasicTensor tb = new BasicTensor(new BasicTensor(ValueType.INT64, new int[]{11, 12, 13}, false));
+		BasicTensorBlock tb = new BasicTensorBlock(new BasicTensorBlock(ValueType.INT64, new int[]{11, 12, 13}, false));
 		Assert.assertEquals(ValueType.INT64, tb.getValueType());
 		Assert.assertEquals(3, tb.getNumDims());
 		Assert.assertEquals(11, tb.getNumRows());
@@ -136,12 +129,11 @@ public class TensorConstructionTest {
 		Assert.assertEquals(13, tb.getDim(2));
 		Assert.assertEquals(0, tb.getNonZeros());
 		Assert.assertFalse(tb.isSparse());
-		Assert.assertFalse(tb.isMatrix());
 	}
 
 	@Test
 	public void testMetaCopyTypedBasicTensor3() {
-		BasicTensor tb = new BasicTensor(new BasicTensor(ValueType.BOOLEAN, new int[]{11, 12}, true));
+		BasicTensorBlock tb = new BasicTensorBlock(new BasicTensorBlock(ValueType.BOOLEAN, new int[]{11, 12}, true));
 		Assert.assertEquals(ValueType.BOOLEAN, tb.getValueType());
 		Assert.assertEquals(2, tb.getNumDims());
 		Assert.assertEquals(11, tb.getNumRows());
@@ -149,32 +141,29 @@ public class TensorConstructionTest {
 		Assert.assertEquals(12, tb.getDim(1));
 		Assert.assertEquals(0, tb.getNonZeros());
 		Assert.assertTrue(tb.isSparse());
-		Assert.assertTrue(tb.isMatrix());
 	}
 
 	@Test
 	public void testMetaDefaultDataTensor() {
-		DataTensor tb = new DataTensor();
+		DataTensorBlock tb = new DataTensorBlock();
 		Assert.assertArrayEquals(new ValueType[0], tb.getSchema());
 		Assert.assertEquals(2, tb.getNumDims());
 		Assert.assertEquals(0, tb.getNumRows());
 		Assert.assertEquals(0, tb.getNumColumns());
-		Assert.assertFalse(tb.isMatrix());
 	}
 
 	@Test
 	public void testMetaValueDataTensor() {
-		DataTensor tb = new DataTensor(7.3);
+		DataTensorBlock tb = new DataTensorBlock(7.3);
 		Assert.assertArrayEquals(new ValueType[]{ValueType.FP64}, tb.getSchema());
 		Assert.assertEquals(2, tb.getNumDims());
 		Assert.assertEquals(1, tb.getNumRows());
 		Assert.assertEquals(1, tb.getNumColumns());
-		Assert.assertFalse(tb.isMatrix());
 	}
 
 	@Test
 	public void testMetaTypedDataTensor() {
-		DataTensor tb = new DataTensor(ValueType.INT64, new int[]{11, 12, 13});
+		DataTensorBlock tb = new DataTensorBlock(ValueType.INT64, new int[]{11, 12, 13});
 		ValueType[] schema = new ValueType[12];
 		Arrays.fill(schema, ValueType.INT64);
 		Assert.assertArrayEquals(schema, tb.getSchema());
@@ -182,81 +171,74 @@ public class TensorConstructionTest {
 		Assert.assertEquals(11, tb.getNumRows());
 		Assert.assertEquals(12, tb.getNumColumns());
 		Assert.assertEquals(13, tb.getDim(2));
-		Assert.assertFalse(tb.isMatrix());
 	}
 
 	@Test
 	public void testMetaSchemaTypedDataTensor() {
 		ValueType[] schema = new ValueType[] {ValueType.BOOLEAN, ValueType.INT32, ValueType.STRING};
-		DataTensor tb = new DataTensor(schema);
+		DataTensorBlock tb = new DataTensorBlock(schema);
 		Assert.assertArrayEquals(schema, tb.getSchema());
 		Assert.assertEquals(2, tb.getNumDims());
 		Assert.assertEquals(0, tb.getNumRows());
 		Assert.assertEquals(schema.length, tb.getNumColumns());
-		Assert.assertFalse(tb.isMatrix());
 	}
 
 	@Test
 	public void testMetaNColsTypedDataTensor() {
-		DataTensor tb = new DataTensor(10, ValueType.BOOLEAN);
+		DataTensorBlock tb = new DataTensorBlock(10, ValueType.BOOLEAN);
 		ValueType[] schema = new ValueType[10];
 		Arrays.fill(schema, ValueType.BOOLEAN);
 		Assert.assertArrayEquals(schema, tb.getSchema());
 		Assert.assertEquals(2, tb.getNumDims());
 		Assert.assertEquals(0, tb.getNumRows());
 		Assert.assertEquals(10, tb.getNumColumns());
-		Assert.assertFalse(tb.isMatrix());
 	}
 
 	@Test
 	public void testMetaCopyDefaultDataTensor() {
-		DataTensor tb = new DataTensor(new DataTensor());
+		DataTensorBlock tb = new DataTensorBlock(new DataTensorBlock());
 		Assert.assertArrayEquals(new ValueType[0], tb.getSchema());
 		Assert.assertEquals(2, tb.getNumDims());
 		Assert.assertEquals(0, tb.getNumRows());
 		Assert.assertEquals(0, tb.getNumColumns());
-		Assert.assertFalse(tb.isMatrix());
 	}
 
 	@Test
 	public void testMetaCopyValueDataTensor() {
-		DataTensor tb = new DataTensor(new DataTensor(7.3));
+		DataTensorBlock tb = new DataTensorBlock(new DataTensorBlock(7.3));
 		Assert.assertArrayEquals(new ValueType[]{ValueType.FP64}, tb.getSchema());
 		Assert.assertEquals(2, tb.getNumDims());
 		Assert.assertEquals(1, tb.getNumRows());
 		Assert.assertEquals(1, tb.getNumColumns());
-		Assert.assertFalse(tb.isMatrix());
 	}
 
 	@Test
 	public void testMetaCopyTypedDataTensor() {
 		ValueType[] schema = {ValueType.INT32, ValueType.INT64, ValueType.BOOLEAN};
-		DataTensor tb = new DataTensor(new DataTensor(schema, new int[]{11, 3, 13}));
+		DataTensorBlock tb = new DataTensorBlock(new DataTensorBlock(schema, new int[]{11, 3, 13}));
 		Assert.assertArrayEquals(schema, tb.getSchema());
 		Assert.assertEquals(3, tb.getNumDims());
 		Assert.assertEquals(11, tb.getNumRows());
 		Assert.assertEquals(3, tb.getNumColumns());
 		Assert.assertEquals(13, tb.getDim(2));
-		Assert.assertFalse(tb.isMatrix());
 	}
 
 	@Test
 	public void testMetaCopyTypedDataTensor2() {
 		ValueType[] schema = {ValueType.FP64, ValueType.FP32, ValueType.STRING};
-		DataTensor tb = new DataTensor(new DataTensor(schema, new int[]{11, 3, 13}));
+		DataTensorBlock tb = new DataTensorBlock(new DataTensorBlock(schema, new int[]{11, 3, 13}));
 		Assert.assertArrayEquals(schema, tb.getSchema());
 		Assert.assertEquals(3, tb.getNumDims());
 		Assert.assertEquals(11, tb.getNumRows());
 		Assert.assertEquals(3, tb.getNumColumns());
 		Assert.assertEquals(13, tb.getDim(2));
-		Assert.assertFalse(tb.isMatrix());
 	}
 
 	@Test
 	public void testMetaCopyTypedDataTensor3() {
 		ValueType[] schema = {ValueType.FP64, ValueType.FP32, ValueType.INT64, ValueType.INT32, ValueType.BOOLEAN,
 				ValueType.STRING};
-		DataTensor tb = new DataTensor(new DataTensor(schema, new int[]{2, schema.length, 2}, new String[][]{
+		DataTensorBlock tb = new DataTensorBlock(new DataTensorBlock(schema, new int[]{2, schema.length, 2}, new String[][]{
 				new String[]{"1.4", "-5.34", "4.5", "-100000.1"},
 				new String[]{"1.4", "-5.34", "4.5", "-100000.1"},
 				new String[]{"1", "-5", "4", "-100000"},
@@ -269,6 +251,167 @@ public class TensorConstructionTest {
 		Assert.assertEquals(2, tb.getNumRows());
 		Assert.assertEquals(schema.length, tb.getNumColumns());
 		Assert.assertEquals(2, tb.getDim(2));
+	}
+
+	@Test
+	public void testMetaDefaultTensorBlock() {
+		TensorBlock tb = new TensorBlock();
+		Assert.assertArrayEquals(null, tb.getSchema());
+		Assert.assertEquals(ValueType.FP64, tb.getValueType());
+		Assert.assertTrue(tb.isBasic());
+		Assert.assertNull(tb.getDataTensor());
+		Assert.assertFalse(tb.isAllocated());
+		Assert.assertEquals(2, tb.getNumDims());
+		Assert.assertEquals(0, tb.getNumRows());
+		Assert.assertEquals(0, tb.getNumColumns());
 		Assert.assertFalse(tb.isMatrix());
+		Assert.assertFalse(tb.isVector());
+	}
+
+	@Test
+	public void testMetaHeterogeneousTensorBlock() {
+		TensorBlock tb = new TensorBlock(new int[]{1, 1}, false);
+		Assert.assertArrayEquals(new ValueType[]{ValueType.FP64}, tb.getSchema());
+		Assert.assertNull(tb.getValueType());
+		Assert.assertFalse(tb.isBasic());
+		Assert.assertNull(tb.getBasicTensor());
+		Assert.assertNull(tb.getDataTensor());
+		Assert.assertFalse(tb.isAllocated());
+		Assert.assertEquals(2, tb.getNumDims());
+		Assert.assertEquals(1, tb.getNumRows());
+		Assert.assertEquals(1, tb.getNumColumns());
+		Assert.assertFalse(tb.isMatrix());
+		Assert.assertTrue(tb.isVector());
+	}
+
+	@Test
+	public void testMetaHomogeneousTensorBlock() {
+		TensorBlock tb = new TensorBlock(new int[]{1, 1}, true);
+		Assert.assertNull(tb.getSchema());
+		Assert.assertEquals(ValueType.FP64, tb.getValueType());
+		Assert.assertTrue(tb.isBasic());
+		Assert.assertNull(tb.getBasicTensor());
+		Assert.assertNull(tb.getDataTensor());
+		Assert.assertFalse(tb.isAllocated());
+		Assert.assertEquals(2, tb.getNumDims());
+		Assert.assertEquals(1, tb.getNumRows());
+		Assert.assertEquals(1, tb.getNumColumns());
+		Assert.assertFalse(tb.isMatrix());
+		Assert.assertTrue(tb.isVector());
+	}
+
+	@Test
+	public void testMetaValueTensorBlock() {
+		double val = 7.3;
+		TensorBlock tb = new TensorBlock(val);
+		Assert.assertArrayEquals(null, tb.getSchema());
+		Assert.assertEquals(ValueType.FP64, tb.getValueType());
+		Assert.assertTrue(tb.isBasic());
+		Assert.assertNull(tb.getDataTensor());
+		Assert.assertTrue(tb.isAllocated());
+		Assert.assertEquals(2, tb.getNumDims());
+		Assert.assertEquals(1, tb.getNumRows());
+		Assert.assertEquals(1, tb.getNumColumns());
+		Assert.assertFalse(tb.isMatrix());
+		Assert.assertTrue(tb.isVector());
+		Assert.assertEquals(val, tb.get(0, 0), 0);
+	}
+
+	@Test
+	public void testMetaTypedTensorBlock() {
+		TensorBlock tb = new TensorBlock(ValueType.INT64, new int[]{11, 12, 13});
+		Assert.assertArrayEquals(null, tb.getSchema());
+		Assert.assertEquals(ValueType.INT64, tb.getValueType());
+		Assert.assertTrue(tb.isBasic());
+		Assert.assertNull(tb.getDataTensor());
+		Assert.assertTrue(tb.isAllocated());
+		Assert.assertEquals(3, tb.getNumDims());
+		Assert.assertEquals(11, tb.getNumRows());
+		Assert.assertEquals(12, tb.getNumColumns());
+		Assert.assertEquals(13, tb.getDim(2));
+		Assert.assertFalse(tb.isMatrix());
+		Assert.assertFalse(tb.isVector());
+	}
+
+	@Test
+	public void testMetaSchemaTypedTensorBlock() {
+		ValueType[] schema = new ValueType[] {ValueType.BOOLEAN, ValueType.INT32, ValueType.STRING};
+		TensorBlock tb = new TensorBlock(schema, new int[]{4, 3, 2});
+		Assert.assertArrayEquals(schema, tb.getSchema());
+		Assert.assertNull(tb.getValueType());
+		Assert.assertFalse(tb.isBasic());
+		Assert.assertNull(tb.getBasicTensor());
+		Assert.assertTrue(tb.isAllocated());
+		Assert.assertEquals(3, tb.getNumDims());
+		Assert.assertEquals(4, tb.getNumRows());
+		Assert.assertEquals(3, tb.getNumColumns());
+		Assert.assertEquals(2, tb.getDim(2));
+		Assert.assertFalse(tb.isMatrix());
+		Assert.assertFalse(tb.isVector());
+	}
+
+	@Test
+	public void testMetaCopyDefaultTensorBlock() {
+		TensorBlock tb = new TensorBlock(new TensorBlock());
+		Assert.assertArrayEquals(null, tb.getSchema());
+		Assert.assertEquals(ValueType.FP64, tb.getValueType());
+		Assert.assertTrue(tb.isBasic());
+		Assert.assertNull(tb.getDataTensor());
+		Assert.assertFalse(tb.isAllocated());
+		Assert.assertEquals(2, tb.getNumDims());
+		Assert.assertEquals(0, tb.getNumRows());
+		Assert.assertEquals(0, tb.getNumColumns());
+		Assert.assertFalse(tb.isMatrix());
+		Assert.assertFalse(tb.isVector());
+	}
+
+	@Test
+	public void testMetaCopyValueTensorBlock() {
+		double val = 7.3;
+		TensorBlock tb = new TensorBlock(new TensorBlock(val));
+		Assert.assertArrayEquals(null, tb.getSchema());
+		Assert.assertEquals(ValueType.FP64, tb.getValueType());
+		Assert.assertTrue(tb.isBasic());
+		Assert.assertNull(tb.getDataTensor());
+		Assert.assertTrue(tb.isAllocated());
+		Assert.assertEquals(2, tb.getNumDims());
+		Assert.assertEquals(1, tb.getNumRows());
+		Assert.assertEquals(1, tb.getNumColumns());
+		Assert.assertFalse(tb.isMatrix());
+		Assert.assertTrue(tb.isVector());
+		Assert.assertEquals(val, tb.get(0, 0), 0);
+	}
+
+	@Test
+	public void testMetaCopyTypedTensorBlock() {
+		TensorBlock tb = new TensorBlock(new TensorBlock(ValueType.INT64, new int[]{11, 12, 13}));
+		Assert.assertArrayEquals(null, tb.getSchema());
+		Assert.assertEquals(ValueType.INT64, tb.getValueType());
+		Assert.assertTrue(tb.isBasic());
+		Assert.assertNull(tb.getDataTensor());
+		Assert.assertTrue(tb.isAllocated());
+		Assert.assertEquals(3, tb.getNumDims());
+		Assert.assertEquals(11, tb.getNumRows());
+		Assert.assertEquals(12, tb.getNumColumns());
+		Assert.assertEquals(13, tb.getDim(2));
+		Assert.assertFalse(tb.isMatrix());
+		Assert.assertFalse(tb.isVector());
+	}
+
+	@Test
+	public void testMetaCopySchemaTypedTensorBlock() {
+		ValueType[] schema = new ValueType[] {ValueType.BOOLEAN, ValueType.INT32, ValueType.STRING};
+		TensorBlock tb = new TensorBlock(new TensorBlock(schema, new int[]{4, 3, 2}));
+		Assert.assertArrayEquals(schema, tb.getSchema());
+		Assert.assertNull(tb.getValueType());
+		Assert.assertFalse(tb.isBasic());
+		Assert.assertNull(tb.getBasicTensor());
+		Assert.assertTrue(tb.isAllocated());
+		Assert.assertEquals(3, tb.getNumDims());
+		Assert.assertEquals(4, tb.getNumRows());
+		Assert.assertEquals(3, tb.getNumColumns());
+		Assert.assertEquals(2, tb.getDim(2));
+		Assert.assertFalse(tb.isMatrix());
+		Assert.assertFalse(tb.isVector());
 	}
 }

--- a/src/test/java/org/tugraz/sysds/test/component/tensor/TensorGetSetIndexingTest.java
+++ b/src/test/java/org/tugraz/sysds/test/component/tensor/TensorGetSetIndexingTest.java
@@ -19,9 +19,10 @@ package org.tugraz.sysds.test.component.tensor;
 import org.junit.Assert;
 import org.junit.Test;
 import org.tugraz.sysds.common.Types.ValueType;
-import org.tugraz.sysds.runtime.data.DataTensor;
+import org.tugraz.sysds.runtime.data.TensorBlock;
 import org.tugraz.sysds.runtime.util.UtilFunctions;
-import org.tugraz.sysds.runtime.data.BasicTensor;
+
+import java.util.Arrays;
 
 
 public class TensorGetSetIndexingTest
@@ -30,75 +31,75 @@ public class TensorGetSetIndexingTest
 	// TODO large tensor tests
 	@Test
 	public void testIndexBasicTensor2FP32SetGetCell() {
-		BasicTensor tb = getBasicTensor2(ValueType.FP32);
+		TensorBlock tb = getBasicTensor2(ValueType.FP32);
 		checkSequence(setSequence(tb));
 	}
 
 	@Test
 	public void testIndexBasicTensor2FP64SetGetCell() {
-		BasicTensor tb = getBasicTensor2(ValueType.FP64);
+		TensorBlock tb = getBasicTensor2(ValueType.FP64);
 		checkSequence(setSequence(tb));
 	}
 
 	@Test
 	public void testIndexBasicTensor2BoolSetGetCell() {
-		BasicTensor tb = getBasicTensor2(ValueType.BOOLEAN);
+		TensorBlock tb = getBasicTensor2(ValueType.BOOLEAN);
 		checkSequence(setSequence(tb));
 	}
 
 	@Test
 	public void testIndexBasicTensor2Int32SetGetCell() {
-		BasicTensor tb = getBasicTensor2(ValueType.INT32);
+		TensorBlock tb = getBasicTensor2(ValueType.INT32);
 		checkSequence(setSequence(tb));
 	}
 
 	@Test
 	public void testIndexBasicTensor2Int64SetGetCell() {
-		BasicTensor tb = getBasicTensor2(ValueType.INT64);
+		TensorBlock tb = getBasicTensor2(ValueType.INT64);
 		checkSequence(setSequence(tb));
 	}
 
 	@Test
 	public void testIndexBasicTensor3FP32SetGetCell() {
-		BasicTensor tb = getBasicTensor3(ValueType.FP32);
+		TensorBlock tb = getBasicTensor3(ValueType.FP32);
 		checkSequence(setSequence(tb));
 	}
 
 	@Test
 	public void testIndexBasicTensor3FP64SetGetCell() {
-		BasicTensor tb = getBasicTensor3(ValueType.FP64);
+		TensorBlock tb = getBasicTensor3(ValueType.FP64);
 		checkSequence(setSequence(tb));
 	}
 
 	@Test
 	public void testIndexBasicTensor3BoolSetGetCell() {
-		BasicTensor tb = getBasicTensor3(ValueType.BOOLEAN);
+		TensorBlock tb = getBasicTensor3(ValueType.BOOLEAN);
 		checkSequence(setSequence(tb));
 	}
 
 	@Test
 	public void testIndexBasicTensor3Int32SetGetCell() {
-		BasicTensor tb = getBasicTensor3(ValueType.INT32);
+		TensorBlock tb = getBasicTensor3(ValueType.INT32);
 		checkSequence(setSequence(tb));
 	}
 
 	@Test
 	public void testIndexBasicTensor3Int64SetGetCell() {
-		BasicTensor tb = getBasicTensor3(ValueType.INT64);
+		TensorBlock tb = getBasicTensor3(ValueType.INT64);
 		checkSequence(setSequence(tb));
 	}
 
-	private BasicTensor getBasicTensor2(ValueType vt) {
+	private TensorBlock getBasicTensor2(ValueType vt) {
 		// Todo: implement sparse for Tensor
-		return new BasicTensor(vt, new int[] {DIM0,DIM1}, false);
+		return new TensorBlock(vt, new int[] {DIM0,DIM1});
 	}
 
-	private BasicTensor getBasicTensor3(ValueType vt) {
+	private TensorBlock getBasicTensor3(ValueType vt) {
 		// Todo: implement sparse for Tensor
-		return new BasicTensor(vt, new int[] {DIM0,DIM1,DIM2}, false);
+		return new TensorBlock(vt, new int[] {DIM0,DIM1,DIM2});
 	}
 
-	private BasicTensor setSequence(BasicTensor tb) {
+	private TensorBlock setSequence(TensorBlock tb) {
 		if( tb.getNumDims() == DIM0 ) {
 			int dim12 = DIM1*DIM2;
 			for(int i=0; i<tb.getNumRows(); i++)
@@ -114,8 +115,8 @@ public class TensorGetSetIndexingTest
 		return tb;
 	}
 
-	private void checkSequence(BasicTensor tb) {
-		boolean isBool = tb.getValueType() == ValueType.BOOLEAN;
+	private void checkSequence(TensorBlock tb) {
+		boolean isBool = (tb.isBasic() ? tb.getValueType() : tb.getSchema()[0]) == ValueType.BOOLEAN;
 		if( tb.getNumDims() == DIM0 ) {
 			int dim12 = DIM1 * DIM2;
 			for(int i=0; i<tb.getNumRows(); i++)
@@ -124,7 +125,8 @@ public class TensorGetSetIndexingTest
 						int val = i*dim12+j*DIM2+k;
 						double expected = isBool && val!=0 ? 1 : val;
 						Object actualObj = tb.get(new int[]{i, j, k});
-						double actual = UtilFunctions.objectToDouble(tb.getValueType(), actualObj);
+						ValueType vt = !tb.isBasic() ? tb.getSchema()[j] : tb.getValueType();
+						double actual = UtilFunctions.objectToDouble(vt, actualObj);
 						Assert.assertEquals(expected, actual, 0);
 					}
 		}
@@ -133,8 +135,9 @@ public class TensorGetSetIndexingTest
 				for(int j=0; j<DIM1; j++) {
 					int val = i*DIM1+j;
 					double expected = isBool && val!=0 ? 1 : val;
+					ValueType vt = !tb.isBasic() ? tb.getSchema()[j] : tb.getValueType();
 					double actual = UtilFunctions.objectToDouble(
-						tb.getValueType(), tb.get(new int[]{i, j}));
+						vt, tb.get(new int[]{i, j}));
 					Assert.assertEquals(expected, actual, 0);
 				}
 		}
@@ -142,111 +145,73 @@ public class TensorGetSetIndexingTest
 
 	@Test
 	public void testIndexDataTensor2FP32SetGetCell() {
-		DataTensor tb = getDataTensor2(ValueType.FP32);
+		TensorBlock tb = getDataTensor2(ValueType.FP32);
 		checkSequence(setSequence(tb));
 	}
 
 	@Test
 	public void testIndexDataTensor2FP64SetGetCell() {
-		DataTensor tb = getDataTensor2(ValueType.FP64);
+		TensorBlock tb = getDataTensor2(ValueType.FP64);
 		checkSequence(setSequence(tb));
 	}
 
 	@Test
 	public void testIndexDataTensor2BoolSetGetCell() {
-		DataTensor tb = getDataTensor2(ValueType.BOOLEAN);
+		TensorBlock tb = getDataTensor2(ValueType.BOOLEAN);
 		checkSequence(setSequence(tb));
 	}
 
 	@Test
 	public void testIndexDataTensor2Int32SetGetCell() {
-		DataTensor tb = getDataTensor2(ValueType.INT32);
+		TensorBlock tb = getDataTensor2(ValueType.INT32);
 		checkSequence(setSequence(tb));
 	}
 
 	@Test
 	public void testIndexDataTensor2Int64SetGetCell() {
-		DataTensor tb = getDataTensor2(ValueType.INT64);
+		TensorBlock tb = getDataTensor2(ValueType.INT64);
 		checkSequence(setSequence(tb));
 	}
 
 	@Test
 	public void testIndexDataTensor3FP32SetGetCell() {
-		DataTensor tb = getDataTensor3(ValueType.FP32);
+		TensorBlock tb = getDataTensor3(ValueType.FP32);
 		checkSequence(setSequence(tb));
 	}
 
 	@Test
 	public void testIndexDataTensor3FP64SetGetCell() {
-		DataTensor tb = getDataTensor3(ValueType.FP64);
+		TensorBlock tb = getDataTensor3(ValueType.FP64);
 		checkSequence(setSequence(tb));
 	}
 
 	@Test
 	public void testIndexDataTensor3BoolSetGetCell() {
-		DataTensor tb = getDataTensor3(ValueType.BOOLEAN);
+		TensorBlock tb = getDataTensor3(ValueType.BOOLEAN);
 		checkSequence(setSequence(tb));
 	}
 
 	@Test
 	public void testIndexDataTensor3Int32SetGetCell() {
-		DataTensor tb = getDataTensor3(ValueType.INT32);
+		TensorBlock tb = getDataTensor3(ValueType.INT32);
 		checkSequence(setSequence(tb));
 	}
 
 	@Test
 	public void testIndexDataTensor3Int64SetGetCell() {
-		DataTensor tb = getDataTensor3(ValueType.INT64);
+		TensorBlock tb = getDataTensor3(ValueType.INT64);
 		checkSequence(setSequence(tb));
 	}
 
-	private DataTensor getDataTensor2(ValueType vt) {
-		return new DataTensor(vt, new int[] {DIM0,DIM1});
+	private TensorBlock getDataTensor2(ValueType vt) {
+		ValueType[] schema = new ValueType[DIM1];
+		Arrays.fill(schema, vt);
+		return new TensorBlock(schema, new int[] {DIM0,DIM1});
 	}
 
-	private DataTensor getDataTensor3(ValueType vt) {
-		return new DataTensor(vt, new int[] {DIM0,DIM1,DIM2});
-	}
-
-	private DataTensor setSequence(DataTensor tb) {
-		if( tb.getNumDims() == DIM0 ) {
-			int dim12 = DIM1*DIM2;
-			for(int i=0; i<tb.getNumRows(); i++)
-				for(int j=0; j<DIM1; j++)
-					for(int k=0; k<DIM2; k++)
-						tb.set(new int[] {i,j,k}, (double)i*dim12+j*DIM2+k);
-		}
-		else { //num dims = 2
-			for(int i=0; i<tb.getNumRows(); i++)
-				for(int j=0; j<DIM1; j++)
-					tb.set(new int[]{i,j}, i*DIM1+j);
-		}
-		return tb;
-	}
-
-	private void checkSequence(DataTensor tb) {
-		boolean isBool = tb.getSchema()[0] == ValueType.BOOLEAN;
-		if( tb.getNumDims() == DIM0 ) {
-			int dim12 = DIM1*DIM2;
-			for(int i=0; i<tb.getNumRows(); i++)
-				for(int j=0; j<DIM1; j++)
-					for(int k=0; k<DIM2; k++) {
-						int val = i*dim12+j*DIM2+k;
-						double expected = isBool && val!=0 ? 1 : val;
-						double actual = UtilFunctions.objectToDouble(
-							tb.getSchema()[0], tb.get(new int[]{i, j, k}));
-						Assert.assertEquals(expected, actual, 0);
-					}
-		}
-		else { //num dims = 2
-			for(int i=0; i<tb.getNumRows(); i++)
-				for(int j=0; j<DIM1; j++) {
-					int val = i*DIM1+j;
-					double expected = isBool && val!=0 ? 1 : val;
-					double actual = UtilFunctions.objectToDouble(
-						tb.getSchema()[0], tb.get(new int[]{i, j}));
-					Assert.assertEquals(expected, actual, 0);
-				}
-		}
+	private TensorBlock getDataTensor3(ValueType vt) {
+		ValueType[] schema = new ValueType[DIM1];
+		Arrays.fill(schema, vt);
+		return new TensorBlock(schema, new int[] {DIM0,DIM1,DIM2});
 	}
 }

--- a/src/test/java/org/tugraz/sysds/test/component/tensor/TensorSerializationTest.java
+++ b/src/test/java/org/tugraz/sysds/test/component/tensor/TensorSerializationTest.java
@@ -19,150 +19,93 @@ package org.tugraz.sysds.test.component.tensor;
 import java.io.DataInput;
 import java.io.DataOutput;
 
-import org.junit.Assert;
 import org.junit.Test;
 import org.tugraz.sysds.common.Types.ValueType;
 import org.tugraz.sysds.runtime.DMLRuntimeException;
 import org.tugraz.sysds.runtime.controlprogram.caching.CacheDataInput;
 import org.tugraz.sysds.runtime.controlprogram.caching.CacheDataOutput;
-import org.tugraz.sysds.runtime.data.DataTensor;
-import org.tugraz.sysds.runtime.data.BasicTensor;
-import org.tugraz.sysds.runtime.matrix.data.MatrixBlock;
-import org.tugraz.sysds.runtime.util.DataConverter;
-import org.tugraz.sysds.test.TestUtils;
+import org.tugraz.sysds.runtime.data.TensorBlock;
+
+import static org.tugraz.sysds.test.TestUtils.*;
 
 
 public class TensorSerializationTest 
 {
 	@Test
 	public void testSerializeBasicTensorFP32() {
-		BasicTensor tb1 = createBasicTensor(ValueType.FP32, 70, 30, 0.7);
-		BasicTensor tb2 = serializeAndDeserializeBasicTensor(tb1);
-		compareBasicTensors(tb1, tb2);
+		testSerializeBasicTensor(ValueType.FP32);
 	}
 	
 	@Test
 	public void testSerializeBasicTensorFP64() {
-		BasicTensor tb1 = createBasicTensor(ValueType.FP64, 70, 30, 0.7);
-		BasicTensor tb2 = serializeAndDeserializeBasicTensor(tb1);
-		compareBasicTensors(tb1, tb2);
+		testSerializeBasicTensor(ValueType.FP64);
 	}
 	
 	@Test
 	public void testSerializeBasicTensorINT32() {
-		BasicTensor tb1 = createBasicTensor(ValueType.INT32, 70, 30, 0.7);
-		BasicTensor tb2 = serializeAndDeserializeBasicTensor(tb1);
-		compareBasicTensors(tb1, tb2);
+		testSerializeBasicTensor(ValueType.INT32);
 	}
 	
 	@Test
 	public void testSerializeBasicTensorINT64() {
-		BasicTensor tb1 = createBasicTensor(ValueType.INT64, 70, 30, 0.7);
-		BasicTensor tb2 = serializeAndDeserializeBasicTensor(tb1);
-		compareBasicTensors(tb1, tb2);
+		testSerializeBasicTensor(ValueType.INT64);
 	}
 	
 	@Test
 	public void testSerializeBasicTensorBoolean() {
-		BasicTensor tb1 = createBasicTensor(ValueType.BOOLEAN, 70, 30, 0.7);
-		BasicTensor tb2 = serializeAndDeserializeBasicTensor(tb1);
-		compareBasicTensors(tb1, tb2);
+		testSerializeBasicTensor(ValueType.BOOLEAN);
+	}
+
+	private void testSerializeBasicTensor(ValueType vt) {
+		TensorBlock tb1 = createBasicTensor(vt, 70, 30, 0.7);
+		TensorBlock tb2 = serializeAndDeserializeTensorBlock(tb1);
+		compareTensorBlocks(tb1, tb2);
 	}
 
 	@Test
 	public void testSerializeDataTensorFP32() {
-		DataTensor tb1 = createDataTensor(ValueType.FP32, 70, 30, 0.7);
-		DataTensor tb2 = serializeAndDeserializeDataTensor(tb1);
-		compareDataTensors(tb1, tb2);
+		testSerializeDataTensor(ValueType.FP32);
 	}
 
 	@Test
 	public void testSerializeDataTensorFP64() {
-		DataTensor tb1 = createDataTensor(ValueType.FP64, 70, 30, 0.7);
-		DataTensor tb2 = serializeAndDeserializeDataTensor(tb1);
-		compareDataTensors(tb1, tb2);
+		testSerializeDataTensor(ValueType.FP64);
 	}
 
 	@Test
 	public void testSerializeDataTensorINT32() {
-		DataTensor tb1 = createDataTensor(ValueType.INT32, 70, 30, 0.7);
-		DataTensor tb2 = serializeAndDeserializeDataTensor(tb1);
-		compareDataTensors(tb1, tb2);
+		testSerializeDataTensor(ValueType.INT32);
 	}
 
 	@Test
 	public void testSerializeDataTensorINT64() {
-		DataTensor tb1 = createDataTensor(ValueType.INT64, 70, 30, 0.7);
-		DataTensor tb2 = serializeAndDeserializeDataTensor(tb1);
-		compareDataTensors(tb1, tb2);
+		testSerializeDataTensor(ValueType.INT64);
 	}
 
 	@Test
 	public void testSerializeDataTensorBoolean() {
-		DataTensor tb1 = createDataTensor(ValueType.BOOLEAN, 70, 30, 0.7);
-		DataTensor tb2 = serializeAndDeserializeDataTensor(tb1);
-		compareDataTensors(tb1, tb2);
+		testSerializeDataTensor(ValueType.BOOLEAN);
 	}
 
-	private BasicTensor serializeAndDeserializeBasicTensor(BasicTensor tb1) {
+	private void testSerializeDataTensor(ValueType vt) {
+		TensorBlock tb1 = createDataTensor(vt, 70, 30, 0.7);
+		TensorBlock tb2 = serializeAndDeserializeTensorBlock(tb1);
+		compareTensorBlocks(tb1, tb2);
+	}
+
+	private TensorBlock serializeAndDeserializeTensorBlock(TensorBlock tb1) {
 		try {
 			//serialize and deserialize tensor block
 			byte[] bdata = new byte[(int)tb1.getExactSerializedSize()];
 			DataOutput dout = new CacheDataOutput(bdata);
 			tb1.write(dout); //tb1 serialized into bdata
 			DataInput din = new CacheDataInput(bdata);
-			BasicTensor tb2 = new BasicTensor();
+			TensorBlock tb2 = new TensorBlock();
 			tb2.readFields(din); //bdata deserialized into tb2
 			return tb2;
 		}
 		catch(Exception ex) {
 			throw new DMLRuntimeException(ex);
 		}
-	}
-
-	private DataTensor serializeAndDeserializeDataTensor(DataTensor tb1) {
-		try {
-			//serialize and deserialize tensor block
-			byte[] bdata = new byte[(int)tb1.getExactSerializedSize()];
-			DataOutput dout = new CacheDataOutput(bdata);
-			tb1.write(dout); //tb1 serialized into bdata
-			DataInput din = new CacheDataInput(bdata);
-			DataTensor tb2 = new DataTensor();
-			tb2.readFields(din); //bdata deserialized into tb2
-			return tb2;
-		}
-		catch(Exception ex) {
-			throw new DMLRuntimeException(ex);
-		}
-	}
-
-	private BasicTensor createBasicTensor(ValueType vt, int rows, int cols, double sparsity) {
-		return (BasicTensor) DataConverter.convertToTensorBlock(TestUtils.round(
-				MatrixBlock.randOperations(rows, cols, sparsity, 0, 1, "uniform", 7)), vt, true);
-	}
-
-	private DataTensor createDataTensor(ValueType vt, int rows, int cols, double sparsity) {
-		return (DataTensor) DataConverter.convertToTensorBlock(TestUtils.round(
-				MatrixBlock.randOperations(rows, cols, sparsity, 0, 1, "uniform", 7)), vt, false);
-	}
-
-	private void compareBasicTensors(BasicTensor tb1, BasicTensor tb2) {
-		Assert.assertEquals(tb1.getValueType(), tb2.getValueType());
-		Assert.assertEquals(tb1.getNumRows(), tb2.getNumRows());
-		Assert.assertEquals(tb1.getNumColumns(), tb2.getNumColumns());
-		for(int i=0; i<tb1.getNumRows(); i++)
-			for(int j=0; j<tb1.getNumColumns(); j++)
-				Assert.assertEquals(Double.valueOf(tb1.get(i, j)),
-					Double.valueOf(tb2.get(i, j)));
-	}
-
-	private void compareDataTensors(DataTensor tb1, DataTensor tb2) {
-		Assert.assertArrayEquals(tb1.getSchema(), tb2.getSchema());
-		Assert.assertEquals(tb1.getNumRows(), tb2.getNumRows());
-		Assert.assertEquals(tb1.getNumColumns(), tb2.getNumColumns());
-		for(int i=0; i<tb1.getNumRows(); i++)
-			for(int j=0; j<tb1.getNumColumns(); j++)
-				Assert.assertEquals(Double.valueOf(tb1.get(i, j)),
-						Double.valueOf(tb2.get(i, j)));
 	}
 }

--- a/src/test/java/org/tugraz/sysds/test/functions/data/TensorBinaryBlockTest.java
+++ b/src/test/java/org/tugraz/sysds/test/functions/data/TensorBinaryBlockTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2019 Graz University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.tugraz.sysds.test.functions.data;
+
+import org.junit.Test;
+import org.tugraz.sysds.common.Types.ValueType;
+import org.tugraz.sysds.runtime.DMLRuntimeException;
+import org.tugraz.sysds.runtime.data.TensorBlock;
+import org.tugraz.sysds.runtime.io.TensorReaderBinaryBlock;
+import org.tugraz.sysds.runtime.io.TensorWriterBinaryBlock;
+
+import java.util.Arrays;
+
+import static org.tugraz.sysds.test.TestUtils.*;
+
+
+public class TensorBinaryBlockTest {
+	@Test
+	public void testReadWriteBinaryBlockBasicTensorFP32() {
+		testReadWriteBinaryBlockBasicTensor(ValueType.FP32);
+	}
+
+	@Test
+	public void testReadWriteBinaryBlockBasicTensorFP64() {
+		testReadWriteBinaryBlockBasicTensor(ValueType.FP64);
+	}
+
+	@Test
+	public void testReadWriteBinaryBlockBasicTensorINT32() {
+		testReadWriteBinaryBlockBasicTensor(ValueType.INT32);
+	}
+
+	@Test
+	public void testReadWriteBinaryBlockBasicTensorINT64() {
+		testReadWriteBinaryBlockBasicTensor(ValueType.INT64);
+	}
+
+	@Test
+	public void testReadWriteBinaryBlockBasicTensorBoolean() {
+		testReadWriteBinaryBlockBasicTensor(ValueType.BOOLEAN);
+	}
+
+	@Test
+	public void testReadWriteBinaryBlockBasicTensorString() {
+		testReadWriteBinaryBlockBasicTensor(ValueType.STRING);
+	}
+
+	private void testReadWriteBinaryBlockBasicTensor(ValueType vt) {
+		TensorBlock tb1 = createBasicTensor(vt, 70, 30, 0.7);
+		TensorBlock tb2 = writeAndReadBasicTensorBinaryBlock(tb1);
+		compareTensorBlocks(tb1, tb2);
+	}
+
+	@Test
+	public void testReadWriteBinaryBlockDataTensorFP32() {
+		testReadWriteBinaryBlockDataTensor(ValueType.FP32);
+	}
+
+	@Test
+	public void testReadWriteBinaryBlockDataTensorFP64() {
+		testReadWriteBinaryBlockDataTensor(ValueType.FP64);
+	}
+
+	@Test
+	public void testReadWriteBinaryBlockDataTensorINT32() {
+		testReadWriteBinaryBlockDataTensor(ValueType.INT32);
+	}
+
+	@Test
+	public void testReadWriteBinaryBlockDataTensorINT64() {
+		testReadWriteBinaryBlockDataTensor(ValueType.INT64);
+	}
+
+	@Test
+	public void testReadWriteBinaryBlockDataTensorBoolean() {
+		testReadWriteBinaryBlockDataTensor(ValueType.BOOLEAN);
+	}
+
+	@Test
+	public void testReadWriteBinaryBlockDataTensorString() {
+		testReadWriteBinaryBlockDataTensor(ValueType.STRING);
+	}
+
+	private void testReadWriteBinaryBlockDataTensor(ValueType vt) {
+		TensorBlock tb1 = createDataTensor(vt, 70, 30, 0.7);
+		TensorBlock tb2 = writeAndReadDataTensorBinaryBlock(tb1);
+		compareTensorBlocks(tb1, tb2);
+	}
+
+	private TensorBlock writeAndReadBasicTensorBinaryBlock(TensorBlock tb1) {
+		try {
+			long[] dims = Arrays.stream(tb1.getDims()).mapToLong(i -> i).toArray();
+			TensorWriterBinaryBlock writer = new TensorWriterBinaryBlock();
+			writer.writeTensorToHDFS(tb1, "a", dims, 1024);
+			TensorReaderBinaryBlock reader = new TensorReaderBinaryBlock();
+			return reader.readTensorFromHDFS("a", dims, 1024, new ValueType[]{tb1.getValueType()});
+		}
+		catch (Exception ex) {
+			throw new DMLRuntimeException(ex);
+		}
+	}
+
+	private TensorBlock writeAndReadDataTensorBinaryBlock(TensorBlock tb1) {
+		try {
+			long[] dims = Arrays.stream(tb1.getDims()).mapToLong(i -> i).toArray();
+			TensorWriterBinaryBlock writer = new TensorWriterBinaryBlock();
+			writer.writeTensorToHDFS(tb1, "a", dims, 1024);
+			TensorReaderBinaryBlock reader = new TensorReaderBinaryBlock();
+			return reader.readTensorFromHDFS("a", dims, 1024, tb1.getSchema());
+		}
+		catch (Exception ex) {
+			throw new DMLRuntimeException(ex);
+		}
+	}
+}

--- a/src/test/java/org/tugraz/sysds/test/functions/data/TensorBinaryBlockTest.java
+++ b/src/test/java/org/tugraz/sysds/test/functions/data/TensorBinaryBlockTest.java
@@ -59,7 +59,7 @@ public class TensorBinaryBlockTest {
 	}
 
 	private void testReadWriteBinaryBlockBasicTensor(ValueType vt) {
-		TensorBlock tb1 = createBasicTensor(vt, 70, 30, 0.7);
+		TensorBlock tb1 = createBasicTensor(vt, 70, 3000, 0.7);
 		TensorBlock tb2 = writeAndReadBasicTensorBinaryBlock(tb1);
 		compareTensorBlocks(tb1, tb2);
 	}
@@ -95,7 +95,7 @@ public class TensorBinaryBlockTest {
 	}
 
 	private void testReadWriteBinaryBlockDataTensor(ValueType vt) {
-		TensorBlock tb1 = createDataTensor(vt, 70, 30, 0.7);
+		TensorBlock tb1 = createDataTensor(vt, 70, 3000, 0.7);
 		TensorBlock tb2 = writeAndReadDataTensorBinaryBlock(tb1);
 		compareTensorBlocks(tb1, tb2);
 	}

--- a/src/test/java/org/tugraz/sysds/test/functions/data/TensorBinaryBlockTest.java
+++ b/src/test/java/org/tugraz/sysds/test/functions/data/TensorBinaryBlockTest.java
@@ -24,8 +24,6 @@ import org.tugraz.sysds.runtime.data.TensorBlock;
 import org.tugraz.sysds.runtime.io.TensorReaderBinaryBlock;
 import org.tugraz.sysds.runtime.io.TensorWriterBinaryBlock;
 
-import java.util.Arrays;
-
 import static org.tugraz.sysds.test.TestUtils.*;
 
 
@@ -104,7 +102,7 @@ public class TensorBinaryBlockTest {
 
 	private TensorBlock writeAndReadBasicTensorBinaryBlock(TensorBlock tb1) {
 		try {
-			long[] dims = Arrays.stream(tb1.getDims()).mapToLong(i -> i).toArray();
+			long[] dims = tb1.getLongDims();
 			TensorWriterBinaryBlock writer = new TensorWriterBinaryBlock();
 			writer.writeTensorToHDFS(tb1, "a", dims, 1024);
 			TensorReaderBinaryBlock reader = new TensorReaderBinaryBlock();
@@ -117,7 +115,7 @@ public class TensorBinaryBlockTest {
 
 	private TensorBlock writeAndReadDataTensorBinaryBlock(TensorBlock tb1) {
 		try {
-			long[] dims = Arrays.stream(tb1.getDims()).mapToLong(i -> i).toArray();
+			long[] dims = tb1.getLongDims();
 			TensorWriterBinaryBlock writer = new TensorWriterBinaryBlock();
 			writer.writeTensorToHDFS(tb1, "a", dims, 1024);
 			TensorReaderBinaryBlock reader = new TensorReaderBinaryBlock();

--- a/src/test/java/org/tugraz/sysds/test/functions/data/TensorTextCellTest.java
+++ b/src/test/java/org/tugraz/sysds/test/functions/data/TensorTextCellTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2019 Graz University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.tugraz.sysds.test.functions.data;
+
+import org.junit.Test;
+import org.tugraz.sysds.common.Types.ValueType;
+import org.tugraz.sysds.runtime.DMLRuntimeException;
+import org.tugraz.sysds.runtime.data.TensorBlock;
+import org.tugraz.sysds.runtime.io.TensorReaderTextCell;
+import org.tugraz.sysds.runtime.io.TensorWriterTextCell;
+
+import java.util.Arrays;
+
+import static org.tugraz.sysds.test.TestUtils.*;
+
+
+public class TensorTextCellTest {
+	@Test
+	public void testReadWriteTextCellBasicTensorFP32() {
+		testReadWriteTextCellBasicTensor(ValueType.FP32);
+	}
+
+	@Test
+	public void testReadWriteTextCellBasicTensorFP64() {
+		testReadWriteTextCellBasicTensor(ValueType.FP64);
+	}
+
+	@Test
+	public void testReadWriteTextCellBasicTensorINT32() {
+		testReadWriteTextCellBasicTensor(ValueType.INT32);
+	}
+
+	@Test
+	public void testReadWriteTextCellBasicTensorINT64() {
+		testReadWriteTextCellBasicTensor(ValueType.INT64);
+	}
+
+	@Test
+	public void testReadWriteTextCellBasicTensorBoolean() {
+		testReadWriteTextCellBasicTensor(ValueType.BOOLEAN);
+	}
+
+	@Test
+	public void testReadWriteTextCellBasicTensorString() {
+		testReadWriteTextCellBasicTensor(ValueType.STRING);
+	}
+
+	private void testReadWriteTextCellBasicTensor(ValueType vt) {
+		TensorBlock tb1 = createBasicTensor(vt, 70, 30, 0.7);
+		TensorBlock tb2 = writeAndReadBasicTensorTextCell(tb1);
+		compareTensorBlocks(tb1, tb2);
+	}
+
+	@Test
+	public void testReadWriteTextCellDataTensorFP32() {
+		testReadWriteTextCellDataTensor(ValueType.FP32);
+	}
+
+	@Test
+	public void testReadWriteTextCellDataTensorFP64() {
+		testReadWriteTextCellDataTensor(ValueType.FP64);
+	}
+
+	@Test
+	public void testReadWriteTextCellDataTensorINT32() {
+		testReadWriteTextCellDataTensor(ValueType.INT32);
+	}
+
+	@Test
+	public void testReadWriteTextCellDataTensorINT64() {
+		testReadWriteTextCellDataTensor(ValueType.INT64);
+	}
+
+	@Test
+	public void testReadWriteTextCellDataTensorBoolean() {
+		testReadWriteTextCellDataTensor(ValueType.BOOLEAN);
+	}
+
+	@Test
+	public void testReadWriteTextCellDataTensorString() {
+		testReadWriteTextCellDataTensor(ValueType.STRING);
+	}
+
+	private void testReadWriteTextCellDataTensor(ValueType vt) {
+		TensorBlock tb1 = createDataTensor(vt, 70, 30, 0.7);
+		TensorBlock tb2 = writeAndReadDataTensorTextCell(tb1);
+		compareTensorBlocks(tb1, tb2);
+	}
+
+	private TensorBlock writeAndReadBasicTensorTextCell(TensorBlock tb1) {
+		try {
+			long[] dims = new long[tb1.getNumDims()];
+			for (int i = 0; i < dims.length; i++)
+				dims[i] = tb1.getDim(i);
+			TensorWriterTextCell writer = new TensorWriterTextCell();
+			writer.writeTensorToHDFS(tb1, "a", dims, 1024);
+			TensorReaderTextCell reader = new TensorReaderTextCell();
+			return reader.readTensorFromHDFS("a", dims, 1024, new ValueType[]{tb1.getValueType()});
+		}
+		catch (Exception ex) {
+			throw new DMLRuntimeException(ex);
+		}
+	}
+
+	private TensorBlock writeAndReadDataTensorTextCell(TensorBlock tb1) {
+		try {
+			long[] dims = Arrays.stream(tb1.getDims()).mapToLong(i -> i).toArray();
+			TensorWriterTextCell writer = new TensorWriterTextCell();
+			writer.writeTensorToHDFS(tb1, "a", dims, 1024);
+			TensorReaderTextCell reader = new TensorReaderTextCell();
+			return reader.readTensorFromHDFS("a", dims, 1024, tb1.getSchema());
+		}
+		catch (Exception ex) {
+			throw new DMLRuntimeException(ex);
+		}
+	}
+}

--- a/src/test/java/org/tugraz/sysds/test/functions/data/TensorTextCellTest.java
+++ b/src/test/java/org/tugraz/sysds/test/functions/data/TensorTextCellTest.java
@@ -24,8 +24,6 @@ import org.tugraz.sysds.runtime.data.TensorBlock;
 import org.tugraz.sysds.runtime.io.TensorReaderTextCell;
 import org.tugraz.sysds.runtime.io.TensorWriterTextCell;
 
-import java.util.Arrays;
-
 import static org.tugraz.sysds.test.TestUtils.*;
 
 
@@ -104,9 +102,7 @@ public class TensorTextCellTest {
 
 	private TensorBlock writeAndReadBasicTensorTextCell(TensorBlock tb1) {
 		try {
-			long[] dims = new long[tb1.getNumDims()];
-			for (int i = 0; i < dims.length; i++)
-				dims[i] = tb1.getDim(i);
+			long[] dims = tb1.getLongDims();
 			TensorWriterTextCell writer = new TensorWriterTextCell();
 			writer.writeTensorToHDFS(tb1, "a", dims, 1024);
 			TensorReaderTextCell reader = new TensorReaderTextCell();
@@ -119,7 +115,7 @@ public class TensorTextCellTest {
 
 	private TensorBlock writeAndReadDataTensorTextCell(TensorBlock tb1) {
 		try {
-			long[] dims = Arrays.stream(tb1.getDims()).mapToLong(i -> i).toArray();
+			long[] dims = tb1.getLongDims();
 			TensorWriterTextCell writer = new TensorWriterTextCell();
 			writer.writeTensorToHDFS(tb1, "a", dims, 1024);
 			TensorReaderTextCell reader = new TensorReaderTextCell();


### PR DESCRIPTION
Adds read and write (TextCell and BinaryBlock) support for tensor. Currently only the `write` DML instructions is working correctly, `read` will fail, because arbitrary number of dimensions support is still missing for the `read` instruction.