### PR TITLE
Remove `istensor` parameter from rand instruction

### DIFF
--- a/src/main/java/org/tugraz/sysds/hops/DataGenOp.java
+++ b/src/main/java/org/tugraz/sysds/hops/DataGenOp.java
@@ -96,10 +96,7 @@ public class DataGenOp extends MultiThreadedHop
 		_op = mthd;
 		
 		//ensure all parameters existing and consistent with data type
-		//TODO remove once this unnecessary parameter is cleaned up
-		if( !inputParameters.containsKey(DataExpression.RAND_TENSOR) )
-			inputParameters.put(DataExpression.RAND_TENSOR, new LiteralOp(false));
-		else if (HopRewriteUtils.isLiteralOfValue(inputParameters.get(DataExpression.RAND_TENSOR), true))
+		if( inputParameters.containsKey(DataExpression.RAND_DIMS) )
 			setDataType(DataType.TENSOR);
 		
 		int index = 0;
@@ -115,7 +112,7 @@ public class DataGenOp extends MultiThreadedHop
 		
 		Hop sparsityOp = inputParameters.get(DataExpression.RAND_SPARSITY);
 		if ( mthd == DataGenMethod.RAND && sparsityOp instanceof LiteralOp)
-			_sparsity = Double.valueOf(((LiteralOp)sparsityOp).getName());
+			_sparsity = Double.parseDouble(sparsityOp.getName());
 		
 		//generate base dir
 		String scratch = ConfigurationManager.getScratchSpace();
