### PR TITLE
Compression Bug Fixes

### DIFF
--- a/src/main/java/org/tugraz/sysds/runtime/compress/ColGroupUncompressed.java
+++ b/src/main/java/org/tugraz/sysds/runtime/compress/ColGroupUncompressed.java
@@ -223,7 +223,8 @@ public class ColGroupUncompressed extends ColGroup {
 		// Run through the rows, putting values into the appropriate locations
 		for(int row = 0; row < _data.getNumRows(); row++) {
 			double cellVal = _data.quickGetValue(row, colpos);
-			target.quickSetValue(row, 0, cellVal);
+			// Apparently rows are cols here.
+			target.quickSetValue(0, row, cellVal);
 		}
 	}
 
@@ -309,15 +310,15 @@ public class ColGroupUncompressed extends ColGroup {
 		// execute unary aggregate operations
 		LibMatrixAgg.aggregateUnaryMatrix(_data, ret, op);
 
-		//shift result into correct column indexes
-		if( op.indexFn instanceof ReduceRow ) {
-			//shift partial results, incl corrections
-			for( int i=_colIndexes.length-1; i>=0; i-- ) {
+		// shift result into correct column indexes
+		if(op.indexFn instanceof ReduceRow) {
+			// shift partial results, incl corrections
+			for(int i = _colIndexes.length - 1; i >= 0; i--) {
 				double val = ret.quickGetValue(0, i);
 				ret.quickSetValue(0, i, 0);
 				ret.quickSetValue(0, _colIndexes[i], val);
-				if( op.aggOp.existsCorrection() )
-					for(int j=1; j<ret.getNumRows(); j++) {
+				if(op.aggOp.existsCorrection())
+					for(int j = 1; j < ret.getNumRows(); j++) {
 						double corr = ret.quickGetValue(j, i);
 						ret.quickSetValue(j, i, 0);
 						ret.quickSetValue(j, _colIndexes[i], corr);

--- a/src/main/java/org/tugraz/sysds/runtime/compress/estim/CompressedSizeEstimatorFactory.java
+++ b/src/main/java/org/tugraz/sysds/runtime/compress/estim/CompressedSizeEstimatorFactory.java
@@ -19,12 +19,10 @@ package org.tugraz.sysds.runtime.compress.estim;
 import org.tugraz.sysds.runtime.matrix.data.MatrixBlock;
 
 public class CompressedSizeEstimatorFactory {
-	public static final double SAMPLING_RATIO = 0.05; // conservative default
 	public static final boolean EXTRACT_SAMPLE_ONCE = true;
 
-	@SuppressWarnings("unused")
-	public static CompressedSizeEstimator getSizeEstimator(MatrixBlock data, int numRows) {
-		return (SAMPLING_RATIO == 1.0) ? new CompressedSizeEstimatorExact(data) : new CompressedSizeEstimatorSample(
-			data, (int) Math.ceil(numRows * SAMPLING_RATIO));
+	public static CompressedSizeEstimator getSizeEstimator(MatrixBlock data, int numRows, long seed, double sampling_ratio) {
+		return (sampling_ratio == 1.0) ? new CompressedSizeEstimatorExact(data) : new CompressedSizeEstimatorSample(
+			data, (int) Math.ceil(numRows * sampling_ratio), seed);
 	}
 }

--- a/src/main/java/org/tugraz/sysds/runtime/compress/estim/CompressedSizeEstimatorSample.java
+++ b/src/main/java/org/tugraz/sysds/runtime/compress/estim/CompressedSizeEstimatorSample.java
@@ -46,10 +46,16 @@ public class CompressedSizeEstimatorSample extends CompressedSizeEstimator {
 	private int[] _sampleRows = null;
 	private HashMap<Integer, Double> _solveCache = null;
 
-	public CompressedSizeEstimatorSample(MatrixBlock data, int sampleSize) {
+	/**
+	 * CompressedSizeEstimatorSample, samples from the input data and estimates the size of the compressed matrix.
+	 * @param data the input data sampled from
+	 * @param sampleSize size of the sampling used
+	 * @param seed Seed for the sampling of the matrix if set to -1 random seed based on system time and class hash is selected
+	 */
+	public CompressedSizeEstimatorSample(MatrixBlock data, int sampleSize, long seed) {
 		super(data);
 		// get sample of rows, incl eager extraction
-		_sampleRows = getSortedUniformSample(_numRows, sampleSize);
+		_sampleRows = getSortedUniformSample(_numRows, sampleSize, seed);
 		if(CompressedSizeEstimatorFactory.EXTRACT_SAMPLE_ONCE) {
 			MatrixBlock select = new MatrixBlock(_numRows, 1, false);
 			for(int i = 0; i < sampleSize; i++)
@@ -289,10 +295,10 @@ public class CompressedSizeEstimatorSample extends CompressedSizeEstimator {
 	 * @param smplSize sample size
 	 * @return sorted array of integers
 	 */
-	private static int[] getSortedUniformSample(int range, int smplSize) {
+	private static int[] getSortedUniformSample(int range, int smplSize, long seed) {
 		if(smplSize == 0)
 			return new int[] {};
-		return UtilFunctions.getSortedSampleIndexes(range, smplSize);
+		return UtilFunctions.getSortedSampleIndexes(range, smplSize, seed);
 	}
 
 	/////////////////////////////////////////////////////

--- a/src/main/java/org/tugraz/sysds/runtime/util/UtilFunctions.java
+++ b/src/main/java/org/tugraz/sysds/runtime/util/UtilFunctions.java
@@ -579,7 +579,14 @@ public class UtilFunctions
 	}
 	
 	public static int[] getSortedSampleIndexes(int range, int sampleSize) {
+		return getSortedSampleIndexes(range, sampleSize, -1);
+	}
+
+	public static int[] getSortedSampleIndexes(int range, int sampleSize, long seed) {
 		RandomDataGenerator rng = new RandomDataGenerator();
+		if (seed != -1){
+			rng.reSeed(seed);
+		}
 		int[] sample = rng.nextPermutation(range, sampleSize);
 		Arrays.sort(sample);
 		return sample;

--- a/src/test/java/org/tugraz/sysds/test/TestConstants.java
+++ b/src/test/java/org/tugraz/sysds/test/TestConstants.java
@@ -21,8 +21,8 @@ package org.tugraz.sysds.test;
  */
 public class TestConstants {
 
-	private static final int rows[] = {4, 3 * 1000 + 7, 1283, 5, 1, 251, 10000, 100000};
-	private static final int cols[] = {20, 20, 13, 998, 321, 1, 30, 21};
+	private static final int rows[] = {4, 2008, 1283, 5, 1, 251, 5000, 100000, 3123};
+	private static final int cols[] = {20, 20, 13, 998, 321, 1, 30, 21, 1};
 	private static final double[] sparsityValues = {0.9, 0.1, 0.0};
 
 	private static final int[] mins = {-10, -2147};
@@ -46,8 +46,7 @@ public class TestConstants {
 		FEW_COL, // A Matrix with a large number of columns
 		SINGLE_ROW, // Single Row with some columns
 		SINGLE_COL, // Single Column with some rows
-		L_ROWS,
-		XL_ROWS,
+		L_ROWS, XL_ROWS, SINGLE_COL_L, // Single Column large.
 	}
 
 	public enum ValueRange {
@@ -111,6 +110,8 @@ public class TestConstants {
 				return rows[6];
 			case XL_ROWS:
 				return rows[7];
+			case SINGLE_COL_L:
+				return rows[8];
 			default:
 				return 0; // Never Happens
 		}
@@ -134,6 +135,8 @@ public class TestConstants {
 				return cols[6];
 			case XL_ROWS:
 				return cols[7];
+			case SINGLE_COL_L:
+				return cols[8];
 			default:
 				return 0; // Never Happens
 		}

--- a/src/test/java/org/tugraz/sysds/test/TestUtils.java
+++ b/src/test/java/org/tugraz/sysds/test/TestUtils.java
@@ -694,6 +694,26 @@ public class TestUtils
 		assertTrue("" + countErrors + " values are not in equal", countErrors == 0);
 	}
 
+	public static void compareMatricesBitAvgDistance(double[][] expectedMatrix, double[][] actualMatrix, int rows, int cols,
+		long maxUnitsOfLeastPrecision, long maxAvgDistance){
+		int countErrors = 0;
+		long sumDistance = 0;
+		long distance;
+		for (int i = 0; i < rows; i++) {
+			for (int j = 0; j < cols; j++) {
+				distance = compareScalarBits(expectedMatrix[i][j], actualMatrix[i][j]);
+				sumDistance += distance;
+				if(distance > maxUnitsOfLeastPrecision){
+					System.out.println(expectedMatrix[i][j] +" vs actual: "+actualMatrix[i][j]+" at "+i+" "+j);
+					countErrors++;
+				}
+			}
+		}
+		long avgDistance = sumDistance / (rows * cols); 
+		assertTrue("" + countErrors + " values are not in equal", countErrors == 0);
+		assertTrue("The avg distance in bits: "+ avgDistance +" was higher than max: " + maxAvgDistance, avgDistance <= maxAvgDistance);
+	}
+
 	/**
 	 * Compare two double precision floats for equality within a margin of error.
 	 *  
@@ -708,14 +728,22 @@ public class TestUtils
 	 * 
 	 * @param d1 The expected value.
 	 * @param d2 The actual value.
-	 * @param maxUnitsOfLeastPrecision The maximum difference in units of least precision.
 	 * @return Whether they are equal or not.
 	 */
-	public static boolean compareScalarBits(double d1, double d2, long maxUnitsOfLeastPrecision) {
+	public static long compareScalarBits(double d1, double d2) {
 		long expectedBits = Double.doubleToLongBits(d1) < 0 ? 0x8000000000000000L - Double.doubleToLongBits(d1) : Double.doubleToLongBits(d1);
 		long actualBits = Double.doubleToLongBits(d2) < 0 ? 0x8000000000000000L - Double.doubleToLongBits(d2) : Double.doubleToLongBits(d2);
 		long difference = expectedBits > actualBits ? expectedBits - actualBits : actualBits - expectedBits;
-		return !Double.isNaN(d1) && !Double.isNaN(d2) && difference <= maxUnitsOfLeastPrecision;
+		return difference;
+	}
+
+	public static boolean compareScalarBits(double d1, double d2, long maxUnitsOfLeastPrecision) {
+		if (Double.isNaN(d1) || Double.isNaN(d2))
+			return false;
+		long expectedBits = Double.doubleToLongBits(d1) < 0 ? 0x8000000000000000L - Double.doubleToLongBits(d1) : Double.doubleToLongBits(d1);
+		long actualBits = Double.doubleToLongBits(d2) < 0 ? 0x8000000000000000L - Double.doubleToLongBits(d2) : Double.doubleToLongBits(d2);
+		long difference = expectedBits > actualBits ? expectedBits - actualBits : actualBits - expectedBits;
+		return difference <= maxUnitsOfLeastPrecision;
 	}
 
 	public static void compareScalarBitsJUnit(double d1, double d2, long maxUnitsOfLeastPrecision){

--- a/src/test/java/org/tugraz/sysds/test/component/compress/CompressedMatrixTest.java
+++ b/src/test/java/org/tugraz/sysds/test/component/compress/CompressedMatrixTest.java
@@ -62,11 +62,13 @@ public class CompressedMatrixTest extends CompressedTestBase {
 	protected double[][] deCompressed;
 
 	public CompressedMatrixTest(SparsityType sparType, ValueType valType, ValueRange valRange, CompressionType compType,
-		MatrixType matrixType, boolean compress) {
-		super(sparType, valType, valRange, compType, matrixType, compress);
+		MatrixType matrixType, boolean compress, double samplingRatio) {
+		super(sparType, valType, valRange, compType, matrixType, compress, samplingRatio);
 		input = TestUtils.generateTestMatrix(rows, cols, min, max, sparsity, 7);
 		mb = getMatrixBlockInput(input);
 		cmb = new CompressedMatrixBlock(mb);
+		cmb.setSeed(1);
+		cmb.setSamplingRatio(samplingRatio);
 		if(compress) {
 			cmbResult = cmb.compress();
 		}
@@ -83,11 +85,10 @@ public class CompressedMatrixTest extends CompressedTestBase {
 				// Assert.assertTrue("Compression Failed \n" + this.toString(), false);
 			}
 
-			double epsilon = 0.0;
-
-			TestUtils.compareMatrices(input, deCompressed, rows, cols, epsilon);
+			TestUtils.compareMatricesBitAvgDistance(input, deCompressed, rows, cols, 0, 0);
 		}
 		catch(Exception e) {
+			e.printStackTrace();
 			throw new RuntimeException(this.toString() + "\n" + e.getMessage(), e);
 		}
 	}
@@ -106,6 +107,7 @@ public class CompressedMatrixTest extends CompressedTestBase {
 				}
 		}
 		catch(Exception e) {
+			e.printStackTrace();
 			throw new RuntimeException(this.toString() + "\n" + e.getMessage(), e);
 		}
 	}
@@ -130,9 +132,10 @@ public class CompressedMatrixTest extends CompressedTestBase {
 			// compare result with input
 			double[][] d1 = DataConverter.convertToDoubleMatrix(ret1);
 			double[][] d2 = DataConverter.convertToDoubleMatrix(ret2);
-			TestUtils.compareMatrices(d1, d2, rows, cols + 1, 0);
+			TestUtils.compareMatricesBitAvgDistance(d1, d2, rows, cols + 1, 0, 1);
 		}
 		catch(Exception e) {
+			e.printStackTrace();
 			throw new RuntimeException(this.toString() + "\n" + e.getMessage(), e);
 		}
 	}
@@ -166,12 +169,11 @@ public class CompressedMatrixTest extends CompressedTestBase {
 				// compare result with input
 				double[][] d1 = DataConverter.convertToDoubleMatrix(ret1);
 				double[][] d2 = DataConverter.convertToDoubleMatrix(ret2);
-				TestUtils.compareMatricesBit(d1, d2, cols, 1, 50);
+				TestUtils.compareMatricesBitAvgDistance(d1, d2, cols, 1, 512, 15);
 			}
-			// ChainType.XtXvy
-
 		}
 		catch(Exception e) {
+			e.printStackTrace();
 			throw new RuntimeException(this.toString() + "\n" + e.getMessage(), e);
 		}
 	}
@@ -194,10 +196,11 @@ public class CompressedMatrixTest extends CompressedTestBase {
 				// compare result with input
 				double[][] d1 = DataConverter.convertToDoubleMatrix(ret1);
 				double[][] d2 = DataConverter.convertToDoubleMatrix(ret2);
-				TestUtils.compareMatricesBit(d1, d2, cols, cols, 100);
+				TestUtils.compareMatricesBitAvgDistance(d1, d2, cols, cols, 2048, 20);
 			}
 		}
 		catch(Exception e) {
+			e.printStackTrace();
 			throw new RuntimeException(this.toString() + "\n" + e.getMessage(), e);
 		}
 	}
@@ -224,9 +227,10 @@ public class CompressedMatrixTest extends CompressedTestBase {
 			// compare result with input
 			double[][] d1 = DataConverter.convertToDoubleMatrix(ret1);
 			double[][] d2 = DataConverter.convertToDoubleMatrix(ret2);
-			TestUtils.compareMatricesBit(d1, d2, rows, 1, 256);
+			TestUtils.compareMatricesBitAvgDistance(d1, d2, rows, 1, 1024, 1);
 		}
 		catch(Exception e) {
+			e.printStackTrace();
 			throw new RuntimeException(this.toString() + "\n" + e.getMessage(), e);
 		}
 	}
@@ -253,9 +257,10 @@ public class CompressedMatrixTest extends CompressedTestBase {
 			// compare result with input
 			double[][] d1 = DataConverter.convertToDoubleMatrix(ret1);
 			double[][] d2 = DataConverter.convertToDoubleMatrix(ret2);
-			TestUtils.compareMatricesBit(d1, d2, 1, cols, 256);
+			TestUtils.compareMatricesBitAvgDistance(d1, d2, 1, cols, 10000, 500);
 		}
 		catch(Exception e) {
+			e.printStackTrace();
 			throw new RuntimeException(this.toString() + "\n" + e.getMessage(), e);
 		}
 	}
@@ -279,9 +284,10 @@ public class CompressedMatrixTest extends CompressedTestBase {
 			double[][] d1 = DataConverter.convertToDoubleMatrix(ret1);
 			double[][] d2 = DataConverter.convertToDoubleMatrix(ret2);
 
-			TestUtils.compareMatricesBit(d1, d2, rows, cols, 150);
+			TestUtils.compareMatricesBitAvgDistance(d1, d2, rows, cols, 150, 1);
 		}
 		catch(Exception e) {
+			e.printStackTrace();
 			throw new RuntimeException(this.toString() + "\n" + e.getMessage(), e);
 		}
 	}
@@ -305,14 +311,15 @@ public class CompressedMatrixTest extends CompressedTestBase {
 			double[][] d1 = DataConverter.convertToDoubleMatrix(ret1);
 			double[][] d2 = DataConverter.convertToDoubleMatrix(ret2);
 
-			TestUtils.compareMatricesBit(d1, d2, rows, cols, 150);
+			TestUtils.compareMatricesBitAvgDistance(d1, d2, rows, cols, 150, 1);
 		}
 		catch(Exception e) {
+			e.printStackTrace();
 			throw new RuntimeException(this.toString() + "\n" + e.getMessage(), e);
 		}
 	}
 
-	//TODO replace with Direction x Types.AggOp
+	// TODO replace with Direction x Types.AggOp
 	enum AggType {
 		ROWSUMS, COLSUMS, SUM, ROWSUMSSQ, COLSUMSSQ, SUMSQ, ROWMAXS, COLMAXS, MAX, ROWMINS, COLMINS, MIN,
 	}
@@ -378,10 +385,11 @@ public class CompressedMatrixTest extends CompressedTestBase {
 				int dim2 = (aggType == AggType.COLSUMS || aggType == AggType.COLSUMSSQ || aggType == AggType.COLMAXS ||
 					aggType == AggType.COLMINS) ? cols : 1;
 
-				TestUtils.compareMatricesBit(d1, d2, dim1, dim2, 150);
+				TestUtils.compareMatricesBitAvgDistance(d1, d2, dim1, dim2, 1024, 20);
 			}
 		}
 		catch(Exception e) {
+			e.printStackTrace();
 			throw new RuntimeException(this.toString() + "\n" + e.getMessage(), e);
 		}
 	}
@@ -410,9 +418,10 @@ public class CompressedMatrixTest extends CompressedTestBase {
 			double[][] d1 = DataConverter.convertToDoubleMatrix(mb);
 			double[][] d2 = DataConverter.convertToDoubleMatrix(tmp);
 
-			TestUtils.compareMatricesBit(d1, d2, rows, cols, 0);
+			TestUtils.compareMatricesBitAvgDistance(d1, d2, rows, cols, 0, 0);
 		}
 		catch(Exception e) {
+			e.printStackTrace();
 			throw new RuntimeException(this.toString() + "\n" + e.getMessage(), e);
 		}
 	}

--- a/src/test/java/org/tugraz/sysds/test/component/compress/CompressedTestBase.java
+++ b/src/test/java/org/tugraz/sysds/test/component/compress/CompressedTestBase.java
@@ -34,38 +34,29 @@ import org.tugraz.sysds.test.TestConstants.ValueType;
 
 public class CompressedTestBase extends AutomatedTestBase {
 
-	protected static SparsityType[] usedSparsityTypes = new SparsityType[] {
-		SparsityType.DENSE, 
-		SparsityType.SPARSE,
+	protected static SparsityType[] usedSparsityTypes = new SparsityType[] {SparsityType.DENSE, SparsityType.SPARSE,
 		// SparsityType.EMPTY
 	};
 	protected static ValueType[] usedValueTypes = new ValueType[] {
-		ValueType.RAND,
-		ValueType.CONST,
-		ValueType.RAND_ROUND_DDC,
-		ValueType.RAND_ROUND_OLE,
-	};
+		// ValueType.RAND,
+		ValueType.CONST, ValueType.RAND_ROUND_DDC, ValueType.RAND_ROUND_OLE,};
 
-	protected static ValueRange[] usedValueRanges = new ValueRange[] {
-		ValueRange.SMALL,
-		ValueRange.LARGE,
-	};
+	protected static ValueRange[] usedValueRanges = new ValueRange[] {ValueRange.SMALL, ValueRange.LARGE,};
 
-	protected static CompressionType[] usedCompressionTypes = new CompressionType[] {
-		CompressionType.LOSSLESS,
+	protected static CompressionType[] usedCompressionTypes = new CompressionType[] {CompressionType.LOSSLESS,
 		// CompressionType.LOSSY,
 	};
 
-	protected static MatrixType[] usedMatrixType = new MatrixType[] {
-		MatrixType.SMALL,
+	protected static MatrixType[] usedMatrixType = new MatrixType[] {MatrixType.SMALL,
 		// MatrixType.LARGE,
-		MatrixType.FEW_COL,
-		MatrixType.FEW_ROW,
-		MatrixType.SINGLE_COL,
-		MatrixType.SINGLE_ROW,
+		MatrixType.FEW_COL, MatrixType.FEW_ROW,
+		// MatrixType.SINGLE_COL,
+		// MatrixType.SINGLE_ROW,
+		MatrixType.L_ROWS,
+		// MatrixType.XL_ROWS,
 	};
 
-
+	public static double[] samplingRatio = {0.05, 1.00};
 
 	protected ValueType valType;
 	protected ValueRange valRange;
@@ -79,7 +70,7 @@ public class CompressedTestBase extends AutomatedTestBase {
 	protected double sparsity;
 
 	public CompressedTestBase(SparsityType sparType, ValueType valType, ValueRange valueRange, CompressionType compType,
-		MatrixType matrixType, boolean compress) {
+		MatrixType matrixType, boolean compress, double samplingRatio) {
 		this.sparsity = TestConstants.getSparsityValue(sparType);
 		this.rows = TestConstants.getNumberOfRows(matrixType);
 		this.cols = TestConstants.getNumberOfColumns(matrixType);
@@ -114,14 +105,16 @@ public class CompressedTestBase extends AutomatedTestBase {
 
 		// Only add a single selected test of constructor with no compression
 		tests.add(new Object[] {SparsityType.SPARSE, ValueType.RAND, ValueRange.SMALL, CompressionType.LOSSLESS,
-			MatrixType.SMALL, false});
+			MatrixType.SMALL, false, 1.0});
 
 		for(SparsityType st : usedSparsityTypes) {
 			for(ValueType vt : usedValueTypes) {
 				for(ValueRange vr : usedValueRanges) {
 					for(CompressionType ct : usedCompressionTypes) {
 						for(MatrixType mt : usedMatrixType) {
-							tests.add(new Object[] {st, vt, vr, ct, mt, true});
+							for(double sr : samplingRatio) {
+								tests.add(new Object[] {st, vt, vr, ct, mt, true, sr});
+							}
 						}
 					}
 				}
@@ -145,15 +138,15 @@ public class CompressedTestBase extends AutomatedTestBase {
 
 		builder.append("args: ");
 
-		builder.append(String.format("%6s%14s","Vt:", valType));
-		builder.append(String.format("%6s%8s","Vr:" , valRange));
-		builder.append(String.format("%6s%8s","CP:" , compType));
-		builder.append(String.format("%6s%5s","CD:" , compress));
-		builder.append(String.format("%6s%5s","Rows:" , rows));
-		builder.append(String.format("%6s%5s","Cols:" , cols));
-		builder.append(String.format("%6s%12s","Min:" , min));
-		builder.append(String.format("%6s%12s","Max:" , max));
-		builder.append(String.format("%6s%4s","Spar:" , sparsity));
+		builder.append(String.format("%6s%14s", "Vt:", valType));
+		builder.append(String.format("%6s%8s", "Vr:", valRange));
+		builder.append(String.format("%6s%8s", "CP:", compType));
+		builder.append(String.format("%6s%5s", "CD:", compress));
+		builder.append(String.format("%6s%5s", "Rows:", rows));
+		builder.append(String.format("%6s%5s", "Cols:", cols));
+		builder.append(String.format("%6s%12s", "Min:", min));
+		builder.append(String.format("%6s%12s", "Max:", max));
+		builder.append(String.format("%6s%4s", "Spar:", sparsity));
 
 		return builder.toString();
 	}


### PR DESCRIPTION
BUGS:
- Column Row misunderstanding in Col Group Uncompressed line 226
- Wrong vector used if transposed in method leftMultByVectorTranspose line 1578 in CompressedMatrixBlock

Added Test cases for these bugs +
- Sampling test variables of 0.05 and 1.0 for compression estimation.
- Setters for seed and sampling ratio in compression