### PR TITLE
URLs for Federated workers

### DIFF
--- a/src/main/java/org/tugraz/sysds/conf/DMLConfig.java
+++ b/src/main/java/org/tugraz/sysds/conf/DMLConfig.java
@@ -88,6 +88,8 @@ public class DMLConfig
 	public static final String PRINT_GPU_MEMORY_INFO = "sysds.gpu.print.memoryInfo";
 	public static final String EVICTION_SHADOW_BUFFERSIZE = "sysds.gpu.eviction.shadow.bufferSize";
 	
+	public static final String DEFAULT_FEDERATED_PORT = "25501";
+
 	//internal config
 	public static final String DEFAULT_SHARED_DIR_PERMISSION = "777"; //for local fs and DFS
 	

--- a/src/main/java/org/tugraz/sysds/runtime/instructions/fed/InitFEDInstruction.java
+++ b/src/main/java/org/tugraz/sysds/runtime/instructions/fed/InitFEDInstruction.java
@@ -19,6 +19,7 @@ package org.tugraz.sysds.runtime.instructions.fed;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.tugraz.sysds.common.Types;
+import org.tugraz.sysds.conf.DMLConfig;
 import org.tugraz.sysds.runtime.DMLRuntimeException;
 import org.tugraz.sysds.runtime.controlprogram.caching.MatrixObject;
 import org.tugraz.sysds.runtime.controlprogram.context.ExecutionContext;
