### PR TITLE
[DIA-22] Add basic lineage support for spark instructions

### DIFF
--- a/src/main/java/org/tugraz/sysds/runtime/instructions/spark/WriteSPInstruction.java
+++ b/src/main/java/org/tugraz/sysds/runtime/instructions/spark/WriteSPInstruction.java
@@ -118,6 +118,12 @@ public class WriteSPInstruction extends SPInstruction implements LineageTraceabl
 		formatProperties = prop;
 	}
 	
+	public CPOperand getInput1() { return input1; }
+	
+	public CPOperand getInput2() {
+		return input2;
+	}
+	
 	@Override
 	public void processInstruction(ExecutionContext ec) {
 		SparkExecutionContext sec = (SparkExecutionContext) ec;

--- a/src/main/java/org/tugraz/sysds/runtime/lineage/LineageMap.java
+++ b/src/main/java/org/tugraz/sysds/runtime/lineage/LineageMap.java
@@ -24,6 +24,7 @@ import org.tugraz.sysds.runtime.instructions.Instruction;
 import org.tugraz.sysds.runtime.instructions.cp.CPOperand;
 import org.tugraz.sysds.runtime.instructions.cp.FunctionCallCPInstruction;
 import org.tugraz.sysds.runtime.instructions.cp.VariableCPInstruction;
+import org.tugraz.sysds.runtime.instructions.spark.WriteSPInstruction;
 import org.tugraz.sysds.runtime.lineage.LineageItem.LineageItemType;
 import org.tugraz.sysds.utils.Explain;
 
@@ -136,7 +137,7 @@ public class LineageMap {
 					break;
 				}
 				case Write: {
-					processWriteLI(vcp_inst, ec);
+					processWriteLI(vcp_inst.getInput1(), vcp_inst.getInput2(), ec);
 					break;
 				}
 				case MoveVariable: {
@@ -155,7 +156,11 @@ public class LineageMap {
 				default:
 					throw new DMLRuntimeException("Unknown VariableCPInstruction (" + inst.getOpcode() + ") traced.");
 			}
-		} else
+		}
+		else if (inst instanceof WriteSPInstruction){
+			processWriteLI(((WriteSPInstruction) inst).getInput1(), ((WriteSPInstruction) inst).getInput2(), ec);
+		}
+		else
 			addLineageItem(li);
 		
 	}