@@ -215,7 +212,7 @@ public class DataGenOp extends MultiThreadedHop
 	@Override
 	protected double computeOutputMemEstimate( long dim1, long dim2, long nnz )
 	{		
-		double ret = 0;
+		double ret;
 		
 		if ( _op == DataGenMethod.RAND && _sparsity != -1 ) {
 			if( hasConstantValue(0.0) ) { //if empty block
@@ -253,11 +250,17 @@ public class DataGenOp extends MultiThreadedHop
 		if( (_op == DataGenMethod.RAND || _op == DataGenMethod.SINIT ) &&
 			OptimizerUtils.ALLOW_WORSTCASE_SIZE_EXPRESSION_EVALUATION )
 		{
-			long dim1 = computeDimParameterInformation(getInput().get(_paramIndexMap.get(DataExpression.RAND_ROWS)), memo);
-			long dim2 = computeDimParameterInformation(getInput().get(_paramIndexMap.get(DataExpression.RAND_COLS)), memo);
-			long nnz = _sparsity >= 0 ? (long)(_sparsity * dim1 * dim2) : -1;
-			if( dim1>=0 && dim2>=0 )
-				return new MatrixCharacteristics(dim1, dim2, -1, nnz);
+			if (_paramIndexMap.containsKey(DataExpression.RAND_DIMS)) {
+				// TODO size information for tensors
+				return null;
+			}
+			else {
+				long dim1 = computeDimParameterInformation(getInput().get(_paramIndexMap.get(DataExpression.RAND_ROWS)), memo);
+				long dim2 = computeDimParameterInformation(getInput().get(_paramIndexMap.get(DataExpression.RAND_COLS)), memo);
+				long nnz = _sparsity >= 0 ? (long) (_sparsity * dim1 * dim2) : -1;
+				if( dim1 >= 0 && dim2 >= 0 )
+					return new MatrixCharacteristics(dim1, dim2, -1, nnz);
+			}
 		}
 		else if ( _op == DataGenMethod.SEQ )
 		{
@@ -454,8 +457,8 @@ public class DataGenOp extends MultiThreadedHop
 		//sparsity awareness if requires
 		if( ret && val != 0 ) {
 			Hop sparsity = getInput().get(_paramIndexMap.get(DataExpression.RAND_SPARSITY)); //sparsity
-			ret &= (sparsity == null || sparsity instanceof LiteralOp 
-				&& HopRewriteUtils.getDoubleValueSafe((LiteralOp)sparsity) == 1);
+			ret = (sparsity == null || sparsity instanceof LiteralOp
+					&& HopRewriteUtils.getDoubleValueSafe((LiteralOp) sparsity) == 1);
 		}
 		
 		return ret;
@@ -522,8 +525,7 @@ public class DataGenOp extends MultiThreadedHop
 			for( Entry<String,Integer> e : _paramIndexMap.entrySet() ) {
 				String key1 = e.getKey();
 				int pos1 = e.getValue();
-				int pos2 = that2._paramIndexMap.containsKey(key1) ?
-					that2._paramIndexMap.get(key1) : -1;
+				int pos2 = that2._paramIndexMap.getOrDefault(key1, -1);
 				ret &= ( pos2 >=0 && that2.getInput().get(pos2)!=null
 					&& getInput().get(pos1) == that2.getInput().get(pos2) );
 			}

--- a/src/main/java/org/tugraz/sysds/hops/UnaryOp.java
+++ b/src/main/java/org/tugraz/sysds/hops/UnaryOp.java
@@ -254,7 +254,7 @@ public class UnaryOp extends MultiThreadedHop
 		//special case single row block (no offsets needed)
 		if( rlen > 0 && clen > 0 && rlen <= blen ) {
 			Lop offset = HopRewriteUtils.createDataGenOpByVal(new LiteralOp(1), new LiteralOp(clen),
-					new LiteralOp("1 1"), DataType.MATRIX, ValueType.FP64, getCumulativeInitValue()).constructLops();
+					null, DataType.MATRIX, ValueType.FP64, getCumulativeInitValue()).constructLops();
 			return constructCumOffBinary(X, offset, aggtype, rlen, clen, blen);
 		}
 		

--- a/src/main/java/org/tugraz/sysds/hops/recompile/Recompiler.java
+++ b/src/main/java/org/tugraz/sysds/hops/recompile/Recompiler.java
@@ -1327,14 +1327,17 @@ public class Recompiler
 				|| d.getOp() == DataGenMethod.SAMPLE ) 
 			{
 				boolean initUnknown = !d.dimsKnown();
-				int ix1 = params.get(DataExpression.RAND_ROWS);
-				int ix2 = params.get(DataExpression.RAND_COLS);
-				//update rows/cols by evaluating simple expression of literals, nrow, ncol, scalars, binaryops
-				HashMap<Long, Long> memo = new HashMap<>();
-				d.refreshRowsParameterInformation(d.getInput().get(ix1), vars, memo);
-				d.refreshColsParameterInformation(d.getInput().get(ix2), vars, memo);
-				if( !(initUnknown & d.dimsKnown()) )
-					d.refreshSizeInformation();
+				// TODO refresh tensor size information
+				if (params.containsKey(DataExpression.RAND_ROWS) && params.containsKey(DataExpression.RAND_COLS)) {
+					int ix1 = params.get(DataExpression.RAND_ROWS);
+					int ix2 = params.get(DataExpression.RAND_COLS);
+					//update rows/cols by evaluating simple expression of literals, nrow, ncol, scalars, binaryops
+					HashMap<Long, Long> memo = new HashMap<>();
+					d.refreshRowsParameterInformation(d.getInput().get(ix1), vars, memo);
+					d.refreshColsParameterInformation(d.getInput().get(ix2), vars, memo);
+					if( !(initUnknown & d.dimsKnown()) )
+						d.refreshSizeInformation();
+				}
 			} 
 			else if ( d.getOp() == DataGenMethod.SEQ ) 
 			{

--- a/src/main/java/org/tugraz/sysds/hops/rewrite/HopRewriteUtils.java
+++ b/src/main/java/org/tugraz/sysds/hops/rewrite/HopRewriteUtils.java
@@ -307,7 +307,6 @@ public class HopRewriteUtils
 		HashMap<String, Hop> params = new HashMap<>();
 		params.put(DataExpression.RAND_ROWS, rows);
 		params.put(DataExpression.RAND_COLS, cols);
-		params.put(DataExpression.RAND_DIMS, new LiteralOp("-1")); //TODO
 		params.put(DataExpression.RAND_MIN, val);
 		params.put(DataExpression.RAND_MAX, val);
 		params.put(DataExpression.RAND_PDF, new LiteralOp(DataExpression.RAND_PDF_UNIFORM));
@@ -337,11 +336,8 @@ public class HopRewriteUtils
 	public static DataGenOp copyDataGenOp( DataGenOp inputGen, double scale, double shift ) 
 	{
 		HashMap<String, Integer> params = inputGen.getParamIndexMap();
-		Hop rows = inputGen.getInput().get(params.get(DataExpression.RAND_ROWS));
-		Hop cols = inputGen.getInput().get(params.get(DataExpression.RAND_COLS));
 		Hop min = inputGen.getInput().get(params.get(DataExpression.RAND_MIN));
 		Hop max = inputGen.getInput().get(params.get(DataExpression.RAND_MAX));
-		Hop dims = inputGen.getInput().get(params.get(DataExpression.RAND_DIMS));
 		Hop pdf = inputGen.getInput().get(params.get(DataExpression.RAND_PDF));
 		Hop mean = inputGen.getInput().get(params.get(DataExpression.RAND_LAMBDA));
 		Hop sparsity = inputGen.getInput().get(params.get(DataExpression.RAND_SPARSITY));
@@ -361,11 +357,18 @@ public class HopRewriteUtils
 		Hop smaxHop = new LiteralOp(smax);
 		
 		HashMap<String, Hop> params2 = new HashMap<>();
-		params2.put(DataExpression.RAND_ROWS, rows);
-		params2.put(DataExpression.RAND_COLS, cols);
+		if( !params.containsKey(DataExpression.RAND_DIMS) ) {
+			Hop rows = inputGen.getInput().get(params.get(DataExpression.RAND_ROWS));
+			Hop cols = inputGen.getInput().get(params.get(DataExpression.RAND_COLS));
+			params2.put(DataExpression.RAND_ROWS, rows);
+			params2.put(DataExpression.RAND_COLS, cols);
+		}
+		else {
+			Hop dims = inputGen.getInput().get(params.get(DataExpression.RAND_DIMS));
+			params2.put(DataExpression.RAND_DIMS, dims);
+		}
 		params2.put(DataExpression.RAND_MIN, sminHop);
 		params2.put(DataExpression.RAND_MAX, smaxHop);
-		params2.put(DataExpression.RAND_DIMS, dims);
 		params2.put(DataExpression.RAND_PDF, pdf);
 		params2.put(DataExpression.RAND_LAMBDA, mean);
 		params2.put(DataExpression.RAND_SPARSITY, sparsity);
@@ -393,7 +396,6 @@ public class HopRewriteUtils
 		HashMap<String, Hop> params = new HashMap<>();
 		params.put(DataExpression.RAND_ROWS, rows);
 		params.put(DataExpression.RAND_COLS, cols);
-		params.put(DataExpression.RAND_DIMS, new LiteralOp("-1")); //TODO
 		params.put(DataExpression.RAND_MIN, val);
 		params.put(DataExpression.RAND_MAX, val);
 		params.put(DataExpression.RAND_PDF, new LiteralOp(DataExpression.RAND_PDF_UNIFORM));
@@ -428,7 +430,6 @@ public class HopRewriteUtils
 		params.put(DataExpression.RAND_COLS, cols);
 		params.put(DataExpression.RAND_MIN, val);
 		params.put(DataExpression.RAND_MAX, val);
-		params.put(DataExpression.RAND_DIMS, new LiteralOp("-1")); //TODO
 		params.put(DataExpression.RAND_PDF, new LiteralOp(DataExpression.RAND_PDF_UNIFORM));
 		params.put(DataExpression.RAND_LAMBDA,new LiteralOp(-1.0));
 		params.put(DataExpression.RAND_SPARSITY, new LiteralOp(1.0));		
@@ -449,16 +450,18 @@ public class HopRewriteUtils
 		Hop val = new LiteralOp(value);
 		
 		HashMap<String, Hop> params = new HashMap<>();
-		params.put(DataExpression.RAND_ROWS, rowInput);
-		params.put(DataExpression.RAND_COLS, colInput);
-		params.put(DataExpression.RAND_DIMS, dimsInput);
+		if (dt.isTensor())
+			params.put(DataExpression.RAND_DIMS, dimsInput);
+		else {
+			params.put(DataExpression.RAND_ROWS, rowInput);
+			params.put(DataExpression.RAND_COLS, colInput);
+		}
 		params.put(DataExpression.RAND_MIN, val);
 		params.put(DataExpression.RAND_MAX, val);
 		params.put(DataExpression.RAND_PDF, new LiteralOp(DataExpression.RAND_PDF_UNIFORM));
 		params.put(DataExpression.RAND_LAMBDA, new LiteralOp(-1.0));
 		params.put(DataExpression.RAND_SPARSITY, new LiteralOp(1.0));		
 		params.put(DataExpression.RAND_SEED, new LiteralOp(DataGenOp.UNSPECIFIED_SEED) );
-		params.put(DataExpression.RAND_TENSOR, new LiteralOp(false));
 		
 		//note internal refresh size information
 		DataIdentifier di = new DataIdentifier("tmp");

--- a/src/main/java/org/tugraz/sysds/hops/rewrite/RewriteAlgebraicSimplificationDynamic.java
+++ b/src/main/java/org/tugraz/sysds/hops/rewrite/RewriteAlgebraicSimplificationDynamic.java
@@ -214,7 +214,7 @@ public class RewriteAlgebraicSimplificationDynamic extends HopRewriteRule
 			{
 				//remove unnecessary right indexing
 				Hop hnew = HopRewriteUtils.createDataGenOpByVal( new LiteralOp(hi.getDim1()),
-						new LiteralOp(hi.getDim2()), new LiteralOp("1 1"), DataType.MATRIX, ValueType.FP64, 0);
+						new LiteralOp(hi.getDim2()), null, DataType.MATRIX, ValueType.FP64, 0);
 				HopRewriteUtils.replaceChildReference(parent, hi, hnew, pos);
 				HopRewriteUtils.cleanupUnreferenced(hi, input);
 				hi = hnew;
@@ -824,7 +824,7 @@ public class RewriteAlgebraicSimplificationDynamic extends HopRewriteRule
 						else //diagm2v TODO support tensor operation
 							hnew = HopRewriteUtils.createDataGenOpByVal(
 									HopRewriteUtils.createValueHop(input,true), new LiteralOp(1),
-									new LiteralOp("1 1"), DataType.MATRIX, ValueType.FP64, 0);
+									null, DataType.MATRIX, ValueType.FP64, 0);
 					}
 				}
 				else if( rhi.getOp() == ReOrgOp.RESHAPE )

--- a/src/main/java/org/tugraz/sysds/lops/DataGen.java
+++ b/src/main/java/org/tugraz/sysds/lops/DataGen.java
@@ -132,7 +132,8 @@ public class DataGen extends Lop
 		//sanity checks
 		if ( method != DataGenMethod.RAND )
 			throw new LopsException("Invalid instruction generation for data generation method " + method);
-		if( getInputs().size() != DataExpression.RAND_VALID_PARAM_NAMES.length ) {
+		if( getInputs().size() != DataExpression.RAND_VALID_PARAM_NAMES.length - 2 && // tensor
+				getInputs().size() != DataExpression.RAND_VALID_PARAM_NAMES.length - 1 ) { // matrix
 			throw new LopsException(printErrorLocation() + "Invalid number of operands (" 
 				+ getInputs().size() + ") for a Rand operation");
 		}
@@ -145,17 +146,20 @@ public class DataGen extends Lop
 		sb.append(RAND_OPCODE);
 		sb.append(OPERAND_DELIMITOR);
 		
-		Lop iLop = _inputParams.get(DataExpression.RAND_ROWS);
-		sb.append(iLop.prepScalarInputOperand(getExecType()));
-		sb.append(OPERAND_DELIMITOR);
-
-		iLop = _inputParams.get(DataExpression.RAND_COLS);
-		sb.append(iLop.prepScalarInputOperand(getExecType()));
-		sb.append(OPERAND_DELIMITOR);
-
-		iLop = _inputParams.get(DataExpression.RAND_DIMS);
-		sb.append(iLop.prepScalarInputOperand(getExecType()));
-		sb.append(OPERAND_DELIMITOR);
+		Lop iLop = _inputParams.get(DataExpression.RAND_DIMS);
+		if (iLop != null) {
+			sb.append(iLop.prepScalarInputOperand(getExecType()));
+			sb.append(OPERAND_DELIMITOR);
+		}
+		else {
+			iLop = _inputParams.get(DataExpression.RAND_ROWS);
+			sb.append(iLop.prepScalarInputOperand(getExecType()));
+			sb.append(OPERAND_DELIMITOR);
+			
+			iLop = _inputParams.get(DataExpression.RAND_COLS);
+			sb.append(iLop.prepScalarInputOperand(getExecType()));
+			sb.append(OPERAND_DELIMITOR);
+		}
 
 		sb.append(getOutputParameters().getBlocksize());
 		sb.append(OPERAND_DELIMITOR);
@@ -219,9 +223,6 @@ public class DataGen extends Lop
 		iLop = _inputParams.get(DataExpression.RAND_COLS);
 		String colsString = iLop.prepScalarLabel();
 
-		iLop = _inputParams.get(DataExpression.RAND_DIMS);
-		String dimsString = iLop.prepScalarLabel();
-
 		String blen = String.valueOf(getOutputParameters().getBlocksize());
 
 		iLop = _inputParams.get(DataExpression.RAND_MIN);
@@ -242,8 +243,6 @@ public class DataGen extends Lop
 		sb.append(rowsString);
 		sb.append(OPERAND_DELIMITOR);
 		sb.append(colsString);
-		sb.append(OPERAND_DELIMITOR);
-		sb.append(dimsString);
 		sb.append(OPERAND_DELIMITOR);
 		sb.append(blen);
 		sb.append(OPERAND_DELIMITOR);

--- a/src/main/java/org/tugraz/sysds/parser/DataExpression.java
+++ b/src/main/java/org/tugraz/sysds/parser/DataExpression.java
@@ -53,7 +53,6 @@ import java.util.Map.Entry;
 public class DataExpression extends DataIdentifier 
 {
 	public static final String RAND_DIMS = "dims";
-	public static final String RAND_TENSOR = "istensor";
 
 	public static final String RAND_ROWS = "rows";
 	public static final String RAND_COLS = "cols";
@@ -103,8 +102,7 @@ public class DataExpression extends DataIdentifier
 	public static final String DELIM_SPARSE = "sparse";  // applicable only for write
 	
 	public static final String[] RAND_VALID_PARAM_NAMES = 
-		{RAND_ROWS, RAND_COLS, RAND_DIMS, RAND_MIN, RAND_MAX, RAND_SPARSITY, RAND_SEED, RAND_PDF, RAND_LAMBDA,
-		RAND_TENSOR}; //FIXME: why is this istensor required at all
+		{RAND_ROWS, RAND_COLS, RAND_DIMS, RAND_MIN, RAND_MAX, RAND_SPARSITY, RAND_SEED, RAND_PDF, RAND_LAMBDA};
 	
 	public static final String[] RESHAPE_VALID_PARAM_NAMES =
 		{  RAND_BY_ROW, RAND_DIMNAMES, RAND_DATA, RAND_ROWS, RAND_COLS, RAND_DIMS};
@@ -497,37 +495,23 @@ public class DataExpression extends DataIdentifier
 	public void setMatrixDefault(){
 		if (getVarParam(RAND_BY_ROW) == null)
 			addVarParam(RAND_BY_ROW, new BooleanIdentifier(true, this));
-		if (getVarParam(RAND_DIMS) == null) {
-			StringIdentifier id = new StringIdentifier("1 1", this);
-			addVarParam(RAND_DIMS, id);
-		}
 	}
 
 	public void setTensorDefault(){
 		if (getVarParam(RAND_BY_ROW) == null)
 			addVarParam(RAND_BY_ROW, new BooleanIdentifier(true, this));
-		if (getVarParam(RAND_ROWS) == null) {
-			IntIdentifier id = new IntIdentifier(1L, this);
-			addVarParam(RAND_ROWS, id);
-		}
-		if (getVarParam(RAND_COLS) == null) {
-			IntIdentifier id = new IntIdentifier(1L, this);
-			addVarParam(RAND_COLS, id);
-		}
 	}
 
 	public void setRandDefault() {
-		if (getVarParam(RAND_ROWS) == null) {
-			IntIdentifier id = new IntIdentifier(1L, this);
-			addVarParam(RAND_ROWS, id);
-		}
-		if (getVarParam(RAND_COLS) == null) {
-			IntIdentifier id = new IntIdentifier(1L, this);
-			addVarParam(RAND_COLS, id);
-		}
 		if (getVarParam(RAND_DIMS) == null) {
-			StringIdentifier id = new StringIdentifier("1 1", this);
-			addVarParam(RAND_DIMS, id);
+			if( getVarParam(RAND_ROWS) == null ) {
+				IntIdentifier id = new IntIdentifier(1L, this);
+				addVarParam(RAND_ROWS, id);
+			}
+			if( getVarParam(RAND_COLS) == null ) {
+				IntIdentifier id = new IntIdentifier(1L, this);
+				addVarParam(RAND_COLS, id);
+			}
 		}
 		if (getVarParam(RAND_MIN) == null) {
 			DoubleIdentifier id = new DoubleIdentifier(0.0, this);
@@ -552,10 +536,6 @@ public class DataExpression extends DataIdentifier
 		if (getVarParam(RAND_LAMBDA) == null) {
 			DoubleIdentifier id = new DoubleIdentifier(1.0, this);
 			addVarParam(RAND_LAMBDA, id);
-		}
-		if (getVarParam(RAND_TENSOR) == null) {
-			BooleanIdentifier id = new BooleanIdentifier(false, this);
-			addVarParam(RAND_TENSOR, id);
 		}
 	}
 
@@ -677,9 +657,6 @@ public class DataExpression extends DataIdentifier
 			
 			// replace DataOp MATRIX with RAND -- Rand handles matrix generation for Scalar values
 			// replace data parameter with min / max within Rand case below
-			// TODO either use dims or rows, cols depending on datatype
-			BooleanIdentifier id = new BooleanIdentifier(_opcode == DataOp.TENSOR, this);
-			addVarParam(RAND_TENSOR, id);
 			this.setOpCode(DataOp.RAND);
 		}
 		
@@ -1027,7 +1004,7 @@ public class DataExpression extends DataIdentifier
 				{
 					getOutput().setFormatType(FormatType.CSV);
 					format = 1;
-				} 
+				}
 				else if ( fmt.equalsIgnoreCase(FORMAT_TYPE_VALUE_MATRIXMARKET) )
 				{
 					getOutput().setFormatType(FormatType.MM);
@@ -1153,11 +1130,11 @@ public class DataExpression extends DataIdentifier
 			}
 			break;
 
-			case RAND: 
+			case RAND:
 			
 			Expression dataParam = getVarParam(RAND_DATA);
 			
-			if( dataParam != null ) 
+			if( dataParam != null )
 			{
 				// handle input variable (matrix/scalar)
 				if( dataParam instanceof DataIdentifier )
@@ -1165,19 +1142,19 @@ public class DataExpression extends DataIdentifier
 					addVarParam(RAND_MIN, dataParam);
 					addVarParam(RAND_MAX, dataParam);
 				}
-				// handle integer constant 
+				// handle integer constant
 				else if (dataParam instanceof IntIdentifier) {
 					addVarParam(RAND_MIN, dataParam);
 					addVarParam(RAND_MAX, dataParam);
 				}
-				// handle double constant 
+				// handle double constant
 				else if (dataParam instanceof DoubleIdentifier) {
 					double roundedValue = ((DoubleIdentifier)dataParam).getValue();
 					Expression minExpr = new DoubleIdentifier(roundedValue, this);
 					addVarParam(RAND_MIN, minExpr);
 					addVarParam(RAND_MAX, minExpr);
 				}
-				// handle string constant (string init) 
+				// handle string constant (string init)
 				else if (dataParam instanceof StringIdentifier) {
 					String data = ((StringIdentifier)dataParam).getValue();
 					Expression minExpr = new StringIdentifier(data, this);
@@ -1206,7 +1183,7 @@ public class DataExpression extends DataIdentifier
 			//parameters w/ support for variable inputs
 			if (getVarParam(RAND_ROWS) instanceof StringIdentifier || getVarParam(RAND_ROWS) instanceof BooleanIdentifier){
 				raiseValidateError("for Rand statement " + RAND_ROWS + " has incorrect value type", conditional);
-			}				
+			}
 			
 			if (getVarParam(RAND_COLS) instanceof StringIdentifier || getVarParam(RAND_COLS) instanceof BooleanIdentifier){
 				raiseValidateError("for Rand statement " + RAND_COLS + " has incorrect value type", conditional);
@@ -1221,12 +1198,7 @@ public class DataExpression extends DataIdentifier
 				raiseValidateError("for Rand statement " + RAND_SEED + " has incorrect value type", conditional);
 			}
 
-			boolean isTensorOperation = false;
-			if (!(getVarParam(RAND_TENSOR) instanceof BooleanIdentifier)) {
-				raiseValidateError("for Rand statement " + RAND_TENSOR + " has incorrect value type", conditional);
-			} else {
-				isTensorOperation = ((BooleanIdentifier)getVarParam(RAND_TENSOR)).getValue();
-			}
+			boolean isTensorOperation = getVarParam(RAND_DIMS) != null;
 
 			if ((getVarParam(RAND_MAX) instanceof StringIdentifier && !_strInit) ||
 					(getVarParam(RAND_MAX) instanceof BooleanIdentifier && !isTensorOperation)) {
@@ -1244,135 +1216,140 @@ public class DataExpression extends DataIdentifier
 			}
 	
 			Expression lambda = getVarParam(RAND_LAMBDA);
-			if (!( (lambda instanceof DataIdentifier 
-					|| lambda instanceof ConstIdentifier) 
-				&& (lambda.getOutput().getValueType() == ValueType.FP64 
+			if (!( (lambda instanceof DataIdentifier
+					|| lambda instanceof ConstIdentifier)
+				&& (lambda.getOutput().getValueType() == ValueType.FP64
 					|| lambda.getOutput().getValueType() == ValueType.INT64) )) {
 				raiseValidateError("for Rand statement " + RAND_LAMBDA + " has incorrect data type", conditional);
 			}
 				
 			long rowsLong = -1L, colsLong = -1L;
-
-			///////////////////////////////////////////////////////////////////
-			// HANDLE ROWS
-			///////////////////////////////////////////////////////////////////
+			
 			Expression rowsExpr = getVarParam(RAND_ROWS);
-			if (rowsExpr instanceof IntIdentifier) {
-				if( ((IntIdentifier)rowsExpr).getValue() < 0 ) {
-					raiseValidateError("In rand statement, can only assign rows a long " +
-						"(integer) value >= 0 -- attempted to assign value: " + ((IntIdentifier)rowsExpr).getValue(), conditional);
+			Expression colsExpr = getVarParam(RAND_COLS);
+			if (!isTensorOperation) {
+				///////////////////////////////////////////////////////////////////
+				// HANDLE ROWS
+				///////////////////////////////////////////////////////////////////
+				if( rowsExpr instanceof IntIdentifier ) {
+					if( ((IntIdentifier) rowsExpr).getValue() < 0 ) {
+						raiseValidateError("In rand statement, can only assign rows a long " +
+								"(integer) value >= 0 -- attempted to assign value: " + ((IntIdentifier) rowsExpr).getValue(), conditional);
+					}
+					rowsLong = ((IntIdentifier) rowsExpr).getValue();
 				}
-				rowsLong = ((IntIdentifier)rowsExpr).getValue();
-			}
-			else if (rowsExpr instanceof DoubleIdentifier) {
-				if ( ((DoubleIdentifier)rowsExpr).getValue() < 0 ) {
-				raiseValidateError("In rand statement, can only assign rows a long " +
-							"(integer) value >= 0 -- attempted to assign value: " + rowsExpr.toString(), conditional);
+				else if( rowsExpr instanceof DoubleIdentifier ) {
+					if( ((DoubleIdentifier) rowsExpr).getValue() < 0 ) {
+						raiseValidateError("In rand statement, can only assign rows a long " +
+								"(integer) value >= 0 -- attempted to assign value: " + rowsExpr.toString(), conditional);
+					}
+					rowsLong = UtilFunctions.toLong(Math.floor(((DoubleIdentifier) rowsExpr).getValue()));
 				}
-				rowsLong = UtilFunctions.toLong(Math.floor(((DoubleIdentifier)rowsExpr).getValue()));
-			}
-			else if (rowsExpr instanceof DataIdentifier && !(rowsExpr instanceof IndexedIdentifier)) {
-				
-				// check if the DataIdentifier variable is a ConstIdentifier
-				String identifierName = ((DataIdentifier)rowsExpr).getName();
-				if (currConstVars.containsKey(identifierName)){
+				else if( rowsExpr instanceof DataIdentifier && !(rowsExpr instanceof IndexedIdentifier) ) {
 					
-					// handle int constant
-					ConstIdentifier constValue = currConstVars.get(identifierName);
-					if (constValue instanceof IntIdentifier){
-						// check rows is >= 1 --- throw exception
-						if( ((IntIdentifier)constValue).getValue() < 0 ){
+					// check if the DataIdentifier variable is a ConstIdentifier
+					String identifierName = ((DataIdentifier) rowsExpr).getName();
+					if( currConstVars.containsKey(identifierName) ) {
+						
+						// handle int constant
+						ConstIdentifier constValue = currConstVars.get(identifierName);
+						if( constValue instanceof IntIdentifier ) {
+							// check rows is >= 1 --- throw exception
+							if( ((IntIdentifier) constValue).getValue() < 0 ) {
+								raiseValidateError("In rand statement, can only assign rows a long " +
+										"(integer) value >= 0 -- attempted to assign value: " + constValue.toString(), conditional);
+							}
+							// update row expr with new IntIdentifier
+							long roundedValue = ((IntIdentifier) constValue).getValue();
+							rowsExpr = new IntIdentifier(roundedValue, this);
+							addVarParam(RAND_ROWS, rowsExpr);
+							rowsLong = roundedValue;
+						}
+						// handle double constant
+						else if( constValue instanceof DoubleIdentifier ) {
+							if( ((DoubleIdentifier) constValue).getValue() < 0 ) {
+								raiseValidateError("In rand statement, can only assign rows a long " +
+										"(double) value >= 0 -- attempted to assign value: " + constValue.toString(), conditional);
+							}
+							// update row expr with new IntIdentifier (rounded down)
+							long roundedValue = Double.valueOf(Math.floor(((DoubleIdentifier) constValue).getValue())).longValue();
+							rowsExpr = new IntIdentifier(roundedValue, this);
+							addVarParam(RAND_ROWS, rowsExpr);
+							rowsLong = roundedValue;
+						}
+						else {
+							// exception -- rows must be integer or double constant
 							raiseValidateError("In rand statement, can only assign rows a long " +
 									"(integer) value >= 0 -- attempted to assign value: " + constValue.toString(), conditional);
 						}
-						// update row expr with new IntIdentifier 
-						long roundedValue = ((IntIdentifier)constValue).getValue();
-						rowsExpr = new IntIdentifier(roundedValue, this);
-						addVarParam(RAND_ROWS, rowsExpr);
-						rowsLong = roundedValue; 
-					}
-					// handle double constant 
-					else if (constValue instanceof DoubleIdentifier){
-						if (((DoubleIdentifier)constValue).getValue() < 0){
-							raiseValidateError("In rand statement, can only assign rows a long " +
-									"(double) value >= 0 -- attempted to assign value: " + constValue.toString(), conditional);
-						}
-						// update row expr with new IntIdentifier (rounded down)
-						long roundedValue = Double.valueOf(Math.floor(((DoubleIdentifier)constValue).getValue())).longValue();
-						rowsExpr = new IntIdentifier(roundedValue, this);
-						addVarParam(RAND_ROWS, rowsExpr);
-						rowsLong = roundedValue; 
 					}
 					else {
-						// exception -- rows must be integer or double constant
-						raiseValidateError("In rand statement, can only assign rows a long " +
-								"(integer) value >= 0 -- attempted to assign value: " + constValue.toString(), conditional);
+						// handle general expression
+						rowsExpr.validateExpression(ids, currConstVars, conditional);
 					}
 				}
 				else {
 					// handle general expression
 					rowsExpr.validateExpression(ids, currConstVars, conditional);
 				}
-			}	
-			else {
-				// handle general expression
-				rowsExpr.validateExpression(ids, currConstVars, conditional);
-			}
-			
-			///////////////////////////////////////////////////////////////////
-			// HANDLE COLUMNS
-			///////////////////////////////////////////////////////////////////
-			
-			Expression colsExpr = getVarParam(RAND_COLS);
-			if (colsExpr instanceof IntIdentifier) {
-				if  (((IntIdentifier)colsExpr).getValue() < 0 ) {
-					raiseValidateError("In rand statement, can only assign cols a long " +
-							"(integer) value >= 0 -- attempted to assign value: " + colsExpr.toString(), conditional);
-				}
-				colsLong = ((IntIdentifier)colsExpr).getValue();
-			}
-			else if (colsExpr instanceof DoubleIdentifier) {
-				if  (((DoubleIdentifier)colsExpr).getValue() < 0 ) {
-					raiseValidateError("In rand statement, can only assign cols a long " +
-							"(integer) value >= 0 -- attempted to assign value: " + colsExpr.toString(), conditional);
-				}
-				colsLong = Double.valueOf((Math.floor(((DoubleIdentifier)colsExpr).getValue()))).longValue();
-			}
-			else if (colsExpr instanceof DataIdentifier && !(colsExpr instanceof IndexedIdentifier)) {
 				
-				// check if the DataIdentifier variable is a ConstIdentifier
-				String identifierName = ((DataIdentifier)colsExpr).getName();
-				if (currConstVars.containsKey(identifierName)){
-					
-					// handle int constant
-					ConstIdentifier constValue = currConstVars.get(identifierName);
-					if (constValue instanceof IntIdentifier){
-						if (((IntIdentifier)constValue).getValue() < 0 ){
-							raiseValidateError("In rand statement, can only assign cols a long " +
-								"(integer) value >= 0 -- attempted to assign value: " + constValue.toString(), conditional);
-						}
-						// update col expr with new IntIdentifier 
-						long roundedValue = ((IntIdentifier)constValue).getValue();
-						colsExpr = new IntIdentifier(roundedValue, this);
-						addVarParam(RAND_COLS, colsExpr);
-						colsLong = roundedValue;
+				///////////////////////////////////////////////////////////////////
+				// HANDLE COLUMNS
+				///////////////////////////////////////////////////////////////////
+				if( colsExpr instanceof IntIdentifier ) {
+					if( ((IntIdentifier) colsExpr).getValue() < 0 ) {
+						raiseValidateError("In rand statement, can only assign cols a long " +
+								"(integer) value >= 0 -- attempted to assign value: " + colsExpr.toString(), conditional);
 					}
-					// handle double constant 
-					else if (constValue instanceof DoubleIdentifier){
-						if (((DoubleIdentifier)constValue).getValue() < 0){
-							raiseValidateError("In rand statement, can only assign cols a long " +
-								"(double) value >= 0 -- attempted to assign value: " + constValue.toString(), conditional);
+					colsLong = ((IntIdentifier) colsExpr).getValue();
+				}
+				else if( colsExpr instanceof DoubleIdentifier ) {
+					if( ((DoubleIdentifier) colsExpr).getValue() < 0 ) {
+						raiseValidateError("In rand statement, can only assign cols a long " +
+								"(integer) value >= 0 -- attempted to assign value: " + colsExpr.toString(), conditional);
+					}
+					colsLong = Double.valueOf((Math.floor(((DoubleIdentifier) colsExpr).getValue()))).longValue();
+				}
+				else if( colsExpr instanceof DataIdentifier && !(colsExpr instanceof IndexedIdentifier) ) {
+					
+					// check if the DataIdentifier variable is a ConstIdentifier
+					String identifierName = ((DataIdentifier) colsExpr).getName();
+					if( currConstVars.containsKey(identifierName) ) {
+						
+						// handle int constant
+						ConstIdentifier constValue = currConstVars.get(identifierName);
+						if( constValue instanceof IntIdentifier ) {
+							if( ((IntIdentifier) constValue).getValue() < 0 ) {
+								raiseValidateError("In rand statement, can only assign cols a long " +
+										"(integer) value >= 0 -- attempted to assign value: " + constValue.toString(), conditional);
+							}
+							// update col expr with new IntIdentifier
+							long roundedValue = ((IntIdentifier) constValue).getValue();
+							colsExpr = new IntIdentifier(roundedValue, this);
+							addVarParam(RAND_COLS, colsExpr);
+							colsLong = roundedValue;
 						}
-						// update col expr with new IntIdentifier (rounded down)
-						long roundedValue = Double.valueOf(Math.floor(((DoubleIdentifier)constValue).getValue())).longValue();
-						colsExpr = new IntIdentifier(roundedValue, this);
-						addVarParam(RAND_COLS, colsExpr);
-						colsLong = roundedValue; 
+						// handle double constant
+						else if( constValue instanceof DoubleIdentifier ) {
+							if( ((DoubleIdentifier) constValue).getValue() < 0 ) {
+								raiseValidateError("In rand statement, can only assign cols a long " +
+										"(double) value >= 0 -- attempted to assign value: " + constValue.toString(), conditional);
+							}
+							// update col expr with new IntIdentifier (rounded down)
+							long roundedValue = Double.valueOf(Math.floor(((DoubleIdentifier) constValue).getValue())).longValue();
+							colsExpr = new IntIdentifier(roundedValue, this);
+							addVarParam(RAND_COLS, colsExpr);
+							colsLong = roundedValue;
+						}
+						else {
+							// exception -- rows must be integer or double constant
+							raiseValidateError("In rand statement, can only assign cols a long " +
+									"(integer) value >= 0 -- attempted to assign value: " + constValue.toString(), conditional);
+						}
 					}
 					else {
-						// exception -- rows must be integer or double constant
-						raiseValidateError("In rand statement, can only assign cols a long " +
-							"(integer) value >= 0 -- attempted to assign value: " + constValue.toString(), conditional);
+						// handle general expression
+						colsExpr.validateExpression(ids, currConstVars, conditional);
 					}
 				}
 				else {
@@ -1380,19 +1357,9 @@ public class DataExpression extends DataIdentifier
 					colsExpr.validateExpression(ids, currConstVars, conditional);
 				}
 			}
-			else {
-				// handle general expression
-				colsExpr.validateExpression(ids, currConstVars, conditional);
-			}
-
-			///////////////////////////////////////////////////////////////////
-			// HANDLE DIMS
-			///////////////////////////////////////////////////////////////////
-			// TODO handle dims for rand
-
 			///////////////////////////////////////////////////////////////////
 			// HANDLE MIN
-			///////////////////////////////////////////////////////////////////	
+			///////////////////////////////////////////////////////////////////
 			Expression minExpr = getVarParam(RAND_MIN);
 			
 			// perform constant propogation
@@ -1406,12 +1373,12 @@ public class DataExpression extends DataIdentifier
 					ConstIdentifier constValue = currConstVars.get(identifierName);
 					if (constValue instanceof IntIdentifier){
 						
-						// update min expr with new IntIdentifier 
+						// update min expr with new IntIdentifier
 						long roundedValue = ((IntIdentifier)constValue).getValue();
 						minExpr = new DoubleIdentifier(roundedValue, this);
 						addVarParam(RAND_MIN, minExpr);
 					}
-					// handle double constant 
+					// handle double constant
 					else if (constValue instanceof DoubleIdentifier){
 		
 						// update col expr with new IntIdentifier (rounded down)
@@ -1451,12 +1418,12 @@ public class DataExpression extends DataIdentifier
 					// handle int constant
 					ConstIdentifier constValue = currConstVars.get(identifierName);
 					if (constValue instanceof IntIdentifier) {
-						// update min expr with new IntIdentifier 
+						// update min expr with new IntIdentifier
 						long roundedValue = ((IntIdentifier)constValue).getValue();
 						maxExpr = new DoubleIdentifier(roundedValue, this);
 						addVarParam(RAND_MAX, maxExpr);
 					}
-					// handle double constant 
+					// handle double constant
 					else if (constValue instanceof DoubleIdentifier) {
 						// update col expr with new IntIdentifier (rounded down)
 						double roundedValue = ((DoubleIdentifier)constValue).getValue();

--- a/src/main/java/org/tugraz/sysds/runtime/instructions/cp/StringInitCPInstruction.java
+++ b/src/main/java/org/tugraz/sysds/runtime/instructions/cp/StringInitCPInstruction.java
@@ -60,13 +60,12 @@ public class StringInitCPInstruction extends UnaryCPInstruction {
 			throw new DMLRuntimeException("Unsupported opcode: "+opcode);
 		//parse instruction
 		String[] s = InstructionUtils.getInstructionPartsWithValueType ( str );
-		InstructionUtils.checkNumFields( s, 6 );
+		InstructionUtils.checkNumFields( s, 5 );
 		CPOperand out = new CPOperand(s[s.length-1]); // output is specified by the last operand
 		long rows = (s[1].contains( Lop.VARIABLE_NAME_PLACEHOLDER)?-1:Double.valueOf(s[1]).longValue());
 		long cols = (s[2].contains( Lop.VARIABLE_NAME_PLACEHOLDER)?-1:Double.valueOf(s[2]).longValue());
-		// Ignore dims
-		int blen = Integer.parseInt(s[4]);
-		String data = s[5];
+		int blen = Integer.parseInt(s[3]);
+		String data = s[4];
 		return new StringInitCPInstruction(null, null, out, rows, cols, blen, data, opcode, str);
 	}
 	

--- a/src/main/java/org/tugraz/sysds/runtime/instructions/spark/RandSPInstruction.java
+++ b/src/main/java/org/tugraz/sysds/runtime/instructions/spark/RandSPInstruction.java
@@ -188,7 +188,7 @@ public class RandSPInstruction extends UnarySPInstruction {
 		DataGenMethod method = DataGenMethod.INVALID;
 		if ( opcode.equalsIgnoreCase(DataGen.RAND_OPCODE) ) {
 			method = DataGenMethod.RAND;
-			InstructionUtils.checkNumFields ( str, 12 );
+			InstructionUtils.checkNumFields ( str, 10, 11 );
 		}
 		else if ( opcode.equalsIgnoreCase(DataGen.SEQ_OPCODE) ) {
 			method = DataGenMethod.SEQ;
@@ -206,21 +206,29 @@ public class RandSPInstruction extends UnarySPInstruction {
 		CPOperand out = new CPOperand(s[s.length-1]); 
 
 		if ( method == DataGenMethod.RAND ) {
-			CPOperand rows = new CPOperand(s[1]);
-			CPOperand cols = new CPOperand(s[2]);
-			CPOperand dims = new CPOperand(s[3]);
-			int blen = Integer.parseInt(s[4]);
-			double sparsity = !s[7].contains(Lop.VARIABLE_NAME_PLACEHOLDER) ?
-				Double.valueOf(s[7]).doubleValue() : -1;
-			long seed = !s[8].contains(Lop.VARIABLE_NAME_PLACEHOLDER) ?
-				Long.valueOf(s[8]).longValue() : -1;
-			String dir = s[9];
-			String pdf = s[10];
-			String pdfParams = !s[11].contains( Lop.VARIABLE_NAME_PLACEHOLDER) ?
-				s[11] : null;
+			int missing; // number of missing params (row & cols or dims)
+			CPOperand rows = null, cols = null, dims = null;
+			if (s.length == 12) {
+				missing = 1;
+				rows = new CPOperand(s[1]);
+				cols = new CPOperand(s[2]);
+			}
+			else {
+				missing = 2;
+				dims = new CPOperand(s[1]);
+			}
+			int blen = Integer.parseInt(s[4 - missing]);
+			double sparsity = !s[7 - missing].contains(Lop.VARIABLE_NAME_PLACEHOLDER) ?
+					Double.parseDouble(s[7 - missing]) : -1;
+			long seed = !s[8 - missing].contains(Lop.VARIABLE_NAME_PLACEHOLDER) ?
+					Long.parseLong(s[8 - missing]) : -1;
+			String dir = s[9 - missing];
+			String pdf = s[10 - missing];
+			String pdfParams = !s[11 - missing].contains( Lop.VARIABLE_NAME_PLACEHOLDER) ?
+				s[11 - missing] : null;
 			
 			return new RandSPInstruction(op, method, null, out, rows, cols, dims,
-				blen, s[5], s[6], sparsity, seed, dir, pdf, pdfParams, opcode, str);
+				blen, s[5 - missing], s[6 - missing], sparsity, seed, dir, pdf, pdfParams, opcode, str);
 		}
 		else if ( method == DataGenMethod.SEQ) {
 			int blen = Integer.parseInt(s[3]);

--- a/src/main/java/org/tugraz/sysds/runtime/lineage/LineageItemUtils.java
+++ b/src/main/java/org/tugraz/sysds/runtime/lineage/LineageItemUtils.java
@@ -176,9 +176,12 @@ public class LineageItemUtils {
 				if (inst instanceof DataGenCPInstruction) {
 					DataGenCPInstruction rand = (DataGenCPInstruction) inst;
 					HashMap<String, Hop> params = new HashMap<>();
-					params.put(DataExpression.RAND_ROWS, new LiteralOp(rand.getRows()));
-					params.put(DataExpression.RAND_COLS, new LiteralOp(rand.getCols()));
-					params.put(DataExpression.RAND_DIMS, new LiteralOp(rand.getDims()));
+					if( rand.output.getDataType() == DataType.TENSOR)
+						params.put(DataExpression.RAND_DIMS, new LiteralOp(rand.getDims()));
+					else {
+						params.put(DataExpression.RAND_ROWS, new LiteralOp(rand.getRows()));
+						params.put(DataExpression.RAND_COLS, new LiteralOp(rand.getCols()));
+					}
 					params.put(DataExpression.RAND_MIN, new LiteralOp(rand.getMinValue()));
 					params.put(DataExpression.RAND_MAX, new LiteralOp(rand.getMaxValue()));
 					params.put(DataExpression.RAND_PDF, new LiteralOp(rand.getPdf()));

--- a/src/test/java/org/tugraz/sysds/test/functions/data/TensorRandTest.java
+++ b/src/test/java/org/tugraz/sysds/test/functions/data/TensorRandTest.java
@@ -93,9 +93,8 @@ public class TensorRandTest extends AutomatedTestBase {
 			String HOME = SCRIPT_DIR + TEST_DIR;
 
 			fullDMLScriptName = HOME + testName + ".dml";
-			StringBuilder dimensionsStringBuilder = new StringBuilder();
-			Arrays.stream(dimensions).forEach((dim) -> dimensionsStringBuilder.append(dim).append(" "));
-			String dimensionsString = dimensionsStringBuilder.toString();
+			String dimensionsString = Arrays.toString(dimensions).replace(",", "");
+			dimensionsString = dimensionsString.substring(1, dimensionsString.length() - 1);
 
 			programArgs = new String[]{"-explain", "-args", dimensionsString, min, max, Integer.toString(seed)};
 

--- a/src/test/scripts/functions/data/RandTensorTest.dml
+++ b/src/test/scripts/functions/data/RandTensorTest.dml
@@ -16,5 +16,5 @@
 #
 #-------------------------------------------------------------
 
-A = rand(dims=$1, min=$2, max=$3, seed=$4, istensor=TRUE)
+A = rand(dims=$1, min=$2, max=$3, seed=$4)
 print(toString(A))


### PR DESCRIPTION
Instead of having an explicit parameter to determine if `rand` function should create a matrix or a tensor, we determine this by the presence of either a `dims` parameter or the presence of both `rows` and `cols` parameters.