@@ -34,98 +35,88 @@ import org.tugraz.sysds.runtime.instructions.cp.StringObject;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.Future;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public class InitFEDInstruction extends FEDInstruction {
 	private CPOperand _addresses, _ranges, _output;
-	
+
 	public InitFEDInstruction(CPOperand addresses, CPOperand ranges, CPOperand out, String opcode, String instr) {
 		super(FEDType.Init, opcode, instr);
 		_addresses = addresses;
 		_ranges = ranges;
 		_output = out;
 	}
-	
+
 	public static InitFEDInstruction parseInstruction(String str) {
 		String[] parts = InstructionUtils.getInstructionPartsWithValueType(str);
-		// We need 3 parts: Opcode, Addresses (list of Strings with url/ip:port/filepath), ranges and the output Operand
-		if( parts.length != 4 )
+		// We need 4 parts: Opcode, Addresses (list of Strings with
+		// url/ip:port/filepath), ranges and the output Operand
+		if (parts.length != 4)
 			throw new DMLRuntimeException("Invalid number of operands in federated instruction: " + str);
 		String opcode = parts[0];
-		
+
 		CPOperand addresses, ranges, out;
 		addresses = new CPOperand(parts[1]);
 		ranges = new CPOperand(parts[2]);
 		out = new CPOperand(parts[3]);
 		return new InitFEDInstruction(addresses, ranges, out, opcode, str);
 	}
-	
+
 	@Override
 	public void processInstruction(ExecutionContext ec) {
 		ListObject addresses = ec.getListObject(_addresses.getName());
 		ListObject ranges = ec.getListObject(_ranges.getName());
 		List<Pair<FederatedRange, FederatedData>> feds = new ArrayList<>();
-		
-		if( addresses.getLength() * 2 != ranges.getLength() )
-			throw new DMLRuntimeException("Federated read needs twice the amount of addresses as ranges " +
-					"(begin and end): addresses=" + addresses.getLength() + " ranges=" + ranges.getLength());
-		
-		long[] usedDims = new long[]{0, 0};
+
+		if (addresses.getLength() * 2 != ranges.getLength())
+			throw new DMLRuntimeException("Federated read needs twice the amount of addresses as ranges "
+					+ "(begin and end): addresses=" + addresses.getLength() + " ranges=" + ranges.getLength());
+
+		long[] usedDims = new long[] { 0, 0 };
 		for (int i = 0; i < addresses.getLength(); i++) {
 			Data addressData = addresses.getData().get(i);
-			if( addressData instanceof StringObject ) {
-				String address = ((StringObject) addressData).getStringValue();
-				// We split address into url/ip, the port and filepath of file to read
-				String urlRegex = "^([-a-zA-Z0-9@]+(?:\\.[a-zA-Z0-9]+)*)";
-				String portRegex = ":([0-9]+)";
-				String filepathRegex = "((?:/[\\w-]+)*/[\\w-.]+)/?$";
-				Pattern compiled = Pattern.compile(urlRegex + portRegex + filepathRegex);
-				Matcher matcher = compiled.matcher(address);
-				if( matcher.matches() ) {
-					// matches: 0 whole match, 1 host address, 2 port, 3 filepath
-					String host = matcher.group(1);
-					int port = Integer.parseInt(matcher.group(2));
-					String filepath = matcher.group(3).substring(1);
-					// get begin and end ranges
-					List<Data> rangesData = ranges.getData();
-					Data beginData = rangesData.get(i * 2);
-					Data endData = rangesData.get(i * 2 + 1);
-					if( beginData.getDataType() != Types.DataType.LIST || endData.getDataType() != Types.DataType.LIST )
-						throw new DMLRuntimeException("Federated read ranges (lower, upper) have to be lists of dimensions");
-					List<Data> beginDimsData = ((ListObject) beginData).getData();
-					List<Data> endDimsData = ((ListObject) endData).getData();
-					
-					// fill begin and end dims
-					long[] beginDims = new long[beginDimsData.size()];
-					long[] endDims = new long[beginDims.length];
-					for (int d = 0; d < beginDims.length; d++) {
-						beginDims[d] = ((ScalarObject) beginDimsData.get(d)).getLongValue();
-						endDims[d] = ((ScalarObject) endDimsData.get(d)).getLongValue();
-					}
-					usedDims[0] = Math.max(usedDims[0], endDims[0]);
-					usedDims[1] = Math.max(usedDims[1], endDims[1]);
-					try {
-						FederatedData federatedData = new FederatedData(
-								new InetSocketAddress(InetAddress.getByName(host), port), filepath);
-						feds.add(new ImmutablePair<>(new FederatedRange(beginDims, endDims), federatedData));
-					}
-					catch (UnknownHostException e) {
-						throw new DMLRuntimeException("federated host was unknown: " + host);
-					}
+			if (addressData instanceof StringObject) {
+
+				// We split address into url/ip, the port and file path of file to read
+				String[] parsedValues = parseURL(((StringObject) addressData).getStringValue());
+				String host = parsedValues[0];
+				int port = Integer.parseInt(parsedValues[1]);
+				String filePath = parsedValues[2];
+				// get beginning and end of data ranges
+				List<Data> rangesData = ranges.getData();
+				Data beginData = rangesData.get(i * 2);
+				Data endData = rangesData.get(i * 2 + 1);
+				if (beginData.getDataType() != Types.DataType.LIST || endData.getDataType() != Types.DataType.LIST)
+					throw new DMLRuntimeException(
+							"Federated read ranges (lower, upper) have to be lists of dimensions");
+				List<Data> beginDimsData = ((ListObject) beginData).getData();
+				List<Data> endDimsData = ((ListObject) endData).getData();
+
+				// fill begin and end dims
+				long[] beginDims = new long[beginDimsData.size()];
+				long[] endDims = new long[beginDims.length];
+				for (int d = 0; d < beginDims.length; d++) {
+					beginDims[d] = ((ScalarObject) beginDimsData.get(d)).getLongValue();
+					endDims[d] = ((ScalarObject) endDimsData.get(d)).getLongValue();
 				}
-				else {
-					throw new DMLRuntimeException("federated address `" + address + "` does not fit required pattern " +
-							"of \"host:port/directory\"");
+				usedDims[0] = Math.max(usedDims[0], endDims[0]);
+				usedDims[1] = Math.max(usedDims[1], endDims[1]);
+				try {
+					FederatedData federatedData = new FederatedData(
+							new InetSocketAddress(InetAddress.getByName(host), port), filePath);
+					feds.add(new ImmutablePair<>(new FederatedRange(beginDims, endDims), federatedData));
+				} catch (UnknownHostException e) {
+					throw new DMLRuntimeException("federated host was unknown: " + host);
 				}
-			}
-			else {
+
+			} else {
 				throw new DMLRuntimeException("federated instruction only takes strings as addresses");
 			}
 		}
@@ -133,7 +124,31 @@ public class InitFEDInstruction extends FEDInstruction {
 		output.getDataCharacteristics().setRows(usedDims[0]).setCols(usedDims[1]);
 		federate(output, feds);
 	}
-	
+
+	public static String[] parseURL(String input) {
+		try {
+			// Artificially making it http protocol. It is not used in the end.
+			URL address = new URL("http://" + input);
+			String host = address.getHost();
+			if (host.length() == 0)
+				throw new DMLRuntimeException("Missing Host name for federated address");
+			String ipRegex = "^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$";
+			if (host.matches("^\\d+\\.\\d+\\.\\d+\\.\\d+$") && !host.matches(ipRegex))
+				throw new DMLRuntimeException("Input Host address looks like an IP address but is outside range");
+			String port = address.getPort() + "";
+			if (port.matches("-1"))
+				port = DMLConfig.DEFAULT_FEDERATED_PORT;
+			String filePath = address.getPath();
+			if (filePath.length() == 0)
+				throw new DMLRuntimeException("Missing File path for federated address");
+
+			return new String[] { host, port, filePath };
+		} catch (MalformedURLException e) {
+			throw new DMLRuntimeException("federated address `" + input
+					+ "` does not fit required pattern URL pattern of \"host:port/directory\"", e);
+		}
+	}
+
 	public void federate(MatrixObject output, List<Pair<FederatedRange, FederatedData>> workers) {
 		Map<FederatedRange, FederatedData> fedMapping = new TreeMap<>();
 		for (Pair<FederatedRange, FederatedData> t : workers) {
@@ -144,7 +159,7 @@ public class InitFEDInstruction extends FEDInstruction {
 		for (Map.Entry<FederatedRange, FederatedData> entry : fedMapping.entrySet()) {
 			FederatedRange range = entry.getKey();
 			FederatedData value = entry.getValue();
-			if( !value.isInitialized() ) {
+			if (!value.isInitialized()) {
 				long[] beginDims = range.getBeginDims();
 				long[] endDims = range.getEndDims();
 				long[] dims = output.getDataCharacteristics().getDims();
@@ -157,17 +172,15 @@ public class InitFEDInstruction extends FEDInstruction {
 		try {
 			for (Pair<FederatedData, Future<FederatedResponse>> idResponse : idResponses) {
 				FederatedResponse response = idResponse.getRight().get();
-				if( response.isSuccessful() )
+				if (response.isSuccessful())
 					idResponse.getLeft().setVarID((Long) response.getData());
 				else
 					throw new DMLRuntimeException(response.getErrorMessage());
 			}
-		}
-		catch (Exception e) {
+		} catch (Exception e) {
 			throw new DMLRuntimeException("Federation initialization failed", e);
 		}
-		output.getDataCharacteristics().setNonZeros(
-			output.getNumColumns() * output.getNumRows());
+		output.getDataCharacteristics().setNonZeros(output.getNumColumns() * output.getNumRows());
 		output.setFedMapping(fedMapping);
 	}
 }

--- a/src/main/java/org/tugraz/sysds/runtime/instructions/fed/InitFEDInstruction.java
+++ b/src/main/java/org/tugraz/sysds/runtime/instructions/fed/InitFEDInstruction.java
@@ -127,31 +127,35 @@ public class InitFEDInstruction extends FEDInstruction {
 
 	public static String[] parseURL(String input) {
 		try {
-			// Artificially making it http protocol. It is not used in the end.
+			// Artificially making it http protocol. 
+			// This is to avoid malformed address error in the URL passing.
+			// TODO: Construct new protocol name for Federated communication
 			URL address = new URL("http://" + input);
 			String host = address.getHost();
 			if (host.length() == 0)
-				throw new DMLRuntimeException("Missing Host name for federated address");
+				throw new IllegalArgumentException("Missing Host name for federated address");
+			// The current system does not support ipv6, only ipv4.
+			// TODO: Support IPV6 address for Federated communication
 			String ipRegex = "^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$";
 			if (host.matches("^\\d+\\.\\d+\\.\\d+\\.\\d+$") && !host.matches(ipRegex))
-				throw new DMLRuntimeException("Input Host address looks like an IP address but is outside range");
-			String port = address.getPort() + "";
-			if (port.matches("-1"))
+				throw new IllegalArgumentException("Input Host address looks like an IP address but is outside range");
+			String port = Integer.toString(address.getPort());
+			if (port.equals("-1"))
 				port = DMLConfig.DEFAULT_FEDERATED_PORT;
 			String filePath = address.getPath();
 			if (filePath.length() == 0)
-				throw new DMLRuntimeException("Missing File path for federated address");
+				throw new IllegalArgumentException("Missing File path for federated address");
 
 			if (address.getQuery() != null)
-				throw new DMLRuntimeException("Query is not supported");
+				throw new IllegalArgumentException("Query is not supported");
 
 			if (address.getRef() != null)
-				throw new DMLRuntimeException("Reference is not supported");
+				throw new IllegalArgumentException("Reference is not supported");
 				
 			return new String[] { host, port, filePath };
 		} catch (MalformedURLException e) {
-			throw new DMLRuntimeException("federated address `" + input
-					+ "` does not fit required pattern URL pattern of \"host:port/directory\"", e);
+			throw new IllegalArgumentException("federated address `" + input
+					+ "` does not fit required URL pattern of \"host:port/directory\"", e);
 		}
 	}
 

--- a/src/main/java/org/tugraz/sysds/runtime/instructions/fed/InitFEDInstruction.java
+++ b/src/main/java/org/tugraz/sysds/runtime/instructions/fed/InitFEDInstruction.java
@@ -142,6 +142,12 @@ public class InitFEDInstruction extends FEDInstruction {
 			if (filePath.length() == 0)
 				throw new DMLRuntimeException("Missing File path for federated address");
 
+			if (address.getQuery() != null)
+				throw new DMLRuntimeException("Query is not supported");
+
+			if (address.getRef() != null)
+				throw new DMLRuntimeException("Reference is not supported");
+				
 			return new String[] { host, port, filePath };
 		} catch (MalformedURLException e) {
 			throw new DMLRuntimeException("federated address `" + input

--- a/src/test/java/org/tugraz/sysds/test/functions/federated/FederatedUrlParserTest.java
+++ b/src/test/java/org/tugraz/sysds/test/functions/federated/FederatedUrlParserTest.java
@@ -120,19 +120,19 @@ public class FederatedUrlParserTest {
 
     @Test(expected = DMLRuntimeException.class)
     public void parseQuery_negative_1() {
-        // All Queries should fail.
+        // All Query flags should fail.
         InitFEDInstruction.parseURL("今日は.世界/../bar世界.txt?shouldnothappen");
     }
 
     @Test(expected = DMLRuntimeException.class)
     public void parseReference_negative_1() {
-        // All Queries should fail.
+        // All Reference flags should fail.
         InitFEDInstruction.parseURL("今日は.世界/../bar世界.txt#shouldnothappen");
     }
 
     @Test(expected = DMLRuntimeException.class)
     public void parseReferenceAndQuery_negative_1() {
-        // All Queries should fail.
+        // If both Reference and Query it should still should fail.
         InitFEDInstruction.parseURL("今日は.世界/../bar世界.txt?please#dont");
     }
 }

--- a/src/test/java/org/tugraz/sysds/test/functions/federated/FederatedUrlParserTest.java
+++ b/src/test/java/org/tugraz/sysds/test/functions/federated/FederatedUrlParserTest.java
@@ -97,4 +97,42 @@ public class FederatedUrlParserTest {
         assertEquals("/file.txt", values[2]);
     }
 
+    @Test
+    public void parseFilePath_1() {
+        // Parse Filepath even if it is nested.
+        String[] values = InitFEDInstruction.parseURL("今日は.世界/fu_u_u/bar.txt");
+        assertEquals("/fu_u_u/bar.txt", values[2]);
+    }
+
+    @Test
+    public void parseFilePath_2() {
+        // Parse Filepath even if it is a folder out.
+        String[] values = InitFEDInstruction.parseURL("今日は.世界/../bar.txt");
+        assertEquals("/../bar.txt", values[2]);
+    }
+
+    @Test
+    public void parseFilePath_3() {
+        // Parse Filepath with special characters.
+        String[] values = InitFEDInstruction.parseURL("今日は.世界/../bar世界.txt");
+        assertEquals("/../bar世界.txt", values[2]);
+    }
+
+    @Test(expected = DMLRuntimeException.class)
+    public void parseQuery_negative_1() {
+        // All Queries should fail.
+        InitFEDInstruction.parseURL("今日は.世界/../bar世界.txt?shouldnothappen");
+    }
+
+    @Test(expected = DMLRuntimeException.class)
+    public void parseReference_negative_1() {
+        // All Queries should fail.
+        InitFEDInstruction.parseURL("今日は.世界/../bar世界.txt#shouldnothappen");
+    }
+
+    @Test(expected = DMLRuntimeException.class)
+    public void parseReferenceAndQuery_negative_1() {
+        // All Queries should fail.
+        InitFEDInstruction.parseURL("今日は.世界/../bar世界.txt?please#dont");
+    }
 }

--- a/src/test/java/org/tugraz/sysds/test/functions/federated/FederatedUrlParserTest.java
+++ b/src/test/java/org/tugraz/sysds/test/functions/federated/FederatedUrlParserTest.java
@@ -18,7 +18,6 @@
 package org.tugraz.sysds.test.functions.federated;
 
 import org.tugraz.sysds.runtime.instructions.fed.InitFEDInstruction;
-import org.tugraz.sysds.runtime.DMLRuntimeException;
 import org.tugraz.sysds.conf.DMLConfig;
 
 import static org.junit.Assert.assertEquals;
@@ -27,25 +26,25 @@ import org.junit.Test;
 
 public class FederatedUrlParserTest {
 
-    @Test(expected = DMLRuntimeException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void parseIPAddress_negative_1() {
         // Fail if the input is empty.
         InitFEDInstruction.parseURL("");
     }
 
-    @Test(expected = DMLRuntimeException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void parseIPAddress_negative_2() {
         // Fail if there is no file specified.
         InitFEDInstruction.parseURL("192.13.4.2");
     }
 
-    @Test(expected = DMLRuntimeException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void parseIPAddress_negative_3() {
         // Fail if there is no file specified even if port is.
         InitFEDInstruction.parseURL("192.13.4.2:132");
     }
 
-    @Test(expected = DMLRuntimeException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void parseIPAddress_negative_4() {
         // Fail if the input clearly is an ipv4 address but malformed.
         InitFEDInstruction.parseURL("192.131111.4.2:132/file.txt");
@@ -118,21 +117,31 @@ public class FederatedUrlParserTest {
         assertEquals("/../bar世界.txt", values[2]);
     }
 
-    @Test(expected = DMLRuntimeException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void parseQuery_negative_1() {
         // All Query flags should fail.
         InitFEDInstruction.parseURL("今日は.世界/../bar世界.txt?shouldnothappen");
     }
 
-    @Test(expected = DMLRuntimeException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void parseReference_negative_1() {
         // All Reference flags should fail.
         InitFEDInstruction.parseURL("今日は.世界/../bar世界.txt#shouldnothappen");
     }
 
-    @Test(expected = DMLRuntimeException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void parseReferenceAndQuery_negative_1() {
         // If both Reference and Query it should still should fail.
         InitFEDInstruction.parseURL("今日は.世界/../bar世界.txt?please#dont");
+    }
+
+
+    @Test
+    public void checkDefaultPortIsValid(){
+        int defaultPort = Integer.parseInt(DMLConfig.DEFAULT_FEDERATED_PORT);
+        // The highest port number allowed. 
+        int IANA_limit = 49152;
+        assert(defaultPort <= IANA_limit);
+        assert(defaultPort > 0);
     }
 }

--- a/src/test/java/org/tugraz/sysds/test/functions/federated/FederatedUrlParserTest.java
+++ b/src/test/java/org/tugraz/sysds/test/functions/federated/FederatedUrlParserTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2019 Graz University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.tugraz.sysds.test.functions.federated;
+
+import org.tugraz.sysds.runtime.instructions.fed.InitFEDInstruction;
+import org.tugraz.sysds.runtime.DMLRuntimeException;
+import org.tugraz.sysds.conf.DMLConfig;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class FederatedUrlParserTest {
+
+    @Test(expected = DMLRuntimeException.class)
+    public void parseIPAddress_negative_1() {
+        // Fail if the input is empty.
+        InitFEDInstruction.parseURL("");
+    }
+
+    @Test(expected = DMLRuntimeException.class)
+    public void parseIPAddress_negative_2() {
+        // Fail if there is no file specified.
+        InitFEDInstruction.parseURL("192.13.4.2");
+    }
+
+    @Test(expected = DMLRuntimeException.class)
+    public void parseIPAddress_negative_3() {
+        // Fail if there is no file specified even if port is.
+        InitFEDInstruction.parseURL("192.13.4.2:132");
+    }
+
+    @Test(expected = DMLRuntimeException.class)
+    public void parseIPAddress_negative_4() {
+        // Fail if the input clearly is an ipv4 address but malformed.
+        InitFEDInstruction.parseURL("192.131111.4.2:132/file.txt");
+    }
+
+    @Test
+    public void parseIPAddress_1() {
+        // Parse Ip normally, with filepath and port.
+        String[] values = InitFEDInstruction.parseURL("192.13.4.2:132/file.txt");
+        assertEquals("192.13.4.2", values[0]);
+        assertEquals("132", values[1]);
+        assertEquals("/file.txt", values[2]);
+    }
+
+    @Test
+    public void parseIPAddress_2() {
+        // Parse Ip normally, with filepath without port specified.
+        String[] values = InitFEDInstruction.parseURL("123.123.41.22/file.txt");
+        assertEquals("123.123.41.22", values[0]);
+        assertEquals(DMLConfig.DEFAULT_FEDERATED_PORT, values[1]);
+        assertEquals("/file.txt", values[2]);
+    }
+
+    @Test
+    public void parseURLAddress_1() {
+        // Parse URL address fine with port.
+        String[] values = InitFEDInstruction.parseURL("hello.com:132/file.txt");
+        assertEquals("hello.com", values[0]);
+        assertEquals("132", values[1]);
+        assertEquals("/file.txt", values[2]);
+    }
+
+    @Test
+    public void parseURLAddress_2() {
+        // parse URL without port.
+        String[] values = InitFEDInstruction.parseURL("hello.com/file.txt");
+        assertEquals("hello.com", values[0]);
+        assertEquals(DMLConfig.DEFAULT_FEDERATED_PORT, values[1]);
+        assertEquals("/file.txt", values[2]);
+    }
+
+    @Test
+    public void parseURLAddress_3() {
+        // Parse URL with extended characters
+        // Here Japanese: Hello.World
+        String[] values = InitFEDInstruction.parseURL("今日は.世界/file.txt");
+        assertEquals("今日は.世界", values[0]);
+        assertEquals(DMLConfig.DEFAULT_FEDERATED_PORT, values[1]);
+        assertEquals("/file.txt", values[2]);
+    }
+
+}


### PR DESCRIPTION
- Changed handling the URL for federated locations through Regex, to handling through java.net.URL package
- Code for invalid URL input detection.
- Test of above mentioned code.
- Setting of default port for federated environments.