@@ -166,7 +171,7 @@ public class LineageMap {
 		// fix literals referring to variables (e.g., for/parfor loop variable)
 		for(int i=0; i<li.getInputs().length; i++) {
 			LineageItem tmp = li.getInputs()[i];
-			if( tmp.getType() != LineageItemType.Literal) 
+			if( tmp.getType() != LineageItemType.Literal)
 				continue;
 			//check if CPOperand is not a literal, w/o parsing
 			if( tmp.getData().endsWith("false") ) {
@@ -197,9 +202,9 @@ public class LineageMap {
 		_traces.put(li.getName(), li);
 	}
 	
-	private void processWriteLI(VariableCPInstruction inst, ExecutionContext ec) {
-		LineageItem li = get(inst.getInput1());
-		String fName = ec.getScalarInput(inst.getInput2().getName(), Types.ValueType.STRING, inst.getInput2().isLiteral()).getStringValue();
+	private void processWriteLI(CPOperand input1, CPOperand input2, ExecutionContext ec) {
+		LineageItem li = get(input1);
+		String fName = ec.getScalarInput(input2.getName(), Types.ValueType.STRING, input2.isLiteral()).getStringValue();
 		
 		if (DMLScript.LINEAGE_DEDUP) {
 			LineageItemUtils.writeTraceToHDFS(Explain.explain(li), fName + ".lineage.dedup");

--- a/src/test/java/org/tugraz/sysds/test/functions/lineage/LineageTraceRandomSparkTest.java
+++ b/src/test/java/org/tugraz/sysds/test/functions/lineage/LineageTraceRandomSparkTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2019 Graz University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.tugraz.sysds.test.functions.lineage;
+
+import org.junit.Test;
+import org.tugraz.sysds.api.DMLScript;
+import org.tugraz.sysds.common.Types;
+import org.tugraz.sysds.hops.OptimizerUtils;
+import org.tugraz.sysds.runtime.lineage.Lineage;
+import org.tugraz.sysds.runtime.lineage.LineageItem;
+import org.tugraz.sysds.runtime.lineage.LineageParser;
+import org.tugraz.sysds.test.AutomatedTestBase;
+import org.tugraz.sysds.test.TestUtils;
+import org.tugraz.sysds.utils.Explain;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class LineageTraceRandomSparkTest extends AutomatedTestBase {
+	
+	protected static final String TEST_DIR = "functions/lineage/";
+	protected static final String TEST_NAME1 = "LineageTraceRandomSpark1";
+	protected static final String TEST_NAME2 = "LineageTraceRandomSpark2";
+	protected String TEST_CLASS_DIR = TEST_DIR + LineageTraceRandomSparkTest.class.getSimpleName() + "/";
+	
+	@Override
+	public void setUp() {
+		addTestConfiguration(TEST_CLASS_DIR, TEST_NAME1);
+		addTestConfiguration(TEST_CLASS_DIR, TEST_NAME2);
+	}
+	
+	@Test
+	public void testLineageTraceRandom1() { testLineageTraceRandom(TEST_NAME1); }
+
+	@Test
+	public void testLineageTraceRandom2() { testLineageTraceRandom(TEST_NAME2); }
+	
+	private void testLineageTraceRandom(String testname) {
+		boolean old_simplification = OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION;
+		boolean old_sum_product = OptimizerUtils.ALLOW_SUM_PRODUCT_REWRITES;
+		Types.ExecMode oldPlatform = rtplatform;
+		boolean oldLocalSparkConfig = DMLScript.USE_LOCAL_SPARK_CONFIG;
+		
+		try {
+			System.out.println("------------ BEGIN " + testname + "------------");
+			
+			OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION = false;
+			OptimizerUtils.ALLOW_SUM_PRODUCT_REWRITES = false;
+			rtplatform = Types.ExecMode.SPARK;
+			DMLScript.USE_LOCAL_SPARK_CONFIG = true;
+			
+			getAndLoadTestConfiguration(testname);
+			
+			List<String> proArgs = new ArrayList<>();
+			
+			proArgs.add("-stats");
+			proArgs.add("-lineage");
+			proArgs.add("-explain");
+			proArgs.add("-args");
+			proArgs.add(output("X"));
+			proArgs.add(output("Y"));
+			programArgs = proArgs.toArray(new String[proArgs.size()]);
+			
+			fullDMLScriptName = getScript();
+			
+			Lineage.resetInternalState();
+			runTest(true, EXCEPTION_NOT_EXPECTED, null, -1);
+			
+			String X_lineage = readDMLLineageFromHDFS("X");
+			String Y_lineage = readDMLLineageFromHDFS("Y");
+			
+			LineageItem X_li = LineageParser.parseLineageTrace(X_lineage);
+			LineageItem Y_li = LineageParser.parseLineageTrace(Y_lineage);
+			
+			TestUtils.compareScalars(X_lineage, Explain.explain(X_li));
+			TestUtils.compareScalars(Y_lineage, Explain.explain(Y_li));
+		} finally {
+			OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION = old_simplification;
+			OptimizerUtils.ALLOW_SUM_PRODUCT_REWRITES = old_sum_product;
+			rtplatform = oldPlatform;
+			DMLScript.USE_LOCAL_SPARK_CONFIG = oldLocalSparkConfig;
+		}
+	}
+}

--- a/src/test/java/org/tugraz/sysds/test/functions/lineage/LineageTraceSparkTest.java
+++ b/src/test/java/org/tugraz/sysds/test/functions/lineage/LineageTraceSparkTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2019 Graz University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.tugraz.sysds.test.functions.lineage;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.tugraz.sysds.api.DMLScript;
+import org.tugraz.sysds.common.Types;
+import org.tugraz.sysds.hops.OptimizerUtils;
+import org.tugraz.sysds.hops.recompile.Recompiler;
+import org.tugraz.sysds.runtime.lineage.Lineage;
+import org.tugraz.sysds.runtime.lineage.LineageItem;
+import org.tugraz.sysds.runtime.lineage.LineageParser;
+import org.tugraz.sysds.test.AutomatedTestBase;
+import org.tugraz.sysds.test.TestConfiguration;
+import org.tugraz.sysds.test.TestUtils;
+import org.tugraz.sysds.utils.Explain;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class LineageTraceSparkTest extends AutomatedTestBase {
+	
+	protected static final String TEST_DIR = "functions/lineage/";
+	protected static final String TEST_NAME1 = "LineageTraceSpark1";
+	protected static final String TEST_NAME2 = "LineageTraceSpark2";
+	protected static final String TEST_NAME3 = "LineageTraceSpark3";
+	protected static final String TEST_NAME4 = "LineageTraceSpark4";
+	protected static String TEST_CLASS_DIR = TEST_DIR + LineageTraceSparkTest.class.getSimpleName() + "/";
+	
+	protected static final int numRecords = 10;
+	protected static final int numFeatures = 5;
+	
+	
+	@Override
+	public void setUp() {
+		TestUtils.clearAssertionInformation();
+		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1, new String[]{"X", "X.lineage", "Y", "Y.lineage"}));
+		addTestConfiguration(TEST_NAME2, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME2, new String[]{"X", "X.lineage", "Y", "Y.lineage"}));
+		addTestConfiguration(TEST_NAME3, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME3, new String[]{"X", "X.lineage", "Y", "Y.lineage"}));
+		addTestConfiguration(TEST_NAME4, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME4, new String[]{"X", "X.lineage", "Y", "Y.lineage"}));
+	}
+	
+	@Test
+	public void testLineageTraceSpark1() {
+		testLineageTraceSpark(TEST_NAME1);
+	}
+	
+	@Test
+	public void testLineageTraceSpark2() {
+		testLineageTraceSpark(TEST_NAME2);
+	}
+	
+	@Test
+	public void testLineageTraceSpark3() {
+		testLineageTraceSpark(TEST_NAME3);
+	}
+	
+	@Test
+	public void testLineageTraceSpark4() {
+		testLineageTraceSpark(TEST_NAME4);
+	}
+	
+	public void testLineageTraceSpark(String testname) {
+		boolean old_simplification = OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION;
+		boolean old_sum_product = OptimizerUtils.ALLOW_SUM_PRODUCT_REWRITES;
+		Types.ExecMode oldPlatform = rtplatform;
+		boolean oldLocalSparkConfig = DMLScript.USE_LOCAL_SPARK_CONFIG;
+		
+		try {
+			System.out.println("------------ BEGIN " + testname + "------------");
+			
+			OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION = false;
+			OptimizerUtils.ALLOW_SUM_PRODUCT_REWRITES = false;
+			rtplatform = Types.ExecMode.SPARK;
+			DMLScript.USE_LOCAL_SPARK_CONFIG = true;
+			
+			int rows = numRecords;
+			int cols = numFeatures;
+			
+			getAndLoadTestConfiguration(testname);
+			
+			List<String> proArgs = new ArrayList<>();
+			
+			proArgs.add("-explain");
+			proArgs.add("-stats");
+			proArgs.add("-lineage");
+			proArgs.add("-args");
+			proArgs.add(input("X"));
+			proArgs.add(output("X"));
+			proArgs.add(output("Y"));
+			programArgs = proArgs.toArray(new String[proArgs.size()]);
+			
+			fullDMLScriptName = getScript();
+			
+			double[][] X = getRandomMatrix(rows, cols, 0, 1, 0.8, -1);
+			writeInputMatrixWithMTD("X", X, true);
+			
+			Lineage.resetInternalState();
+			runTest(true, EXCEPTION_NOT_EXPECTED, null, -1);
+			
+			String X_lineage = readDMLLineageFromHDFS("X");
+			String Y_lineage = readDMLLineageFromHDFS("Y");
+			
+			LineageItem X_li = LineageParser.parseLineageTrace(X_lineage);
+			LineageItem Y_li = LineageParser.parseLineageTrace(Y_lineage);
+			
+			TestUtils.compareScalars(X_lineage, Explain.explain(X_li));
+			TestUtils.compareScalars(Y_lineage, Explain.explain(Y_li));
+		} finally {
+			OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION = old_simplification;
+			OptimizerUtils.ALLOW_SUM_PRODUCT_REWRITES = old_sum_product;
+			rtplatform = oldPlatform;
+			DMLScript.USE_LOCAL_SPARK_CONFIG = oldLocalSparkConfig;
+			Recompiler.reinitRecompiler();
+		}
+	}
+}

--- a/src/test/java/org/tugraz/sysds/test/functions/lineage/LineageTraceSparkTest.java
+++ b/src/test/java/org/tugraz/sysds/test/functions/lineage/LineageTraceSparkTest.java
@@ -16,8 +16,6 @@
 
 package org.tugraz.sysds.test.functions.lineage;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.tugraz.sysds.api.DMLScript;
 import org.tugraz.sysds.common.Types;

--- a/src/test/scripts/functions/lineage/LineageTraceRandomSpark1.dml
+++ b/src/test/scripts/functions/lineage/LineageTraceRandomSpark1.dml
@@ -1,0 +1,32 @@
+#-------------------------------------------------------------
+#
+# Copyright 2019 Graz University of Technology
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#-------------------------------------------------------------
+
+# How to invoke this dml script LineageTrace.dml?
+# Assume LR_HOME is set to the home of the dml script
+# Assume rows = 20 and cols = 20 for X
+# hadoop jar SystemDS.jar -f $LR_HOME/LineageTrace.dml -args "$INPUT_DIR/X" "$OUTPUT_DIR/X" "$OUTPUT_DIR/Y"
+
+X = rand(rows=10, cols=3);
+
+X = X * 3;
+X = X + 5;
+
+Y = t(X) %*% X;
+
+write(X, $1, format="text");
+write(Y, $2, format="text");

--- a/src/test/scripts/functions/lineage/LineageTraceRandomSpark2.dml
+++ b/src/test/scripts/functions/lineage/LineageTraceRandomSpark2.dml
@@ -1,0 +1,32 @@
+#-------------------------------------------------------------
+#
+# Copyright 2019 Graz University of Technology
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#-------------------------------------------------------------
+
+# How to invoke this dml script LineageTrace.dml?
+# Assume LR_HOME is set to the home of the dml script
+# Assume rows = 20 and cols = 20 for X
+# hadoop jar SystemDS.jar -f $LR_HOME/LineageTrace.dml -args "$INPUT_DIR/X" "$OUTPUT_DIR/X" "$OUTPUT_DIR/Y"
+
+X = rand(rows=10, cols=3, seed=42);
+
+X = X * 3;
+X = X + 5;
+
+Y = t(X) %*% X;
+
+write(X, $1, format="text");
+write(Y, $2, format="text");

--- a/src/test/scripts/functions/lineage/LineageTraceSpark1.dml
+++ b/src/test/scripts/functions/lineage/LineageTraceSpark1.dml
@@ -1,0 +1,32 @@
+#-------------------------------------------------------------
+#
+# Copyright 2019 Graz University of Technology
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#-------------------------------------------------------------
+
+# How to invoke this dml script LineageTrace.dml?
+# Assume LR_HOME is set to the home of the dml script
+# Assume rows = 20 and cols = 20 for X
+# hadoop jar SystemDS.jar -f $LR_HOME/LineageTrace.dml -args "$INPUT_DIR/X" "$OUTPUT_DIR/X" "$OUTPUT_DIR/Y"
+
+X = read($1);
+
+X = X * 3;
+X = X + 5;
+
+Y = t(X) %*% X;
+
+write(X, $2, format="text");
+write(Y, $3, format="text");

--- a/src/test/scripts/functions/lineage/LineageTraceSpark2.dml
+++ b/src/test/scripts/functions/lineage/LineageTraceSpark2.dml
@@ -1,0 +1,43 @@
+#-------------------------------------------------------------
+#
+# Copyright 2019 Graz University of Technology
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#-------------------------------------------------------------
+
+# How to invoke this dml script LineageTrace.dml?
+# Assume LR_HOME is set to the home of the dml script
+# Assume rows = 20 and cols = 20 for X
+# hadoop jar SystemDS.jar -f $LR_HOME/LineageTrace.dml -args "$INPUT_DIR/X" "$OUTPUT_DIR/X" "$OUTPUT_DIR/Y"
+
+X = read($1);
+max_iteration = 10;
+i = 0;
+
+while(i < max_iteration) {
+  if (i %% 2 == 1)
+    X = X * X * X;
+  else
+    X = X + 7;
+
+  if (sum(X) > 500)
+    X = X / 2;
+
+  i = i + 1;
+}
+
+Y = t(X) %*% X;
+
+write(X, $2, format="text");
+write(Y, $3, format="text");

--- a/src/test/scripts/functions/lineage/LineageTraceSpark3.dml
+++ b/src/test/scripts/functions/lineage/LineageTraceSpark3.dml
@@ -1,0 +1,40 @@
+#-------------------------------------------------------------
+#
+# Copyright 2019 Graz University of Technology
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#-------------------------------------------------------------
+
+# How to invoke this dml script LineageTrace.dml?
+# Assume LR_HOME is set to the home of the dml script
+# Assume rows = 20 and cols = 20 for X
+# hadoop jar SystemDS.jar -f $LR_HOME/LineageTrace.dml -args "$INPUT_DIR/X" "$OUTPUT_DIR/X" "$OUTPUT_DIR/Y"
+
+# X = rand(rows=20, cols=20);
+X = read($1);
+max_iteration = 3;
+i = 0;
+
+while(i < max_iteration) {
+  if (i %% 2 == 1)
+    X = X * X * X;
+  else
+    X = X + 7;
+  i = i + 1;
+}
+
+Y = t(X) %*% X;
+
+write(X, $2, format="text");
+write(Y, $3, format="text");

--- a/src/test/scripts/functions/lineage/LineageTraceSpark4.dml
+++ b/src/test/scripts/functions/lineage/LineageTraceSpark4.dml
@@ -1,0 +1,34 @@
+#-------------------------------------------------------------
+#
+# Copyright 2019 Graz University of Technology
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#-------------------------------------------------------------
+
+# How to invoke this dml script LineageTrace.dml?
+# Assume LR_HOME is set to the home of the dml script
+# Assume rows = 20 and cols = 20 for X
+# hadoop jar SystemDS.jar -f $LR_HOME/LineageTrace.dml -args "$INPUT_DIR/X" "$OUTPUT_DIR/X" "$OUTPUT_DIR/Y"
+
+A = read($1);
+
+A = A * 3;
+A = A + 5;
+
+A = t(A) %*% A;
+
+[eval, evec] = eigen(A);
+
+write(eval, $2, format="text");
+write(evec, $3, format="text");

--- a/src/test/scripts/functions/lineage/LineageTraceSpark5.dml
+++ b/src/test/scripts/functions/lineage/LineageTraceSpark5.dml
@@ -22,12 +22,15 @@
 # hadoop jar SystemDS.jar -f $LR_HOME/LineageTrace.dml -args "$INPUT_DIR/X" "$OUTPUT_DIR/X" "$OUTPUT_DIR/Y"
 
 X = read($1);
-# TODO mb: fix generation of spark instructions (chkpoint) in LineageItemUtils.rConstructHops()
-
 X = X * 3;
-X = X + 5;
 
-Y = t(X) %*% X;
+ms = matrix(0, rows=2, cols=3*10)
+for (v in 1:10, check=0) { # parallelizable
+    mv = matrix(v, rows=2, cols=3)
+# TODO mb: fix generation of spark instructions (mapLeftIndex) in LineageItemUtils.rConstructHops()
+    ms[,(v-1)*3+1:v*3] = mv
+}
 
-write(X, $2, format="text");
-write(Y, $3, format="text");
+print(lineage(ms));
+write(ms, $2);
+write(X, $3);


### PR DESCRIPTION
Hey @mboehm7, I started with basic lineage support for spark instructions to warm-up for my project.

Therefore I added
 - write lineage trace for spark instruction
 - support for spark rand instruction 
 - some tests with `Types.ExecMode.SPARK` 