### PR TITLE
Add python wrapper module

### DIFF
--- a/src/main/java/org/tugraz/sysds/runtime/instructions/spark/utils/RDDConverterUtilsExt.java
+++ b/src/main/java/org/tugraz/sysds/runtime/instructions/spark/utils/RDDConverterUtilsExt.java
@@ -103,11 +103,19 @@ public class RDDConverterUtilsExt
 	}
 
 	public static MatrixBlock convertPy4JArrayToMB(byte [] data, long rlen, long clen) {
-		return convertPy4JArrayToMB(data, (int)rlen, (int)clen, false);
+		return convertPy4JArrayToMB(data, (int)rlen, (int)clen, false, 2);
+	}
+
+	public static MatrixBlock convertPy4JArrayToMB(byte [] data, long rlen, long clen, int dataType) {
+		return convertPy4JArrayToMB(data, (int)rlen, (int)clen, false, dataType);
 	}
 
 	public static MatrixBlock convertPy4JArrayToMB(byte [] data, int rlen, int clen) {
-		return convertPy4JArrayToMB(data, rlen, clen, false);
+		return convertPy4JArrayToMB(data, rlen, clen, false, 2);
+	}
+	
+	public static MatrixBlock convertPy4JArrayToMB(byte [] data, int rlen, int clen, long dataType) {
+		return convertPy4JArrayToMB(data, rlen, clen, false, dataType);
 	}
 
 	public static MatrixBlock convertSciPyCOOToMB(byte [] data, byte [] row, byte [] col, long rlen, long clen, long nnz) {
@@ -135,7 +143,7 @@ public class RDDConverterUtilsExt
 	}
 
 	public static MatrixBlock convertPy4JArrayToMB(byte [] data, long rlen, long clen, boolean isSparse) {
-		return convertPy4JArrayToMB(data, (int) rlen, (int) clen, isSparse);
+		return convertPy4JArrayToMB(data, (int) rlen, (int) clen, isSparse, 2);
 	}
 
 	public static MatrixBlock allocateDenseOrSparse(int rlen, int clen, boolean isSparse) {
@@ -171,7 +179,8 @@ public class RDDConverterUtilsExt
 		ret.examSparsity();
 	}
 
