### PR TITLE
MICE Nominal Initial Commit

### DIFF
--- a/scripts/builtin/mice_nominal.dml
+++ b/scripts/builtin/mice_nominal.dml
@@ -50,34 +50,23 @@ s_mice_nominal= function(Frame[String] F, Integer iter = 3, Integer complete = 3
     stop("invalid aregument: can not apply mice on single column")
   # detecting the schema of data to identify nominal columns
   schema = detectSchema(F);
-  rec = matrix(0, 1, ncol(schema));
+  s=""
   for(i in 1: ncol(schema))
   {
     if(as.scalar(schema[1, i]) == 'STRING' | as.scalar(schema[1, i]) == 'BOOLEAN' )
-      rec[1, i] = 1
+      s = s+i+","
   }
-  rec = t(rec)
-  
-  # extracting the nominal columns
-  rec = removeEmpty(target=rec*seq(1,nrow(rec)), margin="rows");
-  s=""
-  for(j in 1: nrow(rec))
-  {
-    if(j != nrow(rec))
-      s = s+as.integer(as.scalar(rec[j,1]))+","   
-    else
-      s = s+as.integer(as.scalar(rec[j,1])) 
-  }
-  
   # encoding nominal columns using recode transformation
   jspec = "{ids:true, recode:["+s+"]}";
   [X, M] = transformencode(target=F, spec=jspec);
   
   # replacing the empty cells in encoded data with 0 
   X = replace(target=X, pattern=NaN, replacement=0);
+
   # applying mice_lm on encoded data
-  [X_filled, singleSet] = mice_lm(X=floor(X), iter=iter, complete=complete)
+  [X_filled, singleSet] = mice_lm(X=X, iter=iter, complete=complete)
+
   # decoding frame into its original form 
-  dataset = transformdecode(target=ceil(X_filled), spec=jspec, meta=M);
-  singleSet = transformdecode(target=ceil(singleSet), spec=jspec, meta=M);
+  dataset = transformdecode(target=floor(X_filled), spec=jspec, meta=M);
+  singleSet = transformdecode(target=floor(singleSet), spec=jspec, meta=M);
 }

--- a/scripts/builtin/mice_nominal.dml
+++ b/scripts/builtin/mice_nominal.dml
@@ -1,0 +1,83 @@
+#-------------------------------------------------------------
+#
+# Copyright 2019 Graz University of Technology
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+
+# Builtin function Implements Multiple Imputation using Chained Equations (MICE) for nominal data
+#
+# INPUT PARAMETERS:
+# ---------------------------------------------------------------------------------------------
+# NAME            TYPE    DEFAULT     MEANING
+# ---------------------------------------------------------------------------------------------
+# F               String    ---        Data Frame
+# iter            Integer    3         Number of iteration for multiple imputations 
+# complete        Integer    3         A complete dataset generated though a specific iteration
+# ---------------------------------------------------------------------------------------------
+ 
+
+#Output(s)
+# ---------------------------------------------------------------------------------------------
+# NAME                  TYPE    DEFAULT     MEANING
+# ---------------------------------------------------------------------------------------------
+# dataset               Double   ---        imputed dataset
+# singleSet             Double   ---        A complete dataset generated though a specific iteration
+
+# Assumption missing value are represented with empty string i.e ",," in csv file  
+
+s_mice_nominal= function(Frame[String] F, Integer iter = 3, Integer complete = 3)
+  return(Frame[String] dataset, Frame[String] singleSet)
+{
+  if(ncol(F) == 1)
+    stop("invalid aregument: can not apply mice on single column")
+  # detecting the schema of data to identify nominal columns
+  schema = detectSchema(F);
+  rec = matrix(0, 1, ncol(schema));
+  for(i in 1: ncol(schema))
+  {
+    if(as.scalar(schema[1, i]) == 'STRING' | as.scalar(schema[1, i]) == 'BOOLEAN' )
+      rec[1, i] = 1
+  }
+  rec = t(rec)
+  
+  # extracting the nominal columns
+  rec = removeEmpty(target=rec*seq(1,nrow(rec)), margin="rows");
+  s=""
+  for(j in 1: nrow(rec))
+  {
+    if(j != nrow(rec))
+      s = s+as.integer(as.scalar(rec[j,1]))+","   
+    else
+      s = s+as.integer(as.scalar(rec[j,1])) 
+  }
+  
+  # encoding nominal columns using recode transformation
+  jspec = "{ids:true, recode:["+s+"]}";
+  [X, M] = transformencode(target=F, spec=jspec);
+  
+  # replacing the empty cells in encoded data with 0 
+  X = replace(target=X, pattern=NaN, replacement=0);
+  # applying mice_lm on encoded data
+  [X_filled, singleSet] = mice_lm(X=floor(X), iter=iter, complete=complete)
+  # decoding frame into its original form 
+  dataset = transformdecode(target=ceil(X_filled), spec=jspec, meta=M);
+  singleSet = transformdecode(target=ceil(singleSet), spec=jspec, meta=M);
+}