-	public static MatrixBlock convertPy4JArrayToMB(byte [] data, int rlen, int clen, boolean isSparse) {
+	// dataType: 0...int, 1...float, 2...double
+	public static MatrixBlock convertPy4JArrayToMB(byte [] data, int rlen, int clen, boolean isSparse, long dataType) {
 		MatrixBlock mb = new MatrixBlock(rlen, clen, isSparse, -1);
 		if(isSparse) {
 			throw new DMLRuntimeException("Convertion to sparse format not supported");
@@ -183,8 +192,17 @@ public class RDDConverterUtilsExt
 			double [] denseBlock = new double[(int) limit];
 			ByteBuffer buf = ByteBuffer.wrap(data);
 			buf.order(ByteOrder.nativeOrder());
-			for(int i = 0; i < rlen*clen; i++) {
-				denseBlock[i] = buf.getDouble();
+			if(dataType == 0) {
+				for(int i = 0; i < rlen*clen; i++)
+					denseBlock[i] = buf.getInt();
+			}
+			else if(dataType == 1) {
+				for(int i = 0; i < rlen*clen; i++)
+					denseBlock[i] = buf.getFloat();
+			}
+			else if(dataType == 2) {
+				for(int i = 0; i < rlen*clen; i++)
+					denseBlock[i] = buf.getDouble();
 			}
 			mb.init( denseBlock, rlen, clen );
 		}

--- a/src/main/python/systemds/__init__.py
+++ b/src/main/python/systemds/__init__.py
@@ -1,0 +1,30 @@
+# -------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# -------------------------------------------------------------
+
+from .mlcontext import *
+from .defmatrix import *
+from .converters import *
+from .classloader import *
+
+__all__ = mlcontext.__all__
+__all__ += defmatrix.__all__
+__all__ += converters.__all__
+__all__ += classloader.__all__

--- a/src/main/python/systemds/classloader.py
+++ b/src/main/python/systemds/classloader.py
@@ -1,0 +1,156 @@
+# -------------------------------------------------------------
+#
+# Modifications Copyright 2019 Graz University of Technology
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# -------------------------------------------------------------
+
+__all__ = [
+    'createJavaObject',
+    'get_spark_context']
+
+import os
+import numpy as np
+import pandas as pd
+
+try:
+    import py4j.java_gateway
+    from py4j.java_gateway import JavaObject
+    from pyspark import SparkContext
+    from pyspark.sql import SparkSession
+except ImportError:
+    raise ImportError(
+        'Unable to import `pyspark`. Hint: Make sure you are running with PySpark.')
+
+_loadedSystemDS = False
+
+
+def get_spark_context():
+    """
+    Internal method to get already initialized SparkContext.  Developers should always use
+    get_spark_context() instead of SparkContext._active_spark_context to ensure SystemDS loaded.
+
+    Returns
+    -------
+    sc: SparkContext
+        SparkContext
+    """
+    if SparkContext._active_spark_context is not None:
+        sc = SparkContext._active_spark_context
+        global _loadedSystemDS
+        if not _loadedSystemDS:
+            createJavaObject(sc, 'dummy')
+            _loadedSystemDS = True
+        return sc
+    else:
+        raise Exception('Expected spark context to be created.')
+
+
+_in_jvm_stdout = False
+_initializedSparkSession = False
+
+
+def _createJavaObject(sc, obj_type):
+    # -----------------------------------------------------------------------------------
+    # Avoids race condition between locking of metastore_db of Scala SparkSession and PySpark SparkSession.
+    # This is done at toDF() rather than import level to avoid creation of
+    # SparkSession in worker processes.
+    global _initializedSparkSession
+    if not _initializedSparkSession:
+        _initializedSparkSession = True
+        SparkSession.builder.getOrCreate().createDataFrame(
+            pd.DataFrame(np.array([[1, 2], [3, 4]])))
+    # -----------------------------------------------------------------------------------
+    if obj_type == 'mlcontext':
+        return sc._jvm.org.tugraz.sysds.api.mlcontext.MLContext(sc._jsc)
+    elif obj_type == 'dummy':
+        return sc._jvm.org.tugraz.sysds.utils.SystemDSLoaderUtils()
+    else:
+        raise ValueError(
+            'Incorrect usage: supported values: mlcontext or dummy')
+
+
+def _getJarFileNames(sc):
+    import imp
+    import fnmatch
+    java_dir = os.path.join(imp.find_module("systemds")[1], "systemds-java")
+    jar_file_names = []
+    for file in os.listdir(java_dir):
+        if fnmatch.fnmatch(
+                file, 'systemds-*-SNAPSHOT.jar') or fnmatch.fnmatch(file, 'systemds-*.jar'):
+            jar_file_names = jar_file_names + [os.path.join(java_dir, file)]
+    return jar_file_names
+
+
+def _getLoaderInstance(sc, jar_file_name, className, hint):
+    err_msg = 'Unable to load systemds-*.jar into current pyspark session.'
+    if os.path.isfile(jar_file_name):
+        sc._jsc.addJar(jar_file_name)
+        jar_file_url = sc._jvm.java.io.File(jar_file_name).toURI().toURL()
+        url_class = sc._jvm.java.net.URL
+        jar_file_url_arr = sc._gateway.new_array(url_class, 1)
+        jar_file_url_arr[0] = jar_file_url
+        url_class_loader = sc._jvm.java.net.URLClassLoader(
+            jar_file_url_arr, sc._jsc.getClass().getClassLoader())
+        c1 = sc._jvm.java.lang.Class.forName(className, True, url_class_loader)
+        return c1.newInstance()
+    else:
+        raise ImportError(err_msg + hint)
+
+
+def createJavaObject(sc, obj_type):
+    """
+    Performs appropriate check if SystemDS.jar is available and returns the handle to MLContext object on JVM
+
+    Parameters
+    ----------
+    sc: SparkContext
+        SparkContext
+    obj_type: Type of object to create ('mlcontext' or 'dummy')
+    """
+    try:
+        return _createJavaObject(sc, obj_type)
+    except (py4j.protocol.Py4JError, TypeError):
+        err_msg = 'Unable to load systemds-*.jar into current pyspark session.'
+        hint = 'Provide the following argument to pyspark: --driver-class-path '
+        jar_file_names = _getJarFileNames(sc)
+        if len(jar_file_names) != 2:
+            raise ImportError(
+                'Expected only systemds and systemds-extra jars, but found ' +
+                str(jar_file_names))
+        for jar_file_name in jar_file_names:
+            if 'extra' in jar_file_name:
+                x = _getLoaderInstance(
+                    sc,
+                    jar_file_name,
+                    'org.tugraz.sysds.api.dl.Caffe2DMLLoader',
+                    hint + 'systemds-*-extra.jar')
+                x.loadCaffe2DML(jar_file_name)
+            else:
+                x = _getLoaderInstance(
+                    sc,
+                    jar_file_name,
+                    'org.tugraz.sysds.utils.SystemDSLoaderUtils',
+                    hint + 'systemds-*.jar')
+                x.loadSystemDS(jar_file_name)
+        try:
+            ret = _createJavaObject(sc, obj_type)
+        except (py4j.protocol.Py4JError, TypeError):
+            raise ImportError(err_msg + ' Hint: ' + hint + jar_file_name)
+        return ret

--- a/src/main/python/systemds/converters.py
+++ b/src/main/python/systemds/converters.py
@@ -1,0 +1,403 @@
+# -------------------------------------------------------------
+#
+# Modifications Copyright 2019 Graz University of Technology
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# -------------------------------------------------------------
+
+__all__ = [
+    'getNumCols',
+    'convertToMatrixBlock',
+    'convert_caffemodel',
+    'convert_lmdb_to_jpeg',
+    'convertToNumPyArr',
+    'convertToPandasDF',
+    'SUPPORTED_TYPES',
+    'convertToLabeledDF',
+    'convertImageToNumPyArr',
+    'getDatasetMean']
+
+import numpy as np
+import pandas as pd
+import os
+import math
+
+from pyspark.context import SparkContext
+from scipy.sparse import coo_matrix, spmatrix, csr_matrix
+from .classloader import *
+
+SUPPORTED_TYPES = (np.ndarray, pd.DataFrame, spmatrix)
+
+DATASET_MEAN = {'VGG_ILSVRC_19_2014': [103.939, 116.779, 123.68]}
+
+
+def getNumCols(numPyArr):
+    if numPyArr.ndim == 1:
+        return 1
+    else:
+        return numPyArr.shape[1]
+
+
+def get_pretty_str(key, value):
+    return '\t"' + key + '": ' + str(value) + ',\n'
+
+
+def write_tensor_csv(tensor, file_path, shouldTranspose):
+    w = w.reshape(w.shape[0], -1)
+    if shouldTranspose:
+        w = w.T
+    np.writetxt(file_path, w, delimiter=',')
+    with open(file_path + '.mtd', 'w') as file:
+        file.write('{\n\t"data_type": "matrix",\n\t"value_type": "double",\n')
+        file.write(get_pretty_str('rows', w.shape[0]))
+        file.write(get_pretty_str('cols', w.shape[1]))
+        file.write(get_pretty_str('nnz', np.count_nonzero(w)))
+        file.write(
+            '\t"format": "csv",\n\t"description": {\n\t\t"author": "SystemDS"\n\t}\n}\n')
+
+
+def convert_caffemodel(sc, deploy_file, caffemodel_file,
+                       output_dir, format="binary", is_caffe_installed=False):
+    """
+    Saves the weights and bias in the caffemodel file to output_dir in the specified format.
+    This method does not requires caffe to be installed.
+
+    Parameters
+    ----------
+    sc: SparkContext
+        SparkContext
+
+    deploy_file: string
+        Path to the input network file
+
+    caffemodel_file: string
+        Path to the input caffemodel file
+
+    output_dir: string
+        Path to the output directory
+
+    format: string
+        Format of the weights and bias (can be binary, csv or text)
+
+    is_caffe_installed: bool
+        True if caffe is installed
+    """
+    if is_caffe_installed:
+        if format != 'csv':
+            raise ValueError(
+                'The format ' +
+                str(format) +
+                ' is not supported when caffe is installed. Hint: Please specify format=csv')
+        import caffe
+        net = caffe.Net(deploy_file, caffemodel_file, caffe.TEST)
+        for layerName in net.params.keys():
+            num_parameters = len(net.params[layerName])
+            if num_parameters == 0:
+                continue
+            elif num_parameters == 2:
+                # Weights and Biases
+                layerType = net.layers[list(
+                    net._layer_names).index(layerName)].type
+                shouldTranspose = True if layerType == 'InnerProduct' else False
+                write_tensor_csv(
+                    net.params[layerName][0].data,
+                    os.path.join(
+                        output_dir,
+                        layerName +
+                        '_weight.mtx'),
+                    shouldTranspose)
+                write_tensor_csv(
+                    net.params[layerName][1].data,
+                    os.path.join(
+                        output_dir,
+                        layerName +
+                        '_bias.mtx'),
+                    shouldTranspose)
+            elif num_parameters == 1:
+                # Only Weight
+                layerType = net.layers[list(
+                    net._layer_names).index(layerName)].type
+                shouldTranspose = True if layerType == 'InnerProduct' else False
+                write_tensor_csv(
+                    net.params[layerName][0].data,
+                    os.path.join(
+                        output_dir,
+                        layerName +
+                        '_weight.mtx'),
+                    shouldTranspose)
+            else:
+                raise ValueError(
+                    'Unsupported number of parameters:' +
+                    str(num_parameters))
+    else:
+        createJavaObject(sc, 'dummy')
+        utilObj = sc._jvm.org.tugraz.sysds.api.dl.Utils()
+        utilObj.saveCaffeModelFile(
+            sc._jsc,
+            deploy_file,
+            caffemodel_file,
+            output_dir,
+            format)
+
+
+def convert_lmdb_to_jpeg(lmdb_img_file, output_dir):
+    """
+    Saves the images in the lmdb file as jpeg in the output_dir. This method requires caffe to be installed along with lmdb and cv2 package.
+    To install cv2 package, do `pip install opencv-python`.
+
+    Parameters
+    ----------
+    lmdb_img_file: string
+        Path to the input lmdb file
+
+    output_dir: string
+        Output directory for images (local filesystem)
+    """
+    import lmdb
+    import caffe
+    import cv2
+    lmdb_cursor = lmdb.open(lmdb_file, readonly=True).begin().cursor()
+    datum = caffe.proto.caffe_pb2.Datum()
+    i = 1
+    for _, value in lmdb_cursor:
+        datum.ParseFromString(value)
+        data = caffe.io.datum_to_array(datum)
+        output_file_path = os.path.join(output_dir, 'file_' + str(i) + '.jpg')
+        image = np.transpose(data, (1, 2, 0))  # CxHxW to HxWxC in cv2
+        cv2.imwrite(output_file_path, image)
+        i = i + 1
+
+
+def convertToLabeledDF(sparkSession, X, y=None):
+    from pyspark.ml.feature import VectorAssembler
+    if y is not None:
+        pd1 = pd.DataFrame(X)
+        pd2 = pd.DataFrame(y, columns=['label'])
+        pdf = pd.concat([pd1, pd2], axis=1)
+        inputColumns = ['C' + str(i) for i in pd1.columns]
+        outputColumns = inputColumns + ['label']
+    else:
+        pdf = pd.DataFrame(X)
+        inputColumns = ['C' + str(i) for i in pdf.columns]
+        outputColumns = inputColumns
+    assembler = VectorAssembler(inputCols=inputColumns, outputCol='features')
+    out = assembler.transform(sparkSession.createDataFrame(pdf, outputColumns))
+    if y is not None:
+        return out.select('features', 'label')
+    else:
+        return out.select('features')
+
+
+def _convertSPMatrixToMB(sc, src):
+    src = coo_matrix(src, dtype=np.float64)
+    numRows = src.shape[0]
+    numCols = src.shape[1]
+    data = src.data
+    row = src.row.astype(np.int32)
+    col = src.col.astype(np.int32)
+    nnz = len(src.col)
+    buf1 = bytearray(data.tostring())
+    buf2 = bytearray(row.tostring())
+    buf3 = bytearray(col.tostring())
+    createJavaObject(sc, 'dummy')
+    return sc._jvm.org.tugraz.sysds.runtime.instructions.spark.utils.RDDConverterUtilsExt.convertSciPyCOOToMB(
+        buf1, buf2, buf3, numRows, numCols, nnz)
+
+
+def _convertDenseMatrixToMB(sc, src):
+    numCols = getNumCols(src)
+    numRows = src.shape[0]
+    src = np.asarray(src, dtype=np.float64) if not isinstance(src, np.ndarray) else src
+    # data_type: 0: int, 1: float and 2: double
+    if src.dtype is np.dtype(np.int32):
+        arr = src.ravel().astype(np.int32)
+        dataType = 0
+    elif src.dtype is np.dtype(np.float32):
+        arr = src.ravel().astype(np.float32)
+        dataType = 1
+    else:
+        arr = src.ravel().astype(np.float64)
+        dataType = 2
+    buf = bytearray(arr.tostring())
+    createJavaObject(sc, 'dummy')
+    return sc._jvm.org.tugraz.sysds.runtime.instructions.spark.utils.RDDConverterUtilsExt.convertPy4JArrayToMB(
+        buf, numRows, numCols, dataType)
+
+
+def _copyRowBlock(i, sc, ret, src, numRowsPerBlock, rlen, clen):
+    rowIndex = int(i / numRowsPerBlock)
+    tmp = src[i:min(i + numRowsPerBlock, rlen), ]
+    mb = _convertSPMatrixToMB(
+        sc,
+        tmp) if isinstance(
+        src,
+        spmatrix) else _convertDenseMatrixToMB(
+        sc,
+        tmp)
+    sc._jvm.org.tugraz.sysds.runtime.instructions.spark.utils.RDDConverterUtilsExt.copyRowBlocks(
+        mb, rowIndex, ret, numRowsPerBlock, rlen, clen)
+    return i
+
+
+def convertToMatrixBlock(sc, src, maxSizeBlockInMB=128):
+    if not isinstance(sc, SparkContext):
+        raise TypeError('sc needs to be of type SparkContext')
+    if isinstance(src, spmatrix):
+        isSparse = True
+    else:
+        isSparse = False
+        src = np.asarray(src, dtype=np.float64) if not isinstance(src, np.ndarray) else src
+    if len(src.shape) != 2:
+        src_type = str(type(src).__name__)
+        raise TypeError('Expected 2-dimensional ' +
+                        src_type +
+                        ', instead passed ' +
+                        str(len(src.shape)) +
+                        '-dimensional ' +
+                        src_type)
+    worstCaseSizeInMB = (8 * (src.getnnz() * 3 if isSparse else src.shape[0] * src.shape[1])) / 1000000
+    # Ignoring sparsity for computing numRowsPerBlock for now
+    numRowsPerBlock = int(
+        math.ceil((maxSizeBlockInMB * 1000000) / (src.shape[1] * 8)))
+    if worstCaseSizeInMB <= maxSizeBlockInMB:
+        return _convertSPMatrixToMB(
+            sc, src) if isSparse else _convertDenseMatrixToMB(sc, src)
+    else:
+        # Since coo_matrix does not have range indexing
+        src = csr_matrix(src) if isSparse else src
+        rlen = int(src.shape[0])
+        clen = int(src.shape[1])
+        ret = sc._jvm.org.tugraz.sysds.runtime.instructions.spark.utils.RDDConverterUtilsExt.allocateDenseOrSparse(
+            rlen, clen, isSparse)
+        [_copyRowBlock(i, sc, ret, src, numRowsPerBlock, rlen, clen)
+         for i in range(0, src.shape[0], numRowsPerBlock)]
+        sc._jvm.org.tugraz.sysds.runtime.instructions.spark.utils.RDDConverterUtilsExt.postProcessAfterCopying(
+            ret)
+        return ret
+
+
+def convertToNumPyArr(sc, mb):
+    if isinstance(sc, SparkContext):
+        numRows = mb.getNumRows()
+        numCols = mb.getNumColumns()
+        createJavaObject(sc, 'dummy')
+        buf = sc._jvm.org.tugraz.sysds.runtime.instructions.spark.utils.RDDConverterUtilsExt.convertMBtoPy4JDenseArr(
+            mb)
+        return np.frombuffer(buf, count=numRows * numCols,
+                             dtype=np.float64).reshape((numRows, numCols))
+    else:
+        # TODO: We can generalize this by creating py4j gateway ourselves
+        raise TypeError('sc needs to be of type SparkContext')
+
+
+# Returns the mean of a model if defined otherwise None
+
+
+def getDatasetMean(dataset_name):
+    """
+    Parameters
+    ----------
+    dataset_name: Name of the dataset used to train model. This name is artificial name based on dataset used to train the model.
+
+    Returns
+    -------
+    mean: Mean value of model if its defined in the list DATASET_MEAN else None.
+
+    """
+
+    try:
+        mean = DATASET_MEAN[dataset_name.upper()]
+    except BaseException:
+        mean = None
+    return mean
+
+
+# Example usage: convertImageToNumPyArr(im, img_shape=(3, 224, 224), add_rotated_images=True, add_mirrored_images=True)
+# The above call returns a numpy array of shape (6, 50176) in NCHW format
+def convertImageToNumPyArr(im, img_shape=None, add_rotated_images=False, add_mirrored_images=False,
+                           color_mode='RGB', mean=None):
+    # Input Parameters
+
+    # color_mode: In case of VGG models which expect image data in BGR format instead of RGB for other most models,
+    # color_mode parameter is used to process image data in BGR format.
+
+    # mean: mean value is used to subtract from input data from every pixel
+    # value. By default value is None, so mean value not subtracted.
+
+    if img_shape is not None:
+        num_channels = img_shape[0]
+        size = (img_shape[1], img_shape[2])
+    else:
+        num_channels = 1 if im.mode == 'L' else 3
+        size = None
+    if num_channels != 1 and num_channels != 3:
+        raise ValueError('Expected the number of channels to be either 1 or 3')
+
+    from PIL import Image
+
+    if size is not None:
+        im = im.resize(size, Image.LANCZOS)
+    expected_mode = 'L' if num_channels == 1 else 'RGB'
+    if expected_mode is not im.mode:
+        im = im.convert(expected_mode)
+
+    def _im2NumPy(im):
+        if expected_mode == 'L':
+            return np.asarray(im.getdata()).reshape((1, -1))
+        else:
+            im = (np.array(im).astype(np.float))
+
+            # (H,W,C) -> (C,H,W)
+            im = im.transpose(2, 0, 1)
+
+            # RGB -> BGR
+            if color_mode == 'BGR':
+                im = im[..., ::-1]
+
+            # Subtract Mean
+            if mean is not None:
+                for c in range(3):
+                    im[:, :, c] = im[:, :, c] - mean[c]
+
+            # (C,H,W) --> (1, C*H*W)
+            return im.reshape((1, -1))
+
+    ret = _im2NumPy(im)
+
+    if add_rotated_images:
+        ret = np.vstack(
+            (ret, _im2NumPy(
+                im.rotate(90)), _im2NumPy(
+                im.rotate(180)), _im2NumPy(
+                im.rotate(270))))
+    if add_mirrored_images:
+        ret = np.vstack(
+            (ret, _im2NumPy(
+                im.transpose(
+                    Image.FLIP_LEFT_RIGHT)), _im2NumPy(
+                im.transpose(
+                    Image.FLIP_TOP_BOTTOM))))
+    return ret
+
+
+def convertToPandasDF(X):
+    if not isinstance(X, pd.DataFrame):
+        return pd.DataFrame(X, columns=['C' + str(i)
+                                        for i in range(getNumCols(X))])
+    return X

--- a/src/main/python/systemds/defmatrix.py
+++ b/src/main/python/systemds/defmatrix.py
@@ -1,0 +1,1405 @@
+# -------------------------------------------------------------
+#
+# Modifications Copyright 2019 Graz University of Technology
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# -------------------------------------------------------------
+
+__all__ = [
+    'setSparkContext',
+    'matrix',
+    'eval',
+    'solve',
+    'DMLOp',
+    'set_lazy',
+    'debug_array_conversion',
+    'read',
+    'full',
+    'seq']
+
+import numpy as np
+import pandas as pd
+from scipy.sparse import spmatrix
+
+try:
+    import py4j.java_gateway
+    from py4j.java_gateway import JavaObject
+    from pyspark import SparkContext
+    from pyspark.sql import DataFrame, SparkSession
+    import pyspark.mllib.common
+except ImportError:
+    raise ImportError(
+        'Unable to import `pyspark`. Hint: Make sure you are running with PySpark.')
+
+from . import MLContext, _java2py, Matrix, dml
+from .converters import *
+
+
+def setSparkContext(sc):
+    """
+    Before using the matrix, the user needs to invoke this function if SparkContext is not previously created in the session.
+
+    Parameters
+    ----------
+    sc: SparkContext
+        SparkContext
+    """
+    matrix.sc = sc
+    matrix.sparkSession = SparkSession.builder.getOrCreate()
+    matrix.ml = MLContext(matrix.sc)
+
+
+def check_MLContext():
+    if matrix.ml is None:
+        if SparkContext._active_spark_context is not None:
+            setSparkContext(SparkContext._active_spark_context)
+        else:
+            raise Exception(
+                'Expected setSparkContext(sc) to be called, where sc is active SparkContext.')
+
+
+########################## AST related operations ########################
+
+
+class DMLOp(object):
+    """
+    Represents an intermediate node of Abstract syntax tree created to generate the PyDML script
+    """
+
+    def __init__(self, inputs, dml=None):
+        self.inputs = inputs
+        self.dml = dml
+        self.ID = None
+        self.depth = 1
+        for m in self.inputs:
+            m.referenced = m.referenced + [self]
+            if isinstance(m, matrix) and m.op is not None:
+                self.depth = max(self.depth, m.op.depth + 1)
+
+    MAX_DEPTH = 0
+
+    def _visit(self, execute=True):
+        matrix.dml = matrix.dml + self.dml
+
+    def _print_ast(self, numSpaces):
+        ret = []
+        for m in self.inputs:
+            ret = [m._print_ast(numSpaces + 2)]
+        return ''.join(ret)
+
+
+# Special object used internally to specify the placeholder which will be replaced by output ID
+# This helps to provide dml containing output ID in construct_intermediate_node
+OUTPUT_ID = '$$OutputID$$'
+
+
+def set_lazy(isLazy):
+    """
+    This method allows users to set whether the matrix operations should be executed in lazy manner.
+
+    Parameters
+    ----------
+    isLazy: True if matrix operations should be evaluated in lazy manner.
+    """
+    if isLazy:
+        DMLOp.MAX_DEPTH = 0
+    else:
+        DMLOp.MAX_DEPTH = 1
+
+
+def construct_intermediate_node(inputs, dml):
+    """
+    Convenient utility to create an intermediate node of AST.
+
+    Parameters
+    ----------
+    inputs = list of input matrix objects and/or DMLOp
+    dml = list of DML string (which will be eventually joined before execution). To specify out.ID, please use the placeholder
+    """
+    dmlOp = DMLOp(inputs)
+    out = matrix(None, op=dmlOp)
+    dmlOp.dml = [out.ID if x == OUTPUT_ID else x for x in dml]
+    if DMLOp.MAX_DEPTH > 0 and out.op.depth >= DMLOp.MAX_DEPTH:
+        out.eval()
+    return out
+
+
+def read(file, format='csv'):
+    """
+    Allows user to read a matrix from filesystem
+
+    Parameters
+    ----------
+    file: filepath
+    format: can be csv, text or binary or mm
+    """
+    return construct_intermediate_node(
+        [], [OUTPUT_ID, ' = read(\"', file, '\", format=\"', format, '\")\n'])
+
+
+def full(shape, fill_value):
+    """
+    Return a new array of given shape filled with fill_value.
+
+    Parameters
+    ----------
+    shape: tuple of length 2
+    fill_value: float or int
+    """
+    return construct_intermediate_node([], [OUTPUT_ID, ' = matrix(', str(
+        fill_value), ', rows=', str(shape[0]), ', cols=', str(shape[1]), ')\n'])
+
+
+def reset():
+    """
+    Resets the visited status of matrix and the operators in the generated AST.
+    """
+    for m in matrix.visited:
+        m.visited = False
+    matrix.visited = []
+    matrix.ml = MLContext(matrix.sc)
+    matrix.dml = []
+    matrix.script = dml('')
+
+
+def perform_dfs(outputs, execute):
+    """
+    Traverses the forest of nodes rooted at outputs nodes and returns the DML script to execute
+    """
+    for m in outputs:
+        m.output = True
+        m._visit(execute=execute)
+    return ''.join(matrix.dml)
+
+
+###############################################################################
+
+
+########################## Utility functions ##################################
+
+def _log_base(val, base):
+    if not isinstance(val, str):
+        raise ValueError('The val to _log_base should be of type string')
+    return '(log(' + val + ')/log(' + str(base) + '))'
+
+
+def _matricize(lhs, inputs):
+    """
+    Utility fn to convert the supported types to matrix class or to string (if float or int)
+    and return the string to be passed to DML as well as inputs
+    """
+    if isinstance(lhs, SUPPORTED_TYPES):
+        lhs = matrix(lhs)
+    if isinstance(lhs, matrix):
+        lhsStr = lhs.ID
+        inputs = inputs + [lhs]
+    elif isinstance(lhs, float) or isinstance(lhs, int):
+        lhsStr = str(lhs)
+    else:
+        raise TypeError('Incorrect type')
+    return lhsStr, inputs
+
+
+def binary_op(lhs, rhs, opStr):
+    """
+    Common function called by all the binary operators in matrix class
+    """
+    inputs = []
+    lhsStr, inputs = _matricize(lhs, inputs)
+    rhsStr, inputs = _matricize(rhs, inputs)
+    return construct_intermediate_node(
+        inputs, [OUTPUT_ID, ' = ', lhsStr, opStr, rhsStr, '\n'])
+
+
+def binaryMatrixFunction(X, Y, fnName):
+    """
+    Common function called by supported PyDML built-in function that has two arguments.
+    """
+    inputs = []
+    lhsStr, inputs = _matricize(X, inputs)
+    rhsStr, inputs = _matricize(Y, inputs)
+    return construct_intermediate_node(
+        inputs, [OUTPUT_ID, ' = ', fnName, '(', lhsStr, ', ', rhsStr, ')\n'])
+
+
+def unaryMatrixFunction(X, fnName):
+    """
+    Common function called by supported PyDML built-in function that has one argument.
+    """
+    inputs = []
+    lhsStr, inputs = _matricize(X, inputs)
+    return construct_intermediate_node(
+        inputs, [OUTPUT_ID, ' = ', fnName, '(', lhsStr, ')\n'])
+
+
+def seq(start=None, stop=None, step=1):
+    """
+    Creates a single column vector with values starting from <start>, to <stop>, in increments of <step>.
+    Note: Unlike Numpy's arange which returns a row-vector, this returns a column vector.
+    Also, Unlike Numpy's arange which doesnot include stop, this method includes stop in the interval.
+
+    Parameters
+    ----------
+    start: int or float [Optional: default = 0]
+    stop: int or float
+    step : int float [Optional: default = 1]
+    """
+    if start is None and stop is None:
+        raise ValueError('Both start and stop cannot be None')
+    elif start is not None and stop is None:
+        stop = start
+        start = 0
+    return construct_intermediate_node(
+        [], [OUTPUT_ID, ' = seq(', str(start), ',', str(stop), ',', str(step), ')\n'])
+
+
+# utility function that converts 1:3 into DML string
+
+
+def convert_seq_to_dml(s):
+    ret = []
+    if s is None:
+        return ''
+    elif isinstance(s, slice):
+        if s.step is not None:
+            raise ValueError('Slicing with step is not supported.')
+        if s.start is None:
+            ret = ret + ['0 : ']
+        else:
+            ret = ret + [getValue(s.start), ':']
+        if s.start is None:
+            ret = ret + ['']
+        else:
+            ret = ret + [getValue(s.stop)]
+    else:
+        ret = ret + [getValue(s)]
+    return ''.join(ret)
+
+
+# utility function that converts index (such as [1, 2:3]) into DML string
+
+
+def getIndexingDML(index):
+    ret = ['[']
+    if isinstance(index, tuple) and len(index) == 1:
+        ret = ret + [convert_seq_to_dml(index[0]), ',']
+    elif isinstance(index, tuple) and len(index) == 2:
+        ret = ret + [convert_seq_to_dml(index[0]),
+                     ',', convert_seq_to_dml(index[1])]
+    else:
+        raise TypeError(
+            'matrix indexes can only be tuple of length 2. For example: m[1,1], m[0:1,], m[:, 0:1]')
+    return ret + [']']
+
+
+def convert_outputs_to_list(outputs):
+    if isinstance(outputs, matrix):
+        return [outputs]
+    elif isinstance(outputs, list):
+        for o in outputs:
+            if not isinstance(o, matrix):
+                raise TypeError('Only matrix or list of matrix allowed')
+        return outputs
+    else:
+        raise TypeError('Only matrix or list of matrix allowed')
+
+
+def reset_output_flag(outputs):
+    for m in outputs:
+        m.output = False
+
+
+###############################################################################
+
+########################## Global user-facing functions #######################
+
+def solve(A, b):
+    """
+    Computes the least squares solution for system of linear equations A %*% x = b
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sklearn import datasets
+    >>> import SystemDS as sml
+    >>> from pyspark.sql import SparkSession
+    >>> diabetes = datasets.load_diabetes()
+    >>> diabetes_X = diabetes.data[:, np.newaxis, 2]
+    >>> X_train = diabetes_X[:-20]
+    >>> X_test = diabetes_X[-20:]
+    >>> y_train = diabetes.target[:-20]
+    >>> y_test = diabetes.target[-20:]
+    >>> sml.setSparkContext(sc)
+    >>> X = sml.matrix(X_train)
+    >>> y = sml.matrix(y_train)
+    >>> A = X.transpose().dot(X)
+    >>> b = X.transpose().dot(y)
+    >>> beta = sml.solve(A, b).toNumPy()
+    >>> y_predicted = X_test.dot(beta)
+    >>> print('Residual sum of squares: %.2f' % np.mean((y_predicted - y_test) ** 2))
+    Residual sum of squares: 25282.12
+    """
+    return binaryMatrixFunction(A, b, 'solve')
+
+
+def eval(outputs, execute=True):
+    """
+    Executes the unevaluated DML script and computes the matrices specified by outputs.
+
+    Parameters
+    ----------
+    outputs: list of matrices or a matrix object
+    execute: specified whether to execute the unevaluated operation or just return the script.
+    """
+    check_MLContext()
+    reset()
+    outputs = convert_outputs_to_list(outputs)
+    matrix.script.setScriptString(perform_dfs(outputs, execute))
+    if not execute:
+        reset_output_flag(outputs)
+        return matrix.script.scriptString
+    results = matrix.ml.execute(matrix.script)
+    for m in outputs:
+        m.eval_data = results._java_results.get(m.ID)
+    reset_output_flag(outputs)
+
+
+def debug_array_conversion(throwError):
+    matrix.THROW_ARRAY_CONVERSION_ERROR = throwError
+
+
+def _get_new_var_id():
+    matrix.systemdsVarID += 1
+    return 'mVar' + str(matrix.systemdsVarID)
+
+
+###############################################################################
+
+
+class matrix(object):
+    """
+    matrix class is a python wrapper that implements basic matrix operators, matrix functions
+    as well as converters to common Python types (for example: Numpy arrays, PySpark DataFrame
+    and Pandas DataFrame).
+
+    The operators supported are:
+
+    1. Arithmetic operators: +, -, *, /, //, %, ** as well as dot (i.e. matrix multiplication)
+    2. Indexing in the matrix
+    3. Relational/Boolean operators: <, <=, >, >=, ==, !=, &, |
+
+    In addition, following functions are supported for matrix:
+
+    1. transpose
+    2. Aggregation functions: sum, mean, var, sd, max, min, argmin, argmax, cumsum
+    3. Global statistical built-In functions: exp, log, abs, sqrt, round, floor, ceil, ceiling, sin, cos, tan, asin, acos, atan, sign, solve
+
+    For all the above functions, we always return a two dimensional matrix, especially for aggregation functions with axis.
+    For example: Assuming m1 is a matrix of (3, n), NumPy returns a 1d vector of dimension (3,) for operation m1.sum(axis=1)
+    whereas SystemDS returns a 2d matrix of dimension (3, 1).
+
+    Note: an evaluated matrix contains a data field computed by eval method as DataFrame or NumPy array.
+
+    Examples
+    --------
+    >>> import SystemDS as sml
+    >>> import numpy as np
+    >>> sml.setSparkContext(sc)
+
+    Welcome to Apache SystemDS!
+
+    >>> m1 = sml.matrix(np.ones((3,3)) + 2)
+    >>> m2 = sml.matrix(np.ones((3,3)) + 3)
+    >>> m2 = m1 * (m2 + m1)
+    >>> m4 = 1.0 - m2
+    >>> m4
+    # This matrix (mVar5) is backed by below given PyDML script (which is not yet evaluated). To fetch the data of this matrix, invoke toNumPy() or toDF() or toPandas() methods.
+    mVar1 = read(" ", format="csv")
+    mVar2 = read(" ", format="csv")
+    mVar3 = mVar2 + mVar1
+    mVar4 = mVar1 * mVar3
+    mVar5 = 1.0 - mVar4
+    write(mVar5, " ")
+    >>> m2.eval()
+    >>> m2
+    # This matrix (mVar4) is backed by NumPy array. To fetch the NumPy array, invoke toNumPy() method.
+    >>> m4
+    # This matrix (mVar5) is backed by below given PyDML script (which is not yet evaluated). To fetch the data of this matrix, invoke toNumPy() or toDF() or toPandas() methods.
+    mVar4 = read(" ", format="csv")
+    mVar5 = 1.0 - mVar4
+    write(mVar5, " ")
+    >>> m4.sum(axis=1).toNumPy()
+    array([[-60.],
+           [-60.],
+           [-60.]])
+
+    Design Decisions:
+
+    1. Until eval() method is invoked, we create an AST (not exposed to the user) that consist of unevaluated operations and data required by those operations.
+       As an anology, a spark user can treat eval() method similar to calling RDD.persist() followed by RDD.count().
+    2. The AST consist of two kinds of nodes: either of type matrix or of type DMLOp.
+       Both these classes expose _visit method, that helps in traversing the AST in DFS manner.
+    3. A matrix object can either be evaluated or not.
+       If evaluated, the attribute 'data' is set to one of the supported types (for example: NumPy array or DataFrame). In this case, the attribute 'op' is set to None.
+       If not evaluated, the attribute 'op' which refers to one of the intermediate node of AST and if of type DMLOp.  In this case, the attribute 'data' is set to None.
+    4. DMLOp has an attribute 'inputs' which contains list of matrix objects or DMLOp.
+    5. To simplify the traversal, every matrix object is considered immutable and an matrix operations creates a new matrix object.
+       As an example:
+       `m1 = sml.matrix(np.ones((3,3)))` creates a matrix object backed by 'data=(np.ones((3,3))'.
+       `m1 = m1 * 2` will create a new matrix object which is now backed by 'op=DMLOp( ... )' whose input is earlier created matrix object.
+    6. Left indexing (implemented in __setitem__ method) is a special case, where Python expects the existing object to be mutated.
+       To ensure the above property, we make deep copy of existing object and point any references to the left-indexed matrix to the newly created object.
+       Then the left-indexed matrix is set to be backed by DMLOp consisting of following pydml:
+       left-indexed-matrix = new-deep-copied-matrix
+       left-indexed-matrix[index] = value
+    7. Please use m.print_ast() and/or  type `m` for debugging. Here is a sample session:
+
+       >>> npm = np.ones((3,3))
+       >>> m1 = sml.matrix(npm + 3)
+       >>> m2 = sml.matrix(npm + 5)
+       >>> m3 = m1 + m2
+       >>> m3
+       mVar2 = read(" ", format="csv")
+       mVar1 = read(" ", format="csv")
+       mVar3 = mVar1 + mVar2
+       write(mVar3, " ")
+       >>> m3.print_ast()
+       - [mVar3] (op).
+         - [mVar1] (data).
+         - [mVar2] (data).
+
+    """
+    # Global variable that is used to keep track of intermediate matrix
+    # variables in the DML script
+    systemdsVarID = 0
+
+    # Since joining of string is expensive operation, we collect the set of strings into list and then join
+    # them before execution: See matrix.script.scriptString =
+    # ''.join(matrix.dml) in eval() method
+    dml = []
+
+    # Represents MLContext's script object
+    script = None
+
+    # Represents MLContext object
+    ml = None
+
+    # Contains list of nodes visited in Abstract Syntax Tree. This helps to avoid computation of matrix objects
+    # that have been previously evaluated.
+    visited = []
+
+    def __init__(self, data, op=None):
+        """
+        Constructs a lazy matrix
+
+        Parameters
+        ----------
+        data: NumPy ndarray, Pandas DataFrame, scipy sparse matrix or PySpark DataFrame. (data cannot be None for external users, 'data=None' is used internally for lazy evaluation).
+        """
+        self.dtype = np.double
+        check_MLContext()
+        self.visited = False
+        self.output = False
+        self.ID = _get_new_var_id()
+        self.referenced = []
+        # op refers to the node of Abstract Syntax Tree created internally for
+        # lazy evaluation
+        self.op = op
+        self.eval_data = data
+        self._shape = None
+        if isinstance(data, SUPPORTED_TYPES):
+            self._shape = data.shape
+        if not (isinstance(data, SUPPORTED_TYPES) or hasattr(
+                data, '_jdf') or (data is None and op is not None)):
+            raise TypeError('Unsupported input type')
+
+    def eval(self):
+        """
+        This is a convenience function that calls the global eval method
+        """
+        eval([self])
+
+    def toPandas(self):
+        """
+        This is a convenience function that calls the global eval method and then converts the matrix object into Pandas DataFrame.
+        """
+        self.eval()
+        if isinstance(self.eval_data, py4j.java_gateway.JavaObject):
+            self.eval_data = _java2py(
+                SparkContext._active_spark_context, self.eval_data)
+        if isinstance(self.eval_data, Matrix):
+            self.eval_data = self.eval_data.toNumPy()
+        self.eval_data = convertToPandasDF(self.eval_data)
+        return self.eval_data
+
+    def toNumPy(self):
+        """
+        This is a convenience function that calls the global eval method and then converts the matrix object into NumPy array.
+        """
+        self.eval()
+        if isinstance(self.eval_data, py4j.java_gateway.JavaObject):
+            self.eval_data = _java2py(
+                SparkContext._active_spark_context, self.eval_data)
+        if isinstance(self.eval_data, Matrix):
+            self.eval_data = self.eval_data.toNumPy()
+            return self.eval_data
+        if isinstance(self.eval_data, pd.DataFrame):
+            self.eval_data = self.eval_data.as_matrix()
+        elif isinstance(self.eval_data, DataFrame):
+            self.eval_data = self.eval_data.toPandas().as_matrix()
+        elif isinstance(self.eval_data, spmatrix):
+            self.eval_data = self.eval_data.toarray()
+        elif isinstance(self.eval_data, Matrix):
+            self.eval_data = self.eval_data.toNumPy()
+        # Always keep default format as NumPy array if possible
+        return self.eval_data
+
+    def toDF(self):
+        """
+        This is a convenience function that calls the global eval method and then converts the matrix object into DataFrame.
+        """
+        if isinstance(self.eval_data, DataFrame):
+            return self.eval_data
+        if isinstance(self.eval_data, py4j.java_gateway.JavaObject):
+            self.eval_data = _java2py(
+                SparkContext._active_spark_context, self.eval_data)
+        if isinstance(self.eval_data, Matrix):
+            self.eval_data = self.eval_data.toDF()
+            return self.eval_data
+        self.eval_data = matrix.sparkSession.createDataFrame(self.toPandas())
+        return self.eval_data
+
+    def write(self, file, format='csv'):
+        """
+        Allows user to save a matrix to filesystem
+
+        Parameters
+        ----------
+        file: filepath
+        format: can be csv, text or binary or mm
+        """
+        tmp = construct_intermediate_node(
+            [self], ['write(', self.ID, ',\"', file, '\", format=\"', format, '\")\n'])
+        construct_intermediate_node(
+            [tmp], [OUTPUT_ID, ' = matrix(0, rows=1, cols=1)\n']).eval()
+
+    def _mark_as_visited(self):
+        self.visited = True
+        # for cleanup
+        matrix.visited = matrix.visited + [self]
+        return self
+
+    def _register_as_input(self, execute):
+        # TODO: Remove this when automatic registration of frame is resolved
+        matrix.dml = [self.ID, ' = read(\" \", format=\"csv\")\n'] + matrix.dml
+        if isinstance(self.eval_data, SUPPORTED_TYPES) and execute:
+            matrix.script.input(
+                self.ID, convertToMatrixBlock(
+                    matrix.sc, self.eval_data))
+        elif execute:
+            matrix.script.input(self.ID, self.toDF())
+        return self
+
+    def _register_as_output(self, execute):
+        # TODO: Remove this when automatic registration of frame is resolved
+        matrix.dml = matrix.dml + ['write(', self.ID, ', \" \")\n']
+        if execute:
+            matrix.script.output(self.ID)
+
+    def _visit(self, execute=True):
+        """
+        This function is called for two scenarios:
+        1. For printing the PyDML script which has not yet been evaluated (execute=False). See '__repr__' method.
+        2. Called as part of 'eval' method (execute=True). In this scenario, it builds the PyDML script by visiting itself
+        and its child nodes. Also, it does appropriate registration as input or output that is required by MLContext.
+        """
+        if self.visited:
+            return self
+        self._mark_as_visited()
+        if self.eval_data is not None:
+            self._register_as_input(execute)
+        elif self.op is not None:
+            # Traverse the AST
+            for m in self.op.inputs:
+                m._visit(execute=execute)
+            self.op._visit(execute=execute)
+        else:
+            raise Exception('Expected either op or data to be set')
+        if self.eval_data is None and self.output:
+            self._register_as_output(execute)
+        return self
+
+    def print_ast(self):
+        """
+        Please use m.print_ast() and/or  type `m` for debugging. Here is a sample session:
+
+        >>> npm = np.ones((3,3))
+        >>> m1 = sml.matrix(npm + 3)
+        >>> m2 = sml.matrix(npm + 5)
+        >>> m3 = m1 + m2
+        >>> m3
+        mVar2 = read(" ", format="csv")
+        mVar1 = read(" ", format="csv")
+        mVar3 = mVar1 + mVar2
+        write(mVar3, " ")
+        >>> m3.print_ast()
+        - [mVar3] (op).
+          - [mVar1] (data).
+          - [mVar2] (data).
+        """
+        return self._print_ast(0)
+
+    def _print_ast(self, numSpaces):
+        head = ''.join([' '] * numSpaces + ['- [', self.ID, '] '])
+        if self.eval_data is not None:
+            out = head + '(data).\n'
+        elif self.op is not None:
+            ret = [head, '(op).\n']
+            for m in self.op.inputs:
+                ret = ret + [m._print_ast(numSpaces + 2)]
+            out = ''.join(ret)
+        else:
+            raise ValueError('Either op or data needs to be set')
+        if numSpaces == 0:
+            print(out)
+        else:
+            return out
+
+    def __repr__(self):
+        """
+        This function helps to debug matrix class and also examine the generated PyDML script
+        """
+        if self.eval_data is None:
+            print(
+                    '# This matrix (' +
+                    self.ID +
+                    ') is backed by below given PyDML script (which is not yet evaluated). To fetch the data of this matrix, invoke toNumPy() or toDF() or toPandas() methods.\n' +
+                    eval(
+                        [self],
+                        execute=False))
+        else:
+            print('# This matrix (' + self.ID + ') is backed by ' + str(type(self.eval_data)) +
+                  '. To fetch the DataFrame or NumPy array, invoke toDF() or toNumPy() method respectively.')
+        return ''
+
+    ######################### NumPy related methods ##########################
+
+    __array_priority__ = 10.2
+    ndim = 2
+
+    THROW_ARRAY_CONVERSION_ERROR = False
+
+    def __array__(self, dtype=np.double):
+        """
+        As per NumPy from Python,
+        This method is called to obtain an ndarray object when needed. You should always guarantee this returns an actual ndarray object.
+
+        Using this method, you get back a ndarray object, and subsequent operations on the returned ndarray object will be singlenode.
+        """
+        if not isinstance(self.eval_data, SUPPORTED_TYPES):
+            # Only warn if there is an unevaluated operation (which could
+            # potentially generate large matrix or if data is non-supported
+            # singlenode formats)
+            import inspect
+            frame, filename, line_number, function_name, lines, index = inspect.stack()[
+                1]
+            msg = 'Conversion from SystemDS matrix to NumPy array (occurs in ' + str(
+                filename) + ':' + str(line_number) + ' ' + function_name + ")"
+            if matrix.THROW_ARRAY_CONVERSION_ERROR:
+                raise Exception('[ERROR]:' + msg)
+            else:
+                print('[WARN]:' + msg)
+        return np.array(self.toNumPy(), dtype)
+
+    def astype(self, t):
+        # TODO: Throw error if incorrect type
+        return self
+
+    def asfptype(self):
+        return self
+
+    def set_shape(self, shape):
+        raise NotImplementedError('Reshaping is not implemented')
+
+    def get_shape(self):
+        if self._shape is None:
+            lhsStr, inputs = _matricize(self, [])
+            rlen_ID = _get_new_var_id()
+            clen_ID = _get_new_var_id()
+            multiline_dml = [rlen_ID, ' = ', lhsStr, '.shape(0)\n']
+            multiline_dml = multiline_dml + \
+                            [clen_ID, ' = ', lhsStr, '.shape(1)\n']
+            multiline_dml = multiline_dml + \
+                            [OUTPUT_ID, ' = matrix(0, rows=2, cols=1)\n']
+            multiline_dml = multiline_dml + \
+                            [OUTPUT_ID, '[0,0] = ', rlen_ID, '\n']
+            multiline_dml = multiline_dml + \
+                            [OUTPUT_ID, '[1,0] = ', clen_ID, '\n']
+            ret = construct_intermediate_node(inputs, multiline_dml).toNumPy()
+            self._shape = tuple(np.array(ret, dtype=int).flatten())
+        return self._shape
+
+    shape = property(fget=get_shape, fset=set_shape)
+
+    def __numpy_ufunc__(self, func, method, pos, inputs, **kwargs):
+        """
+        This function enables systemds matrix to be compatible with NumPy's ufuncs.
+
+        Parameters
+        ----------
+        func:  ufunc object that was called.
+        method: string indicating which Ufunc method was called (one of "__call__", "reduce", "reduceat", "accumulate", "outer", "inner").
+        pos: index of self in inputs.
+        inputs:  tuple of the input arguments to the ufunc
+        kwargs: dictionary containing the optional input arguments of the ufunc.
+        """
+        if method != '__call__' or kwargs:
+            return NotImplemented
+        if func in matrix._numpy_to_systeml_mapping:
+            fn = matrix._numpy_to_systeml_mapping[func]
+        else:
+            return NotImplemented
+        if len(inputs) == 2:
+            return fn(inputs[0], inputs[1])
+        elif len(inputs) == 1:
+            return fn(inputs[0])
+        else:
+            raise ValueError('Unsupported number of inputs')
+
+    def hstack(self, other):
+        """
+        Stack matrices horizontally (column wise). Invokes cbind internally.
+        """
+        return binaryMatrixFunction(self, other, 'cbind')
+
+    def vstack(self, other):
+        """
+        Stack matrices vertically (row wise). Invokes rbind internally.
+        """
+        return binaryMatrixFunction(self, other, 'rbind')
+
+    ######################### Arithmetic operators ###########################
+
+    def negative(self):
+        lhsStr, inputs = _matricize(self, [])
+        return construct_intermediate_node(
+            inputs, [OUTPUT_ID, ' = -', lhsStr, '\n'])
+
+    def remainder(self, other):
+        inputs = []
+        lhsStr, inputs = _matricize(self, inputs)
+        rhsStr, inputs = _matricize(other, inputs)
+        return construct_intermediate_node(
+            inputs, [OUTPUT_ID, ' = floor(', lhsStr, '/', rhsStr, ') * ', rhsStr, '\n'])
+
+    def ldexp(self, other):
+        inputs = []
+        lhsStr, inputs = _matricize(self, inputs)
+        rhsStr, inputs = _matricize(other, inputs)
+        return construct_intermediate_node(
+            inputs, [OUTPUT_ID, ' = ', lhsStr, '* (2**', rhsStr, ')\n'])
+
+    def mod(self, other):
+        inputs = []
+        lhsStr, inputs = _matricize(self, inputs)
+        rhsStr, inputs = _matricize(other, inputs)
+        return construct_intermediate_node(inputs, [
+            OUTPUT_ID, ' = ', lhsStr, ' - floor(', lhsStr, '/', rhsStr, ') * ', rhsStr, '\n'])
+
+    def logaddexp(self, other):
+        inputs = []
+        lhsStr, inputs = _matricize(self, inputs)
+        rhsStr, inputs = _matricize(other, inputs)
+        return construct_intermediate_node(
+            inputs, [OUTPUT_ID, ' = log(exp(', lhsStr, ') + exp(', rhsStr, '))\n'])
+
+    def logaddexp2(self, other):
+        inputs = []
+        lhsStr, inputs = _matricize(self, inputs)
+        rhsStr, inputs = _matricize(other, inputs)
+        opStr = _log_base('2**' + lhsStr + '2**' + rhsStr, 2)
+        return construct_intermediate_node(
+            inputs, [OUTPUT_ID, ' = ', opStr, '\n'])
+
+    def log1p(self):
+        inputs = []
+        lhsStr, inputs = _matricize(self, inputs)
+        return construct_intermediate_node(
+            inputs, [OUTPUT_ID, ' = log(1 + ', lhsStr, ')\n'])
+
+    def exp(self):
+        return unaryMatrixFunction(self, 'exp')
+
+    def exp2(self):
+        inputs = []
+        lhsStr, inputs = _matricize(self, inputs)
+        return construct_intermediate_node(
+            inputs, [OUTPUT_ID, ' = 2**', lhsStr, '\n'])
+
+    def square(self):
+        inputs = []
+        lhsStr, inputs = _matricize(self, inputs)
+        return construct_intermediate_node(
+            inputs, [OUTPUT_ID, ' = ', lhsStr, '**2\n'])
+
+    def reciprocal(self):
+        inputs = []
+        lhsStr, inputs = _matricize(self, inputs)
+        return construct_intermediate_node(
+            inputs, [OUTPUT_ID, ' = 1/', lhsStr, '\n'])
+
+    def expm1(self):
+        inputs = []
+        lhsStr, inputs = _matricize(self, inputs)
+        return construct_intermediate_node(
+            inputs, [OUTPUT_ID, ' = exp(', lhsStr, ') - 1\n'])
+
+    def ones_like(self):
+        inputs = []
+        lhsStr, inputs = _matricize(self, inputs)
+        rlen = lhsStr + '.shape(axis=0)'
+        clen = lhsStr + '.shape(axis=1)'
+        return construct_intermediate_node(
+            inputs, [OUTPUT_ID, ' = matrix(1, rows=', rlen, ', cols=', clen, ')\n'])
+
+    def zeros_like(self):
+        inputs = []
+        lhsStr, inputs = _matricize(self, inputs)
+        rlen = lhsStr + '.shape(axis=0)'
+        clen = lhsStr + '.shape(axis=1)'
+        return construct_intermediate_node(
+            inputs, [OUTPUT_ID, ' = matrix(0, rows=', rlen, ', cols=', clen, ')\n'])
+
+    def log2(self):
+        return self.log(2)
+
+    def log10(self):
+        return self.log(10)
+
+    def log(self, y=None):
+        if y is None:
+            return unaryMatrixFunction(self, 'log')
+        else:
+            return binaryMatrixFunction(self, y, 'log')
+
+    def abs(self):
+        return unaryMatrixFunction(self, 'abs')
+
+    def sqrt(self):
+        return unaryMatrixFunction(self, 'sqrt')
+
+    def round(self):
+        return unaryMatrixFunction(self, 'round')
+
+    def floor(self):
+        return unaryMatrixFunction(self, 'floor')
+
+    def ceil(self):
+        return unaryMatrixFunction(self, 'ceil')
+
+    def ceiling(self):
+        return unaryMatrixFunction(self, 'ceiling')
+
+    def sin(self):
+        return unaryMatrixFunction(self, 'sin')
+
+    def cos(self):
+        return unaryMatrixFunction(self, 'cos')
+
+    def tan(self):
+        return unaryMatrixFunction(self, 'tan')
+
+    def sinh(self):
+        return unaryMatrixFunction(self, 'sinh')
+
+    def cosh(self):
+        return unaryMatrixFunction(self, 'cosh')
+
+    def tanh(self):
+        return unaryMatrixFunction(self, 'tanh')
+
+    def arcsin(self):
+        return self.asin()
+
+    def arccos(self):
+        return self.acos()
+
+    def arctan(self):
+        return self.atan()
+
+    def asin(self):
+        return unaryMatrixFunction(self, 'asin')
+
+    def acos(self):
+        return unaryMatrixFunction(self, 'acos')
+
+    def atan(self):
+        return unaryMatrixFunction(self, 'atan')
+
+    def rad2deg(self):
+        """
+        Convert angles from radians to degrees.
+        """
+        inputs = []
+        lhsStr, inputs = _matricize(self, inputs)
+        # 180/pi = 57.2957795131
+        return construct_intermediate_node(
+            inputs, [OUTPUT_ID, ' = ', lhsStr, '*57.2957795131\n'])
+
+    def deg2rad(self):
+        """
+        Convert angles from degrees to radians.
+        """
+        inputs = []
+        lhsStr, inputs = _matricize(self, inputs)
+        # pi/180 = 0.01745329251
+        return construct_intermediate_node(
+            inputs, [OUTPUT_ID, ' = ', lhsStr, '*0.01745329251\n'])
+
+    def sign(self):
+        return unaryMatrixFunction(self, 'sign')
+
+    def __add__(self, other):
+        return binary_op(self, other, ' + ')
+
+    def __sub__(self, other):
+        return binary_op(self, other, ' - ')
+
+    def __mul__(self, other):
+        return binary_op(self, other, ' * ')
+
+    def __floordiv__(self, other):
+        return binary_op(self, other, ' // ')
+
+    def __div__(self, other):
+        """
+        Performs division (Python 2 way).
+        """
+        return binary_op(self, other, ' / ')
+
+    def __truediv__(self, other):
+        """
+        Performs division (Python 3 way).
+        """
+        return binary_op(self, other, ' / ')
+
+    def __mod__(self, other):
+        return binary_op(self, other, ' % ')
+
+    def __pow__(self, other):
+        return binary_op(self, other, ' ** ')
+
+    def __radd__(self, other):
+        return binary_op(other, self, ' + ')
+
+    def __rsub__(self, other):
+        return binary_op(other, self, ' - ')
+
+    def __rmul__(self, other):
+        return binary_op(other, self, ' * ')
+
+    def __rfloordiv__(self, other):
+        return binary_op(other, self, ' // ')
+
+    def __rdiv__(self, other):
+        return binary_op(other, self, ' / ')
+
+    def __rtruediv__(self, other):
+        """
+        Performs division (Python 3 way).
+        """
+        return binary_op(other, self, ' / ')
+
+    def __rmod__(self, other):
+        return binary_op(other, self, ' % ')
+
+    def __rpow__(self, other):
+        return binary_op(other, self, ' ** ')
+
+    def dot(self, other):
+        """
+        Numpy way of performing matrix multiplication
+        """
+        return binaryMatrixFunction(self, other, 'dot')
+
+    def __matmul__(self, other):
+        """
+        Performs matrix multiplication (infix operator: @). See PEP 465)
+        """
+        return binaryMatrixFunction(self, other, 'dot')
+
+    ######################### Relational/Boolean operators ###################
+
+    def __lt__(self, other):
+        return binary_op(self, other, ' < ')
+
+    def __le__(self, other):
+        return binary_op(self, other, ' <= ')
+
+    def __gt__(self, other):
+        return binary_op(self, other, ' > ')
+
+    def __ge__(self, other):
+        return binary_op(self, other, ' >= ')
+
+    def __eq__(self, other):
+        return binary_op(self, other, ' == ')
+
+    def __ne__(self, other):
+        return binary_op(self, other, ' != ')
+
+    # TODO: Cast the output back into scalar and return boolean results
+    def __and__(self, other):
+        return binary_op(other, self, ' & ')
+
+    def __or__(self, other):
+        return binary_op(other, self, ' | ')
+
+    def logical_not(self):
+        inputs = []
+        lhsStr, inputs = _matricize(self, inputs)
+        return construct_intermediate_node(
+            inputs, [OUTPUT_ID, ' = !', lhsStr, '\n'])
+
+    def remove_empty(self, axis=None):
+        """
+        Removes all empty rows or columns from the input matrix target X according to specified axis.
+
+        Parameters
+        ----------
+        axis : int (0 or 1)
+        """
+        if axis is None:
+            raise ValueError('axis is a mandatory argument for remove_empty')
+        if axis == 0:
+            return self._parameterized_helper_fn(
+                self, 'removeEmpty', {'target': self, 'margin': 'rows'})
+        elif axis == 1:
+            return self._parameterized_helper_fn(
+                self, 'removeEmpty', {'target': self, 'margin': 'cols'})
+        else:
+            raise ValueError(
+                'axis for remove_empty needs to be either 0 or 1.')
+
+    def replace(self, pattern=None, replacement=None):
+        """
+        Removes all empty rows or columns from the input matrix target X according to specified axis.
+
+        Parameters
+        ----------
+        pattern : float or int
+        replacement : float or int
+        """
+        if pattern is None or not isinstance(pattern, (float, int)):
+            raise ValueError('pattern should be of type float or int')
+        if replacement is None or not isinstance(replacement, (float, int)):
+            raise ValueError('replacement should be of type float or int')
+        return self._parameterized_helper_fn(
+            self, 'replace', {'target': self, 'pattern': pattern, 'replacement': replacement})
+
+    def _parameterized_helper_fn(self, fnName, **kwargs):
+        """
+        Helper to invoke parameterized builtin function
+        """
+        dml_script = ''
+        lhsStr, inputs = _matricize(self, [])
+        dml_script = [OUTPUT_ID, ' = ', fnName, '(', lhsStr]
+        first_arg = True
+        for key in kwargs:
+            if first_arg:
+                first_arg = False
+            else:
+                dml_script = dml_script + [', ']
+            v = kwargs[key]
+            if isinstance(v, str):
+                dml_script = dml_script + [key, '=\"', v, '\"']
+            elif isinstance(v, matrix):
+                dml_script = dml_script + [key, '=', v.ID]
+            else:
+                dml_script = dml_script + [key, '=', str(v)]
+        dml_script = dml_script + [')\n']
+        return construct_intermediate_node(inputs, dml_script)
+
+    ######################### Aggregation functions ##########################
+
+    def prod(self):
+        """
+        Return the product of all cells in matrix
+        """
+        return self._aggFn('prod', None)
+
+    def sum(self, axis=None):
+        """
+        Compute the sum along the specified axis
+
+        Parameters
+        ----------
+        axis : int, optional
+        """
+        return self._aggFn('sum', axis)
+
+    def mean(self, axis=None):
+        """
+        Compute the arithmetic mean along the specified axis
+
+        Parameters
+        ----------
+        axis : int, optional
+        """
+        return self._aggFn('mean', axis)
+
+    def var(self, axis=None):
+        """
+        Compute the variance along the specified axis.
+        We assume that delta degree of freedom is 1 (unlike NumPy which assumes ddof=0).
+
+        Parameters
+        ----------
+        axis : int, optional
+        """
+        return self._aggFn('var', axis)
+
+    def moment(self, moment=1, axis=None):
+        """
+        Calculates the nth moment about the mean
+
+        Parameters
+        ----------
+        moment : int
+            can be 1, 2, 3 or 4
+        axis : int, optional
+        """
+        if moment == 1:
+            return self.mean(axis)
+        elif moment == 2:
+            return self.var(axis)
+        elif moment == 3 or moment == 4:
+            return self._moment_helper(moment, axis)
+        else:
+            raise ValueError(
+                'The specified moment is not supported:' +
+                str(moment))
+
+    def _moment_helper(self, k, axis=0):
+        dml_script = ''
+        lhsStr, inputs = _matricize(self, [])
+        dml_script = [OUTPUT_ID, ' = moment(', lhsStr, ', ', str(k), ')\n']
+        dml_script = [OUTPUT_ID, ' = moment(', lhsStr, ', ', str(k), ')\n']
+        if axis is None:
+            dml_script = [
+                OUTPUT_ID,
+                ' = moment(matrix(',
+                lhsStr,
+                ', rows=length(',
+                lhsStr,
+                '), cols=1), ',
+                str(k),
+                ')\n']
+        elif axis == 0:
+            dml_script = [
+                OUTPUT_ID, ' = matrix(0, rows=nrow(', lhsStr, '), cols=1)\n']
+            dml_script = dml_script + \
+                         ['parfor(i in 1:nrow(', lhsStr, '), check=0):\n']
+            dml_script = dml_script + ['\t',
+                                       OUTPUT_ID,
+                                       '[i-1, 0] = moment(matrix(',
+                                       lhsStr,
+                                       '[i-1,], rows=ncol(',
+                                       lhsStr,
+                                       '), cols=1), ',
+                                       str(k),
+                                       ')\n\n']
+        elif axis == 1:
+            dml_script = [
+                OUTPUT_ID, ' = matrix(0, rows=1, cols=ncol(', lhsStr, '))\n']
+            dml_script = dml_script + \
+                         ['parfor(i in 1:ncol(', lhsStr, '), check=0):\n']
+            dml_script = dml_script + \
+                         ['\t',
+                          OUTPUT_ID,
+                          '[0, i-1] = moment(',
+                          lhsStr,
+                          '[,i-1], ',
+                          str(k),
+                          ')\n\n']
+        else:
+            raise ValueError('Incorrect axis:' + axis)
+        return construct_intermediate_node(inputs, dml_script)
+
+    def sd(self, axis=None):
+        """
+        Compute the standard deviation along the specified axis
+
+        Parameters
+        ----------
+        axis : int, optional
+        """
+        return self._aggFn('sd', axis)
+
+    def max(self, other=None, axis=None):
+        """
+        Compute the maximum value along the specified axis
+
+        Parameters
+        ----------
+        other: matrix or numpy array (& other supported types) or scalar
+        axis : int, optional
+        """
+        if other is not None and axis is not None:
+            raise ValueError('Both axis and other cannot be not None')
+        elif other is None and axis is not None:
+            return self._aggFn('max', axis)
+        else:
+            return binaryMatrixFunction(self, other, 'max')
+
+    def min(self, other=None, axis=None):
+        """
+        Compute the minimum value along the specified axis
+
+        Parameters
+        ----------
+        other: matrix or numpy array (& other supported types) or scalar
+        axis : int, optional
+        """
+        if other is not None and axis is not None:
+            raise ValueError('Both axis and other cannot be not None')
+        elif other is None and axis is not None:
+            return self._aggFn('min', axis)
+        else:
+            return binaryMatrixFunction(self, other, 'min')
+
+    def cumsum(self):
+        """
+        Returns the column prefix-sum.
+        """
+        return self._aggFn('cumsum', None)
+
+    def transpose(self):
+        """
+        Transposes the matrix.
+        """
+        return self._aggFn('transpose', None)
+
+    def trace(self):
+        """
+        Return the sum of the cells of the main diagonal square matrix
+        """
+        return self._aggFn('trace', None)
+
+    def _aggFn(self, fnName, axis):
+        """
+        Common function that is called for functions that have axis as parameter.
+        """
+        lhsStr, inputs = _matricize(self, [])
+        if axis is None:
+            dml_script = [OUTPUT_ID, ' = ', fnName, '(', lhsStr, ')\n']
+        else:
+            fnName = ('col' if axis == 0 else 'row') + fnName.capitalize() + 's'
+            dml_script = [OUTPUT_ID, ' = ', fnName,
+                          '(', lhsStr, ')\n']
+        return construct_intermediate_node(inputs, dml_script)
+
+    ######################### Indexing operators #############################
+
+    def __getitem__(self, index):
+        """
+        Implements evaluation of right indexing operations such as m[1,1], m[0:1,], m[:, 0:1]
+        """
+        return construct_intermediate_node(
+            [self], [OUTPUT_ID, ' = ', self.ID] + getIndexingDML(index) + ['\n'])
+
+    # Performs deep copy if the matrix is backed by data
+    def _prepareForInPlaceUpdate(self):
+        temp = matrix(self.eval_data, op=self.op)
+        for op in self.referenced:
+            op.inputs = [temp if x.ID == self.ID else x for x in op.inputs]
+        # Copy even the IDs as the IDs might be used to create DML
+        self.ID, temp.ID = temp.ID, self.ID
+        self.op = DMLOp([temp], dml=[self.ID, " = ", temp.ID])
+        self.eval_data = None
+        temp.referenced = self.referenced + [self.op]
+        self.referenced = []
+
+    def __setitem__(self, index, value):
+        """
+        Implements evaluation of left indexing operations such as m[1,1]=2
+        """
+        self._prepareForInPlaceUpdate()
+        if isinstance(value, matrix) or isinstance(value, DMLOp):
+            self.op.inputs = self.op.inputs + [value]
+        if isinstance(value, matrix):
+            value.referenced = value.referenced + [self.op]
+        self.op.dml = self.op.dml + \
+                      ['\n', self.ID] + \
+                      getIndexingDML(index) + [' = ', getValue(value), '\n']
+
+    # Not implemented: conj, hyperbolic/inverse-hyperbolic functions(i.e.
+    # sinh, arcsinh, cosh, ...), bitwise operator, xor operator, isreal,
+    # iscomplex, isfinite, isinf, isnan, copysign, nextafter, modf, frexp,
+    # trunc
+    _numpy_to_systeml_mapping = {
+        np.add: __add__,
+        np.subtract: __sub__,
+        np.multiply: __mul__,
+        np.divide: __div__,
+        np.logaddexp: logaddexp,
+        np.true_divide: __truediv__,
+        np.floor_divide: __floordiv__,
+        np.negative: negative,
+        np.power: __pow__,
+        np.remainder: remainder,
+        np.mod: mod,
+        np.fmod: __mod__,
+        np.absolute: abs,
+        np.rint: round,
+        np.sign: sign,
+        np.exp: exp,
+        np.exp2: exp2,
+        np.log: log,
+        np.log2: log2,
+        np.log10: log10,
+        np.expm1: expm1,
+        np.log1p: log1p,
+        np.sqrt: sqrt,
+        np.square: square,
+        np.reciprocal: reciprocal,
+        np.ones_like: ones_like,
+        np.zeros_like: zeros_like,
+        np.sin: sin,
+        np.cos: cos,
+        np.tan: tan,
+        np.arcsin: arcsin,
+        np.arccos: arccos,
+        np.arctan: arctan,
+        np.deg2rad: deg2rad,
+        np.rad2deg: rad2deg,
+        np.greater: __gt__,
+        np.greater_equal: __ge__,
+        np.less: __lt__,
+        np.less_equal: __le__,
+        np.not_equal: __ne__,
+        np.equal: __eq__,
+        np.logical_not: logical_not,
+        np.logical_and: __and__,
+        np.logical_or: __or__,
+        np.maximum: max,
+        np.minimum: min,
+        np.signbit: sign,
+        np.ldexp: ldexp,
+        np.dot: dot}

--- a/src/main/python/systemds/learn/__init__.py
+++ b/src/main/python/systemds/learn/__init__.py
@@ -1,0 +1,20 @@
+#-------------------------------------------------------------
+#
+# Copyright 2019 Graz University of Technology
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#-------------------------------------------------------------
+from .algorithms import *
+
+__all__ = algorithms.__all__

--- a/src/main/python/systemds/learn/algorithms.py
+++ b/src/main/python/systemds/learn/algorithms.py
@@ -1,0 +1,54 @@
+# -------------------------------------------------------------
+#
+# Copyright 2019 Graz University of Technology
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# -------------------------------------------------------------
+__all__ = ["l2svm"]
+
+import sys
+import os
+
+try:
+    import py4j.java_gateway
+    from py4j.java_gateway import JavaObject
+    from pyspark import SparkContext
+    from pyspark.conf import SparkConf
+    import pyspark.mllib.common
+    from pyspark.sql import SparkSession
+except ImportError:
+    raise ImportError(
+        'Unable to import `pyspark`. Hint: Make sure you are running with PySpark.')
+path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../")
+sys.path.insert(0, path)
+
+from .. import *
+
+ml_context = None
+
+
+def getOrCreateMLContext():
+    global ml_context
+    if ml_context is None:
+        ml_context = MLContext(SparkContext.getOrCreate())
+    return ml_context
+
+
+def l2svm(X, Y, intercept=False, epsilon=0.001, lmbda=1.0, max_iter=100):
+    """
+    Executes l2svm on the given data with the given parameters. Returns a `MLContext.Matrix` object.
+    """
+    script = dml("model = l2svm(X=X, Y=Y, intercept=i, epsilon=eps, lambda=l, maxiterations=maxi)") \
+        .output("model").input(X=X, Y=Y, i=intercept, eps=epsilon, l=lmbda, maxi=max_iter)
+    return getOrCreateMLContext().execute(script).get("model")

--- a/src/main/python/systemds/mlcontext.py
+++ b/src/main/python/systemds/mlcontext.py
@@ -1,0 +1,726 @@
+# -------------------------------------------------------------
+#
+# Modifications Copyright 2019 Graz University of Technology
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# -------------------------------------------------------------
+
+# Methods to create Script object
+script_factory_methods = [
+    'dml',
+    'dmlFromResource',
+    'dmlFromFile',
+    'dmlFromUrl']
+# Utility methods
+util_methods = ['_java2py', 'getHopDAG']
+__all__ = ['MLResults', 'MLContext', 'Script', 'Matrix'] + \
+          script_factory_methods + util_methods
+
+import os
+
+try:
+    import py4j.java_gateway
+    from py4j.java_gateway import JavaObject
+    from pyspark import SparkContext
+    from pyspark.conf import SparkConf
+    import pyspark.mllib.common
+    from pyspark.sql import SparkSession
+except ImportError:
+    raise ImportError(
+        'Unable to import `pyspark`. Hint: Make sure you are running with PySpark.')
+
+from .converters import *
+from .classloader import *
+
+
+def getHopDAG(ml, script, lines=None, conf=None,
+              apply_rewrites=True, with_subgraph=False):
+    """
+    Compile a DML / PyDML script.
+
+    Parameters
+    ----------
+    ml: MLContext instance
+        MLContext instance.
+
+    script: Script instance
+        Script instance defined with the appropriate input and output variables.
+
+    lines: list of integers
+        Optional: only display the hops that have begin and end line number equals to the given integers.
+
+    conf: SparkConf instance
+        Optional spark configuration
+
+    apply_rewrites: boolean
+        If True, perform static rewrites, perform intra-/inter-procedural analysis to propagate size information into functions and apply dynamic rewrites
+
+    with_subgraph: boolean
+        If False, the dot graph will be created without subgraphs for statement blocks.
+
+    Returns
+    -------
+    hopDAG: string
+        hop DAG in dot format
+    """
+    if not isinstance(script, Script):
+        raise ValueError("Expected script to be an instance of Script")
+    scriptString = script.scriptString
+    script_java = script.script_java
+    lines = [int(x) for x in lines] if lines is not None else [int(-1)]
+    sc = get_spark_context()
+    if conf is not None:
+        hopDAG = sc._jvm.org.tugraz.sysds.api.mlcontext.MLContextUtil.getHopDAG(
+            ml._ml, script_java, lines, conf._jconf, apply_rewrites, with_subgraph)
+    else:
+        hopDAG = sc._jvm.org.tugraz.sysds.api.mlcontext.MLContextUtil.getHopDAG(
+            ml._ml, script_java, lines, apply_rewrites, with_subgraph)
+    return hopDAG
+
+
+def dml(scriptString):
+    """
+    Create a dml script object based on a string.
+
+    Parameters
+    ----------
+    scriptString: string
+        Can be a path to a dml script or a dml script itself.
+
+    Returns
+    -------
+    script: Script instance
+        Instance of a script object.
+    """
+    if not isinstance(scriptString, str):
+        raise ValueError(
+            "scriptString should be a string, got %s" %
+            type(scriptString))
+    return Script(scriptString)
+
+
+def dmlFromResource(resourcePath):
+    """
+    Create a dml script object based on a resource path.
+
+    Parameters
+    ----------
+    resourcePath: string
+        Path to a dml script on the classpath.
+
+    Returns
+    -------
+    script: Script instance
+        Instance of a script object.
+    """
+    if not isinstance(resourcePath, str):
+        raise ValueError(
+            "resourcePath should be a string, got %s" %
+            type(resourcePath))
+    return Script(resourcePath, scriptType="dml", isResource=True)
+
+
+def dmlFromFile(filePath):
+    """
+    Create a dml script object based on a file path.
+
+    Parameters
+    ----------
+    filePath: string
+        Path to a dml script.
+
+    Returns
+    -------
+    script: Script instance
+        Instance of a script object.
+    """
+    if not isinstance(filePath, str):
+        raise ValueError(
+            "filePath should be a string, got %s" %
+            type(filePath))
+    return Script(filePath, scriptType="dml",
+                  isResource=False, scriptFormat="file")
+
+
+def dmlFromUrl(url):
+    """
+    Create a dml script object based on a url.
+
+    Parameters
+    ----------
+    url: string
+        URL to a dml script.
+
+    Returns
+    -------
+    script: Script instance
+        Instance of a script object.
+    """
+    if not isinstance(url, str):
+        raise ValueError("url should be a string, got %s" % type(url))
+    return Script(url, scriptType="dml", isResource=False, scriptFormat="url")
+
+
+def _java2py(sc, obj):
+    """ Convert Java object to Python. """
+    # TODO: Port this private PySpark function.
+    obj = pyspark.mllib.common._java2py(sc, obj)
+    if isinstance(obj, JavaObject):
+        class_name = obj.getClass().getSimpleName()
+        if class_name == 'Matrix':
+            obj = Matrix(obj, sc)
+    return obj
+
+
+def _py2java(sc, obj):
+    """ Convert Python object to Java. """
+    if isinstance(obj, SUPPORTED_TYPES):
+        obj = convertToMatrixBlock(sc, obj)
+    else:
+        if isinstance(obj, Matrix):
+            obj = obj._java_matrix
+        # TODO: Port this private PySpark function.
+        obj = pyspark.mllib.common._py2java(sc, obj)
+    return obj
+
+
+class Matrix(object):
+    """
+    Wrapper around a Java Matrix object.
+
+    Parameters
+    ----------
+    javaMatrix: JavaObject
+        A Java Matrix object as returned by calling `ml.execute().get()`.
+
+    sc: SparkContext
+        SparkContext
+    """
+
+    def __init__(self, javaMatrix, sc):
+        self._java_matrix = javaMatrix
+        self._sc = sc
+
+    def __repr__(self):
+        return "Matrix"
+
+    def toDF(self):
+        """
+        Convert the Matrix to a PySpark SQL DataFrame.
+
+        Returns
+        -------
+        PySpark SQL DataFrame
+            A PySpark SQL DataFrame representing the matrix, with
+            one "__INDEX" column containing the row index (since Spark
+            DataFrames are unordered), followed by columns of doubles
+            for each column in the matrix.
+        """
+        jdf = self._java_matrix.toDF()
+        df = _java2py(self._sc, jdf)
+        return df
+
+    def toNumPy(self):
+        """
+        Convert the Matrix to a NumPy Array.
+
+        Returns
+        -------
+        NumPy Array
+            A NumPy Array representing the Matrix object.
+        """
+        np_array = convertToNumPyArr(
+            self._sc, self._java_matrix.toMatrixBlock())
+        return np_array
+
+
+class MLResults(object):
+    """
+    Wrapper around a Java ML Results object.
+
+    Parameters
+    ----------
+    results: JavaObject
+        A Java MLResults object as returned by calling `ml.execute()`.
+
+    sc: SparkContext
+        SparkContext
+    """
+
+    def __init__(self, results, sc):
+        self._java_results = results
+        self._sc = sc
+
+    def __repr__(self):
+        return "MLResults"
+
+    def get(self, *outputs):
+        """
+        Parameters
+        ----------
+        outputs: string, list of strings
+            Output variables as defined inside the DML script.
+        """
+        outs = [_java2py(self._sc, self._java_results.get(out))
+                for out in outputs]
+        if len(outs) == 1:
+            return outs[0]
+        return outs
+
+
+class Script(object):
+    """
+    Instance of a DML Script.
+
+    Parameters
+    ----------
+    scriptString: string
+        Can be either a file path to a DML script or a DML script itself.
+
+    isResource: boolean
+        If true, scriptString is a path to a resource on the classpath
+
+    scriptFormat: string
+        Optional script format, either "auto" or "url" or "file" or "resource" or "string"
+    """
+
+    def __init__(self, scriptString, isResource=False, scriptFormat="auto"):
+        self.sc = get_spark_context()
+        self.scriptString = scriptString
+        self.isResource = isResource
+        if scriptFormat != "auto":
+            if scriptFormat == "url":
+                self.script_java = self.sc._jvm.org.tugraz.sysds.api.mlcontext.ScriptFactory.dmlFromUrl(
+                    scriptString)
+            elif scriptFormat == "file":
+                self.script_java = self.sc._jvm.org.tugraz.sysds.api.mlcontext.ScriptFactory.dmlFromFile(
+                    scriptString)
+            elif isResource:
+                self.script_java = self.sc._jvm.org.tugraz.sysds.api.mlcontext.ScriptFactory.dmlFromResource(
+                    scriptString)
+            elif scriptFormat == "string":
+                self.script_java = self.sc._jvm.org.tugraz.sysds.api.mlcontext.ScriptFactory.dml(
+                    scriptString)
+            elif scriptFormat == "string" and self.scriptType == "pydml":
+                self.script_java = self.sc._jvm.org.tugraz.sysds.api.mlcontext.ScriptFactory.pydml(
+                    scriptString)
+            else:
+                raise ValueError('Unsupported script format' + scriptFormat)
+        else:
+            if scriptString.endswith(".dml"):
+                if scriptString.startswith("http"):
+                    self.script_java = self.sc._jvm.org.tugraz.sysds.api.mlcontext.ScriptFactory.dmlFromUrl(
+                        scriptString)
+                elif os.path.exists(scriptString):
+                    self.script_java = self.sc._jvm.org.tugraz.sysds.api.mlcontext.ScriptFactory.dmlFromFile(
+                        scriptString)
+                elif self.isResource == True:
+                    self.script_java = self.sc._jvm.org.tugraz.sysds.api.mlcontext.ScriptFactory.dmlFromResource(
+                        scriptString)
+                else:
+                    raise ValueError("path: %s does not exist" % scriptString)
+            else:
+                self.script_java = self.sc._jvm.org.tugraz.sysds.api.mlcontext.ScriptFactory.dml(
+                    scriptString)
+
+    def getScriptString(self):
+        """
+        Obtain the script string (in unicode).
+        """
+        return self.script_java.getScriptString()
+
+    def setScriptString(self, scriptString):
+        """
+        Set the script string.
+
+        Parameters
+        ----------
+        scriptString: string
+            Can be either a file path to a DML script or a DML script itself.
+        """
+        self.scriptString = scriptString
+        self.script_java.setScriptString(scriptString)
+        return self
+
+    def getInputVariables(self):
+        """
+        Obtain the input variable names.
+        """
+        return self.script_java.getInputVariables()
+
+    def getOutputVariables(self):
+        """
+        Obtain the output variable names.
+        """
+        return self.script_java.getOutputVariables()
+
+    def clearIOS(self):
+        """
+        Clear the inputs, outputs, and symbol table.
+        """
+        self.script_java.clearIOS()
+        return self
+
+    def clearIO(self):
+        """
+        Clear the inputs and outputs, but not the symbol table.
+        """
+        self.script_java.clearIO()
+        return self
+
+    def clearAll(self):
+        """
+        Clear the script string, inputs, outputs, and symbol table.
+        """
+        self.script_java.clearAll()
+        return self
+
+    def clearInputs(self):
+        """
+        Clear the inputs.
+        """
+        self.script_java.clearInputs()
+        return self
+
+    def clearOutputs(self):
+        """
+        Clear the outputs.
+        """
+        self.script_java.clearOutputs()
+        return self
+
+    def clearSymbolTable(self):
+        """
+        Clear the symbol table.
+        """
+        self.script_java.clearSymbolTable()
+        return self
+
+    def results(self):
+        """
+        Obtain the results of the script execution.
+        """
+        return MLResults(self.script_java.results(), self.sc)
+
+    def getResults(self):
+        """
+        Obtain the results of the script execution.
+        """
+        return MLResults(self.script_java.getResults(), self.sc)
+
+    def setResults(self, results):
+        """
+        Set the results of the script execution.
+        """
+        self.script_java.setResults(results._java_results)
+        return self
+
+    def getScriptExecutionString(self):
+        """
+        Generate the script execution string, which adds read/load/write/save
+        statements to the beginning and end of the script to execute.
+        """
+        return self.script_java.getScriptExecutionString()
+
+    def __repr__(self):
+        return "Script"
+
+    def info(self):
+        """
+        Display information about the script as a String. This consists of the
+        script type, inputs, outputs, input parameters, input variables, output
+        variables, the symbol table, the script string, and the script execution string.
+        """
+        return self.script_java.info()
+
+    def displayInputs(self):
+        """
+        Display the script inputs.
+        """
+        return self.script_java.displayInputs()
+
+    def displayOutputs(self):
+        """
+        Display the script outputs.
+        """
+        return self.script_java.displayOutputs()
+
+    def displayInputParameters(self):
+        """
+        Display the script input parameters.
+        """
+        return self.script_java.displayInputParameters()
+
+    def displayInputVariables(self):
+        """
+        Display the script input variables.
+        """
+        return self.script_java.displayInputVariables()
+
+    def displayOutputVariables(self):
+        """
+        Display the script output variables.
+        """
+        return self.script_java.displayOutputVariables()
+
+    def displaySymbolTable(self):
+        """
+        Display the script symbol table.
+        """
+        return self.script_java.displaySymbolTable()
+
+    def getName(self):
+        """
+        Obtain the script name.
+        """
+        return self.script_java.getName()
+
+    def setName(self, name):
+        """
+        Set the script name.
+        """
+        self.script_java.setName(name)
+        return self
+
+    def getScriptType(self):
+        """
+        Obtain the script type.
+        """
+        return self.scriptType
+
+    def input(self, *args, **kwargs):
+        """
+        Parameters
+        ----------
+        args: name, value tuple
+            where name is a string, and currently supported value formats
+            are double, string, dataframe, rdd, and list of such object.
+
+        kwargs: dict of name, value pairs
+            To know what formats are supported for name and value, look above.
+        """
+        if args and len(args) != 2:
+            raise ValueError("Expected name, value pair.")
+        elif args:
+            self._setInput(args[0], args[1])
+        for name, value in kwargs.items():
+            self._setInput(name, value)
+        return self
+
+    def _setInput(self, key, val):
+        # `in` is a reserved word ("keyword") in Python, so `script_java.in(...)` is not
+        # allowed. Therefore, we use the following code in which we retrieve a function
+        # representing `script_java.in`, and then call it with the arguments.  This is in
+        # lieu of adding a new `input` method on the JVM side, as that would complicate use
+        # from Scala/Java.
+        if isinstance(val, py4j.java_gateway.JavaObject):
+            py4j.java_gateway.get_method(self.script_java, "in")(key, val)
+        else:
+            py4j.java_gateway.get_method(
+                self.script_java, "in")(
+                key, _py2java(
+                    self.sc, val))
+
+    def output(self, *names):
+        """
+        Parameters
+        ----------
+        names: string, list of strings
+            Output variables as defined inside the DML script.
+        """
+        for val in names:
+            self.script_java.out(val)
+        return self
+
+
+class MLContext(object):
+    """
+    Wrapper around the new SystemDS MLContext.
+
+    Parameters
+    ----------
+    sc: SparkContext or SparkSession
+        An instance of pyspark.SparkContext or pyspark.sql.SparkSession.
+    """
+
+    def __init__(self, sc):
+        if isinstance(sc, pyspark.sql.session.SparkSession):
+            sc = sc._sc
+        elif not isinstance(sc, SparkContext):
+            raise ValueError(
+                "Expected sc to be a SparkContext or SparkSession, got " % str(type(sc)))
+        self._sc = sc
+        self._ml = createJavaObject(sc, 'mlcontext')
+
+    def __repr__(self):
+        return "MLContext"
+
+    def execute(self, script):
+        """
+        Execute a DML / PyDML script.
+
+        Parameters
+        ----------
+        script: Script instance
+            Script instance defined with the appropriate input and output variables.
+
+        Returns
+        -------
+        ml_results: MLResults
+            MLResults instance.
+        """
+        if not isinstance(script, Script):
+            raise ValueError("Expected script to be an instance of Script")
+        script_java = script.script_java
+        return MLResults(self._ml.execute(script_java), self._sc)
+
+    def setStatistics(self, statistics):
+        """
+        Whether or not to output statistics (such as execution time, elapsed time)
+        about script executions.
+
+        Parameters
+        ----------
+        statistics: boolean
+        """
+        self._ml.setStatistics(bool(statistics))
+        return self
+
+    def setGPU(self, enable):
+        """
+        Whether or not to enable GPU.
+
+        Parameters
+        ----------
+        enable: boolean
+        """
+        self._ml.setGPU(bool(enable))
+        return self
+
+    def setForceGPU(self, enable):
+        """
+        Whether or not to force the usage of GPU operators.
+
+        Parameters
+        ----------
+        enable: boolean
+        """
+        self._ml.setForceGPU(bool(enable))
+        return self
+
+    def setStatisticsMaxHeavyHitters(self, maxHeavyHitters):
+        """
+        The maximum number of heavy hitters that are printed as part of the statistics.
+
+        Parameters
+        ----------
+        maxHeavyHitters: int
+        """
+        self._ml.setStatisticsMaxHeavyHitters(maxHeavyHitters)
+        return self
+
+    def setExplain(self, explain):
+        """
+        Explanation about the program. Mainly intended for developers.
+
+        Parameters
+        ----------
+        explain: boolean
+        """
+        self._ml.setExplain(bool(explain))
+        return self
+
+    def setExplainLevel(self, explainLevel):
+        """
+        Set explain level.
+
+        Parameters
+        ----------
+        explainLevel: string
+            Can be one of "hops", "runtime", "recompile_hops", "recompile_runtime"
+            or in the above in upper case.
+        """
+        self._ml.setExplainLevel(explainLevel)
+        return self
+
+    def setConfigProperty(self, propertyName, propertyValue):
+        """
+        Set configuration property, such as setConfigProperty("sysds.localtmpdir", "/tmp/systemds").
+
+        Parameters
+        ----------
+        propertyName: String
+        propertyValue: String
+        """
+        self._ml.setConfigProperty(propertyName, propertyValue)
+        return self
+
+    def setConfig(self, configFilePath):
+        """
+        Set SystemDS configuration based on a configuration file.
+
+        Parameters
+        ----------
+        configFilePath: String
+        """
+        self._ml.setConfig(configFilePath)
+        return self
+
+    def resetConfig(self):
+        """
+        Reset configuration settings to default values.
+        """
+        self._ml.resetConfig()
+        return self
+
+    def version(self):
+        """Display the project version."""
+        return self._ml.version()
+
+    def buildTime(self):
+        """Display the project build time."""
+        return self._ml.buildTime()
+
+    def info(self):
+        """Display the project information."""
+        return self._ml.info().toString()
+
+    def isExplain(self):
+        """Returns True if program instruction details should be output, False otherwise."""
+        return self._ml.isExplain()
+
+    def isStatistics(self):
+        """Returns True if program execution statistics should be output, False otherwise."""
+        return self._ml.isStatistics()
+
+    def isGPU(self):
+        """Returns True if GPU mode is enabled, False otherwise."""
+        return self._ml.isGPU()
+
+    def isForceGPU(self):
+        """Returns True if "force" GPU mode is enabled, False otherwise."""
+        return self._ml.isForceGPU()
+
+    def close(self):
+        """
+        Closes this MLContext instance to cleanup buffer pool, static/local state and scratch space.
+        Note the SparkContext is not explicitly closed to allow external reuse.
+        """
+        self._ml.close()
+        return self

--- a/src/main/python/tests/test_l2svm.py
+++ b/src/main/python/tests/test_l2svm.py
@@ -1,0 +1,96 @@
+# -------------------------------------------------------------
+#
+# Modifications Copyright 2019 Graz University of Technology
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# -------------------------------------------------------------
+
+# To run:
+#   - Python 2: `PYSPARK_PYTHON=python2 spark-submit --master local[*] --driver-class-path SystemDS.jar test_l2svm.py`
+#   - Python 3: `PYSPARK_PYTHON=python3 spark-submit --master local[*] --driver-class-path SystemDS.jar test_l2svm.py`
+
+# Make the `systemml` package importable
+import os
+import sys
+
+path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../")
+sys.path.insert(0, path)
+
+import unittest
+
+import numpy as np
+from pyspark.context import SparkContext
+
+from systemds import MLContext, dml, matrix, learn
+
+sc = SparkContext.getOrCreate()
+ml = MLContext(sc)
+
+
+class TestAPI(unittest.TestCase):
+
+    def test_10x10_manual(self):
+        dim = 10
+        np.random.seed(1304)
+        m1 = np.array(np.random.randint(100, size=dim * dim) + 1.01, dtype=np.double)
+        m1.shape = (dim, dim)
+        m2 = np.zeros((dim, 1))
+        for i in range(dim):
+            if np.random.random() > 0.5:
+                m2[i][0] = 1
+        script = dml("model = l2svm(X=X, Y=Y)").output("model").input(X=m1, Y=m2)
+        model = ml.execute(script).get("model").toNumPy()
+        # TODO calculate reference
+        self.assertTrue(np.allclose(model, np.array([[-0.03277166],
+                                                     [-0.00820981],
+                                                     [0.00657115],
+                                                     [0.03228764],
+                                                     [-0.01685067],
+                                                     [0.00892918],
+                                                     [0.00945636],
+                                                     [0.01514383],
+                                                     [0.0713272],
+                                                     [-0.05113976]])))
+
+    def test_10x10_func(self):
+        dim = 10
+        np.random.seed(1304)
+        m1 = np.array(np.random.randint(100, size=dim * dim) + 1.01, dtype=np.double)
+        m1.shape = (dim, dim)
+        m2 = np.zeros((dim, 1))
+        for i in range(dim):
+            if np.random.random() > 0.5:
+                m2[i][0] = 1
+        sc = SparkContext.getOrCreate()
+        model = learn.l2svm(m1, m2).toNumPy()
+        # TODO calculate reference
+        self.assertTrue(np.allclose(model, np.array([[-0.03277166],
+                                                     [-0.00820981],
+                                                     [0.00657115],
+                                                     [0.03228764],
+                                                     [-0.01685067],
+                                                     [0.00892918],
+                                                     [0.00945636],
+                                                     [0.01514383],
+                                                     [0.0713272],
+                                                     [-0.05113976]])))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/main/python/tests/test_matrix_agg_fn.py
+++ b/src/main/python/tests/test_matrix_agg_fn.py
@@ -1,0 +1,101 @@
+# -------------------------------------------------------------
+#
+# Modifications Copyright 2019 Graz University of Technology
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# -------------------------------------------------------------
+
+# To run:
+#   - Python 2: `PYSPARK_PYTHON=python2 spark-submit --master local[*] --driver-class-path SystemDS.jar test_matrix_agg_fn.py`
+#   - Python 3: `PYSPARK_PYTHON=python3 spark-submit --master local[*] --driver-class-path SystemDS.jar test_matrix_agg_fn.py`
+
+# Make the `systemds` package importable
+import os
+import sys
+
+path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../")
+sys.path.insert(0, path)
+
+import unittest
+import systemds as sds
+import numpy as np
+from scipy.stats import kurtosis, skew, moment
+from pyspark.context import SparkContext
+
+sc = SparkContext.getOrCreate()
+
+dim = 5
+m1 = np.array(np.random.randint(100, size=dim * dim) + 1.01, dtype=np.double)
+m1.shape = (dim, dim)
+m2 = np.array(np.random.randint(5, size=dim * dim) + 1, dtype=np.double)
+m2.shape = (dim, dim)
+s = 3.02
+
+
+class TestMatrixAggFn(unittest.TestCase):
+
+    def test_sum1(self):
+        self.assertTrue(np.allclose(sds.matrix(m1).sum(), m1.sum()))
+
+    def test_sum2(self):
+        self.assertTrue(np.allclose(sds.matrix(m1).sum(axis=0), m1.sum(axis=0)))
+
+    def test_sum3(self):
+        self.assertTrue(np.allclose(sds.matrix(m1).sum(axis=1), m1.sum(axis=1).reshape(dim, 1)))
+
+    def test_mean1(self):
+        self.assertTrue(np.allclose(sds.matrix(m1).mean(), m1.mean()))
+
+    def test_mean2(self):
+        self.assertTrue(np.allclose(sds.matrix(m1).mean(axis=0), m1.mean(axis=0).reshape(1, dim)))
+
+    def test_mean3(self):
+        self.assertTrue(np.allclose(sds.matrix(m1).mean(axis=1), m1.mean(axis=1).reshape(dim, 1)))
+
+    def test_hstack(self):
+        self.assertTrue(np.allclose(sds.matrix(m1).hstack(sds.matrix(m1)), np.hstack((m1, m1))))
+
+    def test_vstack(self):
+        self.assertTrue(np.allclose(sds.matrix(m1).vstack(sds.matrix(m1)), np.vstack((m1, m1))))
+
+    def test_full(self):
+        self.assertTrue(np.allclose(sds.full((2, 3), 10.1), np.full((2, 3), 10.1)))
+
+    def test_seq(self):
+        self.assertTrue(np.allclose(sds.seq(3), np.arange(3 + 1).reshape(4, 1)))
+
+    def test_var1(self):
+        print(str(np.array(sds.matrix(m1).var())) + " " + str(np.array(m1.var(ddof=1))))
+        self.assertTrue(np.allclose(sds.matrix(m1).var(), m1.var(ddof=1)))
+
+    def test_var2(self):
+        self.assertTrue(np.allclose(sds.matrix(m1).var(axis=0), m1.var(axis=0, ddof=1).reshape(1, dim)))
+
+    def test_var3(self):
+        self.assertTrue(np.allclose(sds.matrix(m1).var(axis=1), m1.var(axis=1, ddof=1).reshape(dim, 1)))
+
+    def test_moment3(self):
+        self.assertTrue(np.allclose(sds.matrix(m1).moment(moment=3, axis=None), moment(m1, moment=3, axis=None)))
+
+    def test_moment4(self):
+        self.assertTrue(np.allclose(sds.matrix(m1).moment(moment=4, axis=None), moment(m1, moment=4, axis=None)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/main/python/tests/test_matrix_binary_op.py
+++ b/src/main/python/tests/test_matrix_binary_op.py
@@ -1,0 +1,129 @@
+# -------------------------------------------------------------
+#
+# Modifications Copyright 2019 Graz University of Technology
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# -------------------------------------------------------------
+
+# To run:
+#   - Python 2: `PYSPARK_PYTHON=python2 spark-submit --master local[*] --driver-class-path SystemDS.jar test_matrix_binary_op.py`
+#   - Python 3: `PYSPARK_PYTHON=python3 spark-submit --master local[*] --driver-class-path SystemDS.jar test_matrix_binary_op.py`
+
+# Make the `systemds` package importable
+import os
+import sys
+
+path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../")
+sys.path.insert(0, path)
+
+import unittest
+import systemds as sds
+import numpy as np
+from pyspark.context import SparkContext
+
+sc = SparkContext.getOrCreate()
+
+dim = 5
+m1 = np.array(np.random.randint(100, size=dim * dim) + 1.01, dtype=np.double)
+m1.shape = (dim, dim)
+m2 = np.array(np.random.randint(5, size=dim * dim) + 1, dtype=np.double)
+m2.shape = (dim, dim)
+s = 3.02
+
+
+class TestBinaryOp(unittest.TestCase):
+
+    def test_plus(self):
+        self.assertTrue(np.allclose(sds.matrix(m1) + sds.matrix(m2), m1 + m2))
+
+    def test_minus(self):
+        self.assertTrue(np.allclose(sds.matrix(m1) - sds.matrix(m2), m1 - m2))
+
+    def test_mul(self):
+        self.assertTrue(np.allclose(sds.matrix(m1) * sds.matrix(m2), m1 * m2))
+
+    def test_div(self):
+        self.assertTrue(np.allclose(sds.matrix(m1) / sds.matrix(m2), m1 / m2))
+
+    def test_plus1(self):
+        self.assertTrue(np.allclose(sds.matrix(m1) + m2, m1 + m2))
+
+    def test_minus1(self):
+        self.assertTrue(np.allclose(sds.matrix(m1) - m2, m1 - m2))
+
+    def test_mul1(self):
+        self.assertTrue(np.allclose(sds.matrix(m1) * m2, m1 * m2))
+
+    def test_div1(self):
+        self.assertTrue(np.allclose(sds.matrix(m1) / m2, m1 / m2))
+
+    def test_plus2(self):
+        self.assertTrue(np.allclose(m1 + sds.matrix(m2), m1 + m2))
+
+    def test_minus2(self):
+        self.assertTrue(np.allclose(m1 - sds.matrix(m2), m1 - m2))
+
+    def test_mul2(self):
+        self.assertTrue(np.allclose(m1 * sds.matrix(m2), m1 * m2))
+
+    def test_div2(self):
+        self.assertTrue(np.allclose(m1 / sds.matrix(m2), m1 / m2))
+
+    def test_plus3(self):
+        self.assertTrue(np.allclose(sds.matrix(m1) + s, m1 + s))
+
+    def test_minus3(self):
+        self.assertTrue(np.allclose(sds.matrix(m1) - s, m1 - s))
+
+    def test_mul3(self):
+        self.assertTrue(np.allclose(sds.matrix(m1) * s, m1 * s))
+
+    def test_div3(self):
+        self.assertTrue(np.allclose(sds.matrix(m1) / s, m1 / s))
+
+    def test_plus4(self):
+        self.assertTrue(np.allclose(s + sds.matrix(m2), s + m2))
+
+    def test_minus4(self):
+        self.assertTrue(np.allclose(s - sds.matrix(m2), s - m2))
+
+    def test_mul4(self):
+        self.assertTrue(np.allclose(s * sds.matrix(m2), s * m2))
+
+    def test_div4(self):
+        self.assertTrue(np.allclose(s / sds.matrix(m2), s / m2))
+
+    def test_lt(self):
+        self.assertTrue(np.allclose(sds.matrix(m1) < sds.matrix(m2), m1 < m2))
+
+    def test_gt(self):
+        self.assertTrue(np.allclose(sds.matrix(m1) > sds.matrix(m2), m1 > m2))
+
+    def test_le(self):
+        self.assertTrue(np.allclose(sds.matrix(m1) <= sds.matrix(m2), m1 <= m2))
+
+    def test_ge(self):
+        self.assertTrue(np.allclose(sds.matrix(m1) >= sds.matrix(m2), m1 >= m2))
+
+    def test_abs(self):
+        self.assertTrue(np.allclose(sds.matrix(m1).abs(), np.abs(m1)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/main/python/tests/test_mlcontext.py
+++ b/src/main/python/tests/test_mlcontext.py
@@ -1,0 +1,143 @@
+# -------------------------------------------------------------
+#
+# Modifications Copyright 2019 Graz University of Technology
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# -------------------------------------------------------------
+
+# To run:
+#   - Python 2: `PYSPARK_PYTHON=python2 spark-submit --master local[*] --driver-class-path SystemDS.jar test_mlcontext.py`
+#   - Python 3: `PYSPARK_PYTHON=python3 spark-submit --master local[*] --driver-class-path SystemDS.jar test_mlcontext.py`
+
+# Make the `systemds` package importable
+import os
+import sys
+
+path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../")
+sys.path.insert(0, path)
+
+import unittest
+
+import numpy as np
+from pyspark.context import SparkContext
+
+from systemds import MLContext, dml
+
+sc = SparkContext.getOrCreate()
+ml = MLContext(sc)
+
+
+class TestAPI(unittest.TestCase):
+
+    def test_output_string(self):
+        script = dml("x1 = 'Hello World'").output("x1")
+        self.assertEqual(ml.execute(script).get("x1"), "Hello World")
+
+    def test_output_list(self):
+        script = """
+        x1 = 0.2
+        x2 = x1 + 1
+        x3 = x1 + 2
+        """
+        script = dml(script).output("x1", "x2", "x3")
+        self.assertEqual(ml.execute(script).get("x1", "x2"), [0.2, 1.2])
+        self.assertEqual(ml.execute(script).get("x1", "x3"), [0.2, 2.2])
+
+    def test_output_matrix(self):
+        sums = """
+        s1 = sum(m1)
+        m2 = m1 * 2
+        """
+        rdd1 = sc.parallelize(["1.0,2.0", "3.0,4.0"])
+        script = dml(sums).input(m1=rdd1).output("s1", "m2")
+        s1, m2 = ml.execute(script).get("s1", "m2")
+        self.assertEqual((s1, repr(m2)), (10.0, "Matrix"))
+
+    def test_matrix_toDF(self):
+        sums = """
+        s1 = sum(m1)
+        m2 = m1 * 2
+        """
+        rdd1 = sc.parallelize(["1.0,2.0", "3.0,4.0"])
+        script = dml(sums).input(m1=rdd1).output("m2")
+        m2 = ml.execute(script).get("m2")
+        self.assertEqual(repr(m2.toDF()), "DataFrame[__INDEX: double, C1: double, C2: double]")
+
+    def test_matrix_toNumPy(self):
+        script = """
+        m2 = m1 * 2
+        """
+        rdd1 = sc.parallelize(["1.0,2.0", "3.0,4.0"])
+        script = dml(script).input(m1=rdd1).output("m2")
+        m2 = ml.execute(script).get("m2")
+        self.assertTrue((m2.toNumPy() == np.array([[2.0, 4.0], [6.0, 8.0]])).all())
+
+    def test_input_single(self):
+        script = """
+        x2 = x1 + 1
+        x3 = x1 + 2
+        """
+        script = dml(script).input("x1", 5).output("x2", "x3")
+        self.assertEqual(ml.execute(script).get("x2", "x3"), [6, 7])
+
+    def test_input(self):
+        script = """
+        x3 = x1 + x2
+        """
+        script = dml(script).input(x1=5, x2=3).output("x3")
+        self.assertEqual(ml.execute(script).get("x3"), 8)
+
+    def test_numpy_float64(self):
+        script = """
+        x2 = x1 + 2.15
+        """
+        numpy_x1 = np.random.rand(5, 10).astype(np.float64)
+        script = dml(script).input(x1=numpy_x1).output("x2")
+        self.assertTrue(np.allclose(ml.execute(script).get("x2").toNumPy(), numpy_x1 + 2.15))
+
+    def test_numpy_float32(self):
+        script = """
+        x2 = x1 + 2.15
+        """
+        numpy_x1 = np.random.rand(5, 10).astype(np.float32)
+        script = dml(script).input(x1=numpy_x1).output("x2")
+        self.assertTrue(np.allclose(ml.execute(script).get("x2").toNumPy(), numpy_x1 + 2.15))
+
+    def test_numpy_int32(self):
+        script = """
+        x2 = x1 + 2
+        """
+        numpy_x1 = np.random.randint(1000, size=(5, 10)).astype(np.int32)
+        script = dml(script).input(x1=numpy_x1).output("x2")
+        self.assertTrue(np.allclose(ml.execute(script).get("x2").toNumPy(), numpy_x1 + 2))
+
+    def test_rdd(self):
+        sums = """
+        s1 = sum(m1)
+        s2 = sum(m2)
+        s3 = 'whatever'
+        """
+        rdd1 = sc.parallelize(["1.0,2.0", "3.0,4.0"])
+        rdd2 = sc.parallelize(["5.0,6.0", "7.0,8.0"])
+        script = dml(sums).input(m1=rdd1).input(m2=rdd2).output("s1", "s2", "s3")
+        self.assertEqual(ml.execute(script).get("s1", "s2", "s3"), [10.0, 26.0, "whatever"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This adds a python wrapper module, with large parts copied from the old systemml solution. Note that currently it does not have all the necessary files for packages (e.g. `setup.py` and `LICENSE`), because there is a lot of metadata, like e-mails and website links, where I do not know what we want to specify.

I made some minor cleanup of the systemml solution and removed the estimators. I will continue to remove parts and adapt other parts, because some features are no longer supported in systemds (like python-like dml), or changed their function signatures (like `var(X, axis=0/1)` being changed to two functions `colVars` and `rowVars`).

I added a dedicated `l2svm` function, but we have to discuss where those script wrappers should be placed.

FYI: I ran the tests with `PYSPARK_PYTHON=python2 spark-submit --master local --driver-class-path [SYSTEMDS-JAR-PATH] [TEST-PYTHON-SCRIPT]`