--- a/src/main/java/org/tugraz/sysds/common/Builtins.java
+++ b/src/main/java/org/tugraz/sysds/common/Builtins.java
@@ -114,6 +114,7 @@ public enum Builtins {
 	MOMENT("moment", "centralMoment", false),
 	MSVM("msvm", true),
 	MULTILOGREG("multiLogReg", true),
+	MICE_Nominal("mice_nominal", true),
 	NCOL("ncol", false),
 	NORMALIZE("normalize", true),
 	NROW("nrow", false),

--- a/src/test/java/org/tugraz/sysds/test/functions/builtin/BuiltinMiceNominalTest.java
+++ b/src/test/java/org/tugraz/sysds/test/functions/builtin/BuiltinMiceNominalTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 Graz University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.tugraz.sysds.test.functions.builtin;
+
+import org.junit.Test;
+import org.tugraz.sysds.common.Types;
+import org.tugraz.sysds.lops.LopProperties;
+import org.tugraz.sysds.test.AutomatedTestBase;
+import org.tugraz.sysds.test.TestConfiguration;
+
+public class BuiltinMiceNominalTest extends AutomatedTestBase {
+	private final static String TEST_NAME = "mice_nominal";
+	private final static String TEST_DIR = "functions/builtin/";
+	private static final String TEST_CLASS_DIR = TEST_DIR + BuiltinMiceNominalTest.class.getSimpleName() + "/";
+
+	private final static String DATASET = SCRIPT_DIR+"functions/transform/input/homes3/homes.csv";
+	private final static int iter = 3;
+	private final static int com = 2;
+
+	@Override
+	public void setUp() {
+		addTestConfiguration(TEST_NAME, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, new String[]{"B"}));
+	}
+
+	@Test
+	public void testMiceNominalCP() {
+		runMiceNominalTest(LopProperties.ExecType.CP);
+	}
+
+	@Test
+	public void testMiceNominalSpark() {
+		runMiceNominalTest(LopProperties.ExecType.SPARK);
+	}
+
+	private void runMiceNominalTest(LopProperties.ExecType instType) {
+		Types.ExecMode platformOld = setExecMode(instType);
+		try {
+			loadTestConfiguration(getTestConfiguration(TEST_NAME));
+			String HOME = SCRIPT_DIR + TEST_DIR;
+			fullDMLScriptName = HOME + TEST_NAME + ".dml";
+			programArgs = new String[]{"-nvargs", "X=" + DATASET, "iteration=" + iter, "com=" + com, "data=" + output("B")};
+
+			runTest(true, false, null, -1);
+		}
+		finally {
+			rtplatform = platformOld;
+		}
+	}
+}

--- a/src/test/scripts/functions/builtin/mice_nominal.dml
+++ b/src/test/scripts/functions/builtin/mice_nominal.dml
@@ -1,0 +1,26 @@
+#-------------------------------------------------------------
+#
+# Copyright 2019 Graz University of Technology
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+X = read($X, data_type="frame", format="csv");
+[dataset, singleSet]= mice_nominal(F=X, iter=$iteration, complete=$com)
+write(dataset, $data)


### PR DESCRIPTION
MICE implementation for nominal data using MICE_LM. 
The nominal data is first encoded using recode transformation then missing values are imputed using mice_lm and the results are deocded back into original format.

Note: Test cases are not complete (still working on them). 