### PR TITLE
[WIP] Python SystemDSContext instead of shutdown()

### DIFF
--- a/src/main/python/docs/source/matrix.rst
+++ b/src/main/python/docs/source/matrix.rst
@@ -18,6 +18,23 @@
 Matrix API
 ==========
 
+SystemDSContext
+---------------
+
+Since we always need a java instance running which will can execute operations in SystemDS, we
+need to start this connection at some point. We do this with ``SystemDSContext``. A ``SystemDSContext``
+object has to be created and once we are finished ``.close()`` has to be called on it, or
+we can use it by doing ``with SystemDSContext() as context:``, which will automatically close
+the context if an error occurs or we are finished with our operations. Creating an context is
+an expensive procedure, because we might have to start a subprocess running java, therefore
+try to do this only once for your program.
+
+Our SystemDS operations always start with an call on a ``SystemDSContext``, most likely to generate
+a matrix on which we can operate.
+
+.. autoclass:: systemds.context.SystemDSContext
+  :members:
+
 OperationNode
 -------------
 

--- a/src/main/python/docs/source/matrix.rst
+++ b/src/main/python/docs/source/matrix.rst
@@ -27,7 +27,7 @@ object has to be created and once we are finished ``.close()`` has to be called 
 we can use it by doing ``with SystemDSContext() as context:``, which will automatically close
 the context if an error occurs or we are finished with our operations. Creating an context is
 an expensive procedure, because we might have to start a subprocess running java, therefore
-try to do this only once for your program.
+try to do this only once for your program, or always leave at least one context open.
 
 Our SystemDS operations always start with an call on a ``SystemDSContext``, most likely to generate
 a matrix on which we can operate.

--- a/src/main/python/docs/source/matrix.rst
+++ b/src/main/python/docs/source/matrix.rst
@@ -61,13 +61,17 @@ Matrix
 ------
 
 A ``Matrix`` is represented either by an ``OperationNode``, or the derived class ``Matrix``.
-An Matrix can recognized it by checking the ``output_type`` of the object.
+An Matrix can be recognized it by checking the ``output_type`` of the object.
 
 Matrices are the most fundamental objects we operate on.
+
+Although we can generate matrices with the function calls or object construction specified below,
+the recommended way is to use the methods defined on ``SystemDSContext``.
+
 If one generate the matrix in SystemDS directly via a function call,
 it can be used in an function which will generate an ``OperationNode`` e.g. ``federated``, ``full``, ``seq``.
 
-If we want to work on an numpy array we need to use the class ``Matrix``.
+If we want to work on an numpy array, or want to read a matrix from a file, we need to use the class ``Matrix``.
 
 .. autoclass:: systemds.matrix.Matrix
     :members:

--- a/src/main/python/docs/source/simple_examples.rst
+++ b/src/main/python/docs/source/simple_examples.rst
@@ -22,18 +22,24 @@ Let's take a look at some code examples.
 Matrix Operations
 -----------------
 
-Making use of SystemDS, let us multiply an Matrix with an scalar::
+Making use of SystemDS, let us multiply an Matrix with an scalar:
 
-  # Import full
-  from systemds.matrix import full
-  # Full generates a matrix completely filled with one number.
-  # Generate a 5x10 matrix filled with 4.2
-  m = full((5, 10), 4.20)
-  # multiply with scala. Nothing is executed yet!
-  m_res = m * 3.1
-  # Do the calculation in SystemDS by calling compute().
-  # The returned value is an numpy array that can be directly printed.
-  print(m_res.compute())
+.. code-block:: python
+
+  # Import SystemDSContext
+  from systemds.context import SystemDSContext
+  # Create a context and if necessary (no SystemDS py4j instance running)
+  # it starts a subprocess which does the execution in SystemDS
+  with SystemDSContext() as sds:
+      # Full generates a matrix completely filled with one number.
+      # Generate a 5x10 matrix filled with 4.2
+      m = sds.full((5, 10), 4.20)
+      # multiply with scalar. Nothing is executed yet!
+      m_res = m * 3.1
+      # Do the calculation in SystemDS by calling compute().
+      # The returned value is an numpy array that can be directly printed.
+      print(m_res.compute())
+  # context will automatically be closed and process stopped
 
 As output we get::
 
@@ -45,10 +51,14 @@ As output we get::
 
 The Python SystemDS package is compatible with numpy arrays.
 Let us do a quick element-wise matrix multiplication of numpy arrays with SystemDS.
-Remember to first start up a new terminal::
+Remember to first start up a new terminal:
+
+.. code-block:: python
 
   import numpy as np  # import numpy
-  from systemds.matrix import Matrix  # import Matrix class
+
+  # Import SystemDSContext
+  from systemds.context import SystemDSContext
 
   # create a random array
   m1 = np.array(np.random.randint(100, size=5 * 5) + 1.01, dtype=np.double)
@@ -57,22 +67,26 @@ Remember to first start up a new terminal::
   m2 = np.array(np.random.randint(5, size=5 * 5) + 1, dtype=np.double)
   m2.shape = (5, 5)
 
-  # element-wise matrix multiplication, note that nothing is executed yet!
-  m_res = Matrix(m1) * Matrix(m2)
-  # lets do the actual computation in SystemDS! We get an numpy array as a result
-  m_res_np = m_res.compute()
-  print(m_res_np)
+  # Create a context
+  with SystemDSContext() as sds:
+      # element-wise matrix multiplication, note that nothing is executed yet!
+      m_res = sds.matrix(m1) * sds.matrix(m2)
+      # lets do the actual computation in SystemDS! We get an numpy array as a result
+      m_res_np = m_res.compute()
+      print(m_res_np)
 
 More complex operations
 -----------------------
 
-SystemDS provides algorithm level functions as buildin functions to simplify development.
-One example of this is l2SVM.
-high level functions for Data-Scientists, lets take a look at l2svm::
+SystemDS provides algorithm level functions as built-in functions to simplify development.
+, e example of this is l2SVM, a high level functions for Data-Scientists. Let's take a look at l2svm:
+
+.. code-block:: python
 
   # Import numpy and SystemDS matrix
   import numpy as np
-  from systemds.matrix import Matrix
+  from systemds.context import SystemDSContext
+
   # Set a seed
   np.random.seed(0)
   # Generate random features and labels in numpy
@@ -80,13 +94,16 @@ high level functions for Data-Scientists, lets take a look at l2svm::
   features = np.array(np.random.randint(100, size=10 * 10) + 1.01, dtype=np.double)
   features.shape = (10, 10)
   labels = np.zeros((10, 1))
+
   # l2svm labels can only be 0 or 1
   for i in range(10):
       if np.random.random() > 0.5:
           labels[i][0] = 1
+
   # compute our model
-  model = Matrix(features).l2svm(Matrix(labels)).compute()
-  print(model)
+  with SystemDSContext() as sds:
+      model = sds.matrix(features).l2svm(sds.matrix(labels)).compute()
+      print(model)
 
 The output should be similar to::
 

--- a/src/main/python/systemds/context/__init__.py
+++ b/src/main/python/systemds/context/__init__.py
@@ -14,4 +14,6 @@
 #  limitations under the License.
 # ------------------------------------------------------------------------------
 
-__all__ = ['context', 'matrix']
+from .systemds_context import *
+
+__all__ = systemds_context.__all__

--- a/src/main/python/systemds/context/systemds_context.py
+++ b/src/main/python/systemds/context/systemds_context.py
@@ -1,0 +1,142 @@
+# ------------------------------------------------------------------------------
+#  Copyright 2020 Graz University of Technology
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# ------------------------------------------------------------------------------
+
+__all__ = ["SystemDSContext"]
+
+import os
+import subprocess
+import threading
+from typing import Optional, Sequence, Union, Dict, Tuple, Iterable
+
+import numpy as np
+from py4j.java_gateway import JavaGateway
+from py4j.protocol import Py4JNetworkError
+
+from systemds.matrix import full, seq, federated, Matrix
+from systemds.matrix.operation_node import OperationNode
+from systemds.utils.helpers import get_module_dir
+from systemds.utils.consts import VALID_INPUT_TYPES
+
+PROCESS_LOCK: threading.Lock = threading.Lock()
+PROCESS: Optional[subprocess.Popen] = None
+ACTIVE_PROCESS_CONNECTIONS: int = 0
+
+
+class SystemDSContext(object):
+    """A context with a connection to the java instance with which we execute SystemDS operations.
+    If necessary this class might also start a java process which we use for the SystemDS operations,
+    before connecting."""
+    java_gateway: Optional[JavaGateway]
+
+    def __init__(self):
+        global PROCESS_LOCK
+        global PROCESS
+        global ACTIVE_PROCESS_CONNECTIONS
+        # make sure that only we would start a process if necessary and no other thread
+        # is killing the process we would connect to
+        PROCESS_LOCK.acquire()
+        try:
+            # attempt connection to manually started java instance
+            self.java_gateway = JavaGateway(eager_load=True)
+        except Py4JNetworkError:
+            # if no java instance is running start it
+            systemds_java_path = os.path.join(get_module_dir(), 'systemds-java')
+            cp_separator = ':'
+            if os.name == 'nt':  # nt means its Windows
+                cp_separator = ';'
+            lib_cp = os.path.join(systemds_java_path, 'lib', '*')
+            systemds_cp = os.path.join(systemds_java_path, '*')
+            classpath = cp_separator.join([lib_cp, systemds_cp])
+            process = subprocess.Popen(['java', '-cp', classpath, 'org.tugraz.sysds.pythonapi.PythonDMLScript'],
+                                       stdout=subprocess.PIPE, stdin=subprocess.PIPE)
+            process.stdout.readline()  # wait for 'Gateway Server Started\n' written by server
+            assert process.poll() is None, "Could not start JMLC server"
+            self.java_gateway = JavaGateway()
+            PROCESS = process
+        if PROCESS is not None:
+            ACTIVE_PROCESS_CONNECTIONS += 1
+        PROCESS_LOCK.release()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        # TODO are there errors we can fix here?
+        self.close()
+        # We can not fix any errors that come up -> return None
+        return None
+
+    def close(self):
+        """Close the connection to the java process and do necessary cleanup."""
+
+        global PROCESS_LOCK
+        global PROCESS
+        global ACTIVE_PROCESS_CONNECTIONS
+        self.java_gateway.shutdown()
+        PROCESS_LOCK.acquire()
+        # check if no other thread is connected to the process, if we had to start one
+        if PROCESS is not None and ACTIVE_PROCESS_CONNECTIONS == 1:
+            # stop the process by sending a new line (it will shutdown on its own)
+            PROCESS.communicate(input=b'\n')
+            PROCESS.wait()
+            PROCESS = None
+            ACTIVE_PROCESS_CONNECTIONS = 0
+        PROCESS_LOCK.release()
+
+    def matrix(self, mat: Union[np.array, os.PathLike], *args: Sequence[VALID_INPUT_TYPES],
+               **kwargs: Dict[str, VALID_INPUT_TYPES]) -> 'Matrix':
+        """ Create matrix.
+
+        :param mat: Matrix given by numpy array or path to matrix file
+        :param args: additional arguments
+        :param kwargs: additional named arguments
+        :return: the OperationNode representing this operation
+        """
+        return Matrix(self, mat, *args, **kwargs)
+
+    def federated(self, addresses: Iterable[str], ranges: Iterable[Tuple[Iterable[int], Iterable[int]]],
+                  *args: Sequence[VALID_INPUT_TYPES], **kwargs: Dict[str, VALID_INPUT_TYPES]) -> 'OperationNode':
+        """Create federated matrix object.
+    
+        :param addresses: addresses of the federated workers
+        :param ranges: for each federated worker a pair of begin and end index of their held matrix
+        :param args: unnamed params
+        :param kwargs: named params
+        :return: the OperationNode representing this operation
+        """
+        return federated(self, addresses, ranges, *args, **kwargs)
+
+    def full(self, shape: Tuple[int, int], value: Union[float, int]) -> 'OperationNode':
+        """Generates a matrix completely filled with a value
+
+        :param shape: shape (rows and cols) of the matrix
+        :param value: the value to fill all cells with
+        :return: the OperationNode representing this operation
+        """
+        return full(self, shape, value)
+
+    def seq(self, start: Union[float, int], stop: Union[float, int] = None,
+            step: Union[float, int] = 1) -> 'OperationNode':
+        """Create a single column vector with values from `start` to `stop` and an increment of `step`.
+        If no stop is defined and only one parameter is given, then start will be 0 and the parameter will be
+        interpreted as stop.
+
+        :param start: the starting value
+        :param stop: the maximum value
+        :param step: the step size
+        :return: the OperationNode representing this operation
+        """
+        return seq(self, start, stop, step)

--- a/src/main/python/systemds/context/systemds_context.py
+++ b/src/main/python/systemds/context/systemds_context.py
@@ -25,8 +25,7 @@ import numpy as np
 from py4j.java_gateway import JavaGateway
 from py4j.protocol import Py4JNetworkError
 
-from systemds.matrix import full, seq, federated, Matrix
-from systemds.matrix.operation_node import OperationNode
+from systemds.matrix import full, seq, federated, Matrix, OperationNode
 from systemds.utils.helpers import get_module_dir
 from systemds.utils.consts import VALID_INPUT_TYPES
 

--- a/src/main/python/systemds/matrix/matrix.py
+++ b/src/main/python/systemds/matrix/matrix.py
@@ -17,22 +17,29 @@
 __all__ = ['Matrix', 'federated', 'full', 'seq']
 
 import os
-from typing import Union, Optional, Iterable, Dict, Tuple, Sequence
+from typing import Union, Optional, Iterable, Dict, Tuple, Sequence, TYPE_CHECKING
 
 import numpy as np
 from py4j.java_gateway import JVMView, JavaObject
 
 from systemds.utils.converters import numpy_to_matrix_block
-from systemds.script_building.dag import VALID_INPUT_TYPES
 from systemds.matrix.operation_node import OperationNode
 
+from systemds.utils.consts import VALID_INPUT_TYPES
+
+if TYPE_CHECKING:
+    # so we don't get cyclic dependencies during runtime
+    from systemds.context import SystemDSContext
 
 # TODO maybe instead of having a new class we could have a function `matrix` instead, adding behaviour to
 #  `OperationNode` would be necessary
+
+
 class Matrix(OperationNode):
     np_array: Optional[np.array]
 
-    def __init__(self, mat: Union[np.array, os.PathLike], *args: Sequence[VALID_INPUT_TYPES],
+    def __init__(self, sds_context: 'SystemDSContext', mat: Union[np.array, os.PathLike],
+                 *args: Sequence[VALID_INPUT_TYPES],
                  **kwargs: Dict[str, VALID_INPUT_TYPES]) -> None:
         """Generate DAGNode representing matrix with data either given by a numpy array, which will be sent to SystemDS
         on need, or a path pointing to a matrix.
@@ -51,7 +58,7 @@ class Matrix(OperationNode):
             self.np_array = mat
         unnamed_params.extend(args)
         named_params.update(kwargs)
-        super().__init__('read', unnamed_params, named_params, is_python_local_data=self._is_numpy())
+        super().__init__(sds_context, 'read', unnamed_params, named_params, is_python_local_data=self._is_numpy())
 
     def pass_python_data_to_prepared_script(self, jvm: JVMView, var_name: str, prepared_script: JavaObject) -> None:
         assert self.is_python_local_data, 'Can only pass data to prepared script if it is python local!'
@@ -77,10 +84,12 @@ class Matrix(OperationNode):
         return self.np_array is not None
 
 
-def federated(addresses: Iterable[str], ranges: Iterable[Tuple[Iterable[int], Iterable[int]]], *args,
+def federated(sds_context: 'SystemDSContext', addresses: Iterable[str],
+              ranges: Iterable[Tuple[Iterable[int], Iterable[int]]], *args,
               **kwargs) -> OperationNode:
     """Create federated matrix object.
 
+    :param sds_context: the SystemDS context
     :param addresses: addresses of the federated workers
     :param ranges: for each federated worker a pair of begin and end index of their held matrix
     :param args: unnamed params
@@ -94,26 +103,29 @@ def federated(addresses: Iterable[str], ranges: Iterable[Tuple[Iterable[int], It
     ranges_str += ')'
     named_params = {'addresses': addresses_str, 'ranges': ranges_str}
     named_params.update(kwargs)
-    return OperationNode('federated', args, named_params)
+    return OperationNode(sds_context, 'federated', args, named_params)
 
 
-def full(shape: Tuple[int, int], value: Union[float, int]) -> OperationNode:
+def full(sds_context: 'SystemDSContext', shape: Tuple[int, int], value: Union[float, int]) -> OperationNode:
     """Generates a matrix completely filled with a value
 
+    :param sds_context: SystemDS context
     :param shape: shape (rows and cols) of the matrix TODO tensor
     :param value: the value to fill all cells with
     :return: the OperationNode representing this operation
     """
     unnamed_input_nodes = [value]
     named_input_nodes = {'rows': shape[0], 'cols': shape[1]}
-    return OperationNode('matrix', unnamed_input_nodes, named_input_nodes)
+    return OperationNode(sds_context, 'matrix', unnamed_input_nodes, named_input_nodes)
 
 
-def seq(start: Union[float, int], stop: Union[float, int] = None, step: Union[float, int] = 1) -> OperationNode:
+def seq(sds_context: 'SystemDSContext', start: Union[float, int], stop: Union[float, int] = None,
+        step: Union[float, int] = 1) -> OperationNode:
     """Create a single column vector with values from `start` to `stop` and an increment of `step`.
     If no stop is defined and only one parameter is given, then start will be 0 and the parameter will be interpreted as
     stop.
 
+    :param sds_context: SystemDS context
     :param start: the starting value
     :param stop: the maximum value
     :param step: the step size
@@ -123,4 +135,4 @@ def seq(start: Union[float, int], stop: Union[float, int] = None, step: Union[fl
         stop = start
         start = 0
     unnamed_input_nodes = [start, stop, step]
-    return OperationNode('seq', unnamed_input_nodes)
+    return OperationNode(sds_context, 'seq', unnamed_input_nodes)

--- a/src/main/python/systemds/matrix/matrix.py
+++ b/src/main/python/systemds/matrix/matrix.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
 
 
 class Matrix(OperationNode):
-    np_array: Optional[np.array]
+    _np_array: Optional[np.array]
 
     def __init__(self, sds_context: 'SystemDSContext', mat: Union[np.array, os.PathLike],
                  *args: Sequence[VALID_INPUT_TYPES],
@@ -51,11 +51,11 @@ class Matrix(OperationNode):
         if isinstance(mat, str):
             unnamed_params = [f'\'{mat}\'']
             named_params = {}
-            self.np_array = None
+            self._np_array = None
         else:
             unnamed_params = ['\'./tmp/{file_name}\'']  # TODO better alternative than format string?
             named_params = {'rows': -1, 'cols': -1}
-            self.np_array = mat
+            self._np_array = mat
         unnamed_params.extend(args)
         named_params.update(kwargs)
         super().__init__(sds_context, 'read', unnamed_params, named_params, is_python_local_data=self._is_numpy())
@@ -63,7 +63,7 @@ class Matrix(OperationNode):
     def pass_python_data_to_prepared_script(self, jvm: JVMView, var_name: str, prepared_script: JavaObject) -> None:
         assert self.is_python_local_data, 'Can only pass data to prepared script if it is python local!'
         if self._is_numpy():
-            prepared_script.setMatrix(var_name, numpy_to_matrix_block(jvm, self.np_array), True)  # True for reuse
+            prepared_script.setMatrix(var_name, numpy_to_matrix_block(jvm, self._np_array), True)  # True for reuse
 
     def code_line(self, var_name: str, unnamed_input_vars: Sequence[str],
                   named_input_vars: Dict[str, str]) -> str:
@@ -76,12 +76,12 @@ class Matrix(OperationNode):
         if self._is_numpy():
             if verbose:
                 print('[Numpy Array - No Compilation necessary]')
-            return self.np_array
+            return self._np_array
         else:
             return super().compute(verbose, lineage)
 
     def _is_numpy(self) -> bool:
-        return self.np_array is not None
+        return self._np_array is not None
 
 
 def federated(sds_context: 'SystemDSContext', addresses: Iterable[str],

--- a/src/main/python/systemds/matrix/operation_node.py
+++ b/src/main/python/systemds/matrix/operation_node.py
@@ -34,9 +34,9 @@ __all__ = ["OperationNode"]
 
 class OperationNode(DAGNode):
     """A Node representing an operation in SystemDS"""
-    result_var: Optional[Union[float, np.array]]
-    lineage_trace: Optional[str]
-    script: Optional[DMLScript]
+    _result_var: Optional[Union[float, np.array]]
+    _lineage_trace: Optional[str]
+    _script: Optional[DMLScript]
 
     def __init__(self, sds_context: 'SystemDSContext', operation: str,
                  unnamed_input_nodes: Iterable[VALID_INPUT_TYPES] = None,
@@ -58,48 +58,48 @@ class OperationNode(DAGNode):
         if named_input_nodes is None:
             named_input_nodes = {}
         self.operation = operation
-        self.unnamed_input_nodes = unnamed_input_nodes
-        self.named_input_nodes = named_input_nodes
+        self._unnamed_input_nodes = unnamed_input_nodes
+        self._named_input_nodes = named_input_nodes
         self.output_type = output_type
-        self.is_python_local_data = is_python_local_data
-        self.result_var = None
-        self.lineage_trace = None
-        self.script = None
+        self._is_python_local_data = is_python_local_data
+        self._result_var = None
+        self._lineage_trace = None
+        self._script = None
 
     def compute(self, verbose: bool = False, lineage: bool = False) -> \
             Union[float, np.array, Tuple[Union[float, np.array], str]]:
-        if self.result_var is None or self.lineage_trace is None:
-            self.script = DMLScript(self.sds_context)
-            self.script.build_code(self)
+        if self._result_var is None or self._lineage_trace is None:
+            self._script = DMLScript(self.sds_context)
+            self._script.build_code(self)
             if lineage:
-                result_variables, self.lineage_trace = self.script.execute(lineage)
+                result_variables, self._lineage_trace = self._script.execute(lineage)
             else:
-                result_variables = self.script.execute(lineage)
+                result_variables = self._script.execute(lineage)
             if self.output_type == OutputType.DOUBLE:
-                self.result_var = result_variables.getDouble(self.script.out_var_name)
+                self._result_var = result_variables.getDouble(self._script.out_var_name)
             elif self.output_type == OutputType.MATRIX:
-                self.result_var = matrix_block_to_numpy(self.sds_context.java_gateway.jvm,
-                                                        result_variables.getMatrixBlock(self.script.out_var_name))
+                self._result_var = matrix_block_to_numpy(self.sds_context._java_gateway.jvm,
+                                                         result_variables.getMatrixBlock(self._script.out_var_name))
         if verbose:
-            print(self.script.dml_script)
+            print(self._script.dml_script)
             # TODO further info
 
         if lineage:
-            return self.result_var, self.lineage_trace
+            return self._result_var, self._lineage_trace
         else:
-            return self.result_var
+            return self._result_var
 
     def get_lineage_trace(self) -> str:
         """Get the lineage trace for this node.
 
         :return: Lineage trace
         """
-        if self.lineage_trace is None:
-            self.script = DMLScript(self.sds_context)
-            self.script.build_code(self)
-            self.lineage_trace = self.script.get_lineage()
+        if self._lineage_trace is None:
+            self._script = DMLScript(self.sds_context)
+            self._script.build_code(self)
+            self._lineage_trace = self._script.get_lineage()
 
-        return self.lineage_trace
+        return self._lineage_trace
 
     def code_line(self, var_name: str, unnamed_input_vars: Sequence[str],
                   named_input_vars: Dict[str, str]) -> str:

--- a/src/main/python/systemds/matrix/operation_node.py
+++ b/src/main/python/systemds/matrix/operation_node.py
@@ -14,39 +14,45 @@
 #  limitations under the License.
 # ------------------------------------------------------------------------------
 
+from typing import Union, Optional, Iterable, Dict, Sequence, Tuple, TYPE_CHECKING
+
 import numpy as np
 from py4j.java_gateway import JVMView, JavaObject
-from typing import Union, Optional, Iterable, Dict, Sequence, Tuple
 
-from systemds.utils.helpers import get_gateway, create_params_string
+from systemds.utils.consts import VALID_INPUT_TYPES, BINARY_OPERATIONS, VALID_ARITHMETIC_TYPES
+from systemds.utils.helpers import create_params_string
 from systemds.utils.converters import matrix_block_to_numpy
 from systemds.script_building.script import DMLScript
-from systemds.script_building.dag import OutputType, DAGNode, VALID_INPUT_TYPES
+from systemds.script_building.dag import OutputType, DAGNode
 
-BINARY_OPERATIONS = ['+', '-', '/', '//', '*', '<', '<=', '>', '>=', '==', '!=']
-# TODO add numpy array
-VALID_ARITHMETIC_TYPES = Union[DAGNode, int, float]
+if TYPE_CHECKING:
+    # so we don't get cyclic dependencies during runtime
+    from systemds.context import SystemDSContext
 
 __all__ = ["OperationNode"]
 
 
 class OperationNode(DAGNode):
+    """A Node representing an operation in SystemDS"""
     result_var: Optional[Union[float, np.array]]
-    lineage_trace: str
+    lineage_trace: Optional[str]
     script: Optional[DMLScript]
 
-    def __init__(self, operation: str, unnamed_input_nodes: Iterable[VALID_INPUT_TYPES] = None,
+    def __init__(self, sds_context: 'SystemDSContext', operation: str,
+                 unnamed_input_nodes: Iterable[VALID_INPUT_TYPES] = None,
                  named_input_nodes: Dict[str, VALID_INPUT_TYPES] = None,
                  output_type: OutputType = OutputType.MATRIX, is_python_local_data: bool = False):
         """
         Create general `OperationNode`
 
+        :param sds_context: The SystemDS context for performing the operations
         :param operation: The name of the DML function to execute
         :param unnamed_input_nodes: inputs identified by their position, not name
         :param named_input_nodes: inputs with their respective parameter name
         :param output_type: type of the output in DML (double, matrix etc.)
         :param is_python_local_data: if the data is local in python e.g. numpy arrays
         """
+        self.sds_context = sds_context
         if unnamed_input_nodes is None:
             unnamed_input_nodes = []
         if named_input_nodes is None:
@@ -60,40 +66,40 @@ class OperationNode(DAGNode):
         self.lineage_trace = None
         self.script = None
 
-    def compute(self, verbose: bool = False, lineage: bool = False) -> Union[float, np.array, Tuple[Union[float, np.array], str]]:
-        if self.result_var is None:
-            self.script = DMLScript()
+    def compute(self, verbose: bool = False, lineage: bool = False) -> \
+            Union[float, np.array, Tuple[Union[float, np.array], str]]:
+        if self.result_var is None or self.lineage_trace is None:
+            self.script = DMLScript(self.sds_context)
             self.script.build_code(self)
             if lineage:
-                result_variables, ltrace = self.script.execute(lineage)
+                result_variables, self.lineage_trace = self.script.execute(lineage)
             else:
                 result_variables = self.script.execute(lineage)
             if self.output_type == OutputType.DOUBLE:
                 self.result_var = result_variables.getDouble(self.script.out_var_name)
             elif self.output_type == OutputType.MATRIX:
-                self.result_var = matrix_block_to_numpy(get_gateway().jvm,
+                self.result_var = matrix_block_to_numpy(self.sds_context.java_gateway.jvm,
                                                         result_variables.getMatrixBlock(self.script.out_var_name))
         if verbose:
             print(self.script.dml_script)
             # TODO further info
 
         if lineage:
-            return self.result_var, ltrace
+            return self.result_var, self.lineage_trace
         else:
             return self.result_var
 
-    def getLineageTrace(self) -> str:
+    def get_lineage_trace(self) -> str:
         """Get the lineage trace for this node.
 
         :return: Lineage trace
         """
         if self.lineage_trace is None:
-            self.script = DMLScript()
+            self.script = DMLScript(self.sds_context)
             self.script.build_code(self)
-            self.lineage_trace = self.script.getlineage()
+            self.lineage_trace = self.script.get_lineage()
 
         return self.lineage_trace
-        
 
     def code_line(self, var_name: str, unnamed_input_vars: Sequence[str],
                   named_input_vars: Dict[str, str]) -> str:
@@ -116,37 +122,37 @@ class OperationNode(DAGNode):
         assert self.output_type == OutputType.MATRIX, f'{self.operation} only supported for matrices'
 
     def __add__(self, other: VALID_ARITHMETIC_TYPES):
-        return OperationNode('+', [self, other])
+        return OperationNode(self.sds_context, '+', [self, other])
 
     def __sub__(self, other: VALID_ARITHMETIC_TYPES):
-        return OperationNode('-', [self, other])
+        return OperationNode(self.sds_context, '-', [self, other])
 
     def __mul__(self, other: VALID_ARITHMETIC_TYPES):
-        return OperationNode('*', [self, other])
+        return OperationNode(self.sds_context, '*', [self, other])
 
     def __truediv__(self, other: VALID_ARITHMETIC_TYPES):
-        return OperationNode('/', [self, other])
+        return OperationNode(self.sds_context, '/', [self, other])
 
     def __floordiv__(self, other: VALID_ARITHMETIC_TYPES):
-        return OperationNode('//', [self, other])
+        return OperationNode(self.sds_context, '//', [self, other])
 
     def __lt__(self, other) -> 'OperationNode':
-        return OperationNode('<', [self, other])
+        return OperationNode(self.sds_context, '<', [self, other])
 
     def __le__(self, other):
-        return OperationNode('<=', [self, other])
+        return OperationNode(self.sds_context, '<=', [self, other])
 
     def __gt__(self, other):
-        return OperationNode('>', [self, other])
+        return OperationNode(self.sds_context, '>', [self, other])
 
     def __ge__(self, other):
-        return OperationNode('>=', [self, other])
+        return OperationNode(self.sds_context, '>=', [self, other])
 
     def __eq__(self, other):
-        return OperationNode('==', [self, other])
+        return OperationNode(self.sds_context, '==', [self, other])
 
     def __ne__(self, other):
-        return OperationNode('!=', [self, other])
+        return OperationNode(self.sds_context, '!=', [self, other])
 
     def l2svm(self, labels: DAGNode, **kwargs) -> 'OperationNode':
         """Perform l2svm on matrix with labels given.
@@ -156,7 +162,7 @@ class OperationNode(DAGNode):
         self._check_matrix_op()
         params_dict = {'X': self, 'Y': labels}
         params_dict.update(kwargs)
-        return OperationNode('l2svm', named_input_nodes=params_dict)
+        return OperationNode(self.sds_context, 'l2svm', named_input_nodes=params_dict)
 
     def sum(self, axis: int = None) -> 'OperationNode':
         """Calculate sum of matrix.
@@ -166,11 +172,11 @@ class OperationNode(DAGNode):
         """
         self._check_matrix_op()
         if axis == 0:
-            return OperationNode('colSums', [self])
+            return OperationNode(self.sds_context, 'colSums', [self])
         elif axis == 1:
-            return OperationNode('rowSums', [self])
+            return OperationNode(self.sds_context, 'rowSums', [self])
         elif axis is None:
-            return OperationNode('sum', [self], output_type=OutputType.DOUBLE)
+            return OperationNode(self.sds_context, 'sum', [self], output_type=OutputType.DOUBLE)
         raise ValueError(f"Axis has to be either 0, 1 or None, for column, row or complete {self.operation}")
 
     def mean(self, axis: int = None) -> 'OperationNode':
@@ -181,11 +187,11 @@ class OperationNode(DAGNode):
         """
         self._check_matrix_op()
         if axis == 0:
-            return OperationNode('colMeans', [self])
+            return OperationNode(self.sds_context, 'colMeans', [self])
         elif axis == 1:
-            return OperationNode('rowMeans', [self])
+            return OperationNode(self.sds_context, 'rowMeans', [self])
         elif axis is None:
-            return OperationNode('mean', [self], output_type=OutputType.DOUBLE)
+            return OperationNode(self.sds_context, 'mean', [self], output_type=OutputType.DOUBLE)
         raise ValueError(f"Axis has to be either 0, 1 or None, for column, row or complete {self.operation}")
 
     def var(self, axis: int = None) -> 'OperationNode':
@@ -196,11 +202,11 @@ class OperationNode(DAGNode):
         """
         self._check_matrix_op()
         if axis == 0:
-            return OperationNode('colVars', [self])
+            return OperationNode(self.sds_context, 'colVars', [self])
         elif axis == 1:
-            return OperationNode('rowVars', [self])
+            return OperationNode(self.sds_context, 'rowVars', [self])
         elif axis is None:
-            return OperationNode('var', [self], output_type=OutputType.DOUBLE)
+            return OperationNode(self.sds_context, 'var', [self], output_type=OutputType.DOUBLE)
         raise ValueError(f"Axis has to be either 0, 1 or None, for column, row or complete {self.operation}")
 
     def abs(self) -> 'OperationNode':
@@ -208,7 +214,7 @@ class OperationNode(DAGNode):
 
         :return: `OperationNode` representing operation
         """
-        return OperationNode('abs', [self])
+        return OperationNode(self.sds_context, 'abs', [self])
 
     def moment(self, moment, weights: DAGNode = None) -> 'OperationNode':
         # TODO write tests
@@ -217,4 +223,4 @@ class OperationNode(DAGNode):
         if weights is not None:
             unnamed_inputs.append(weights)
         unnamed_inputs.append(moment)
-        return OperationNode('moment', unnamed_inputs, output_type=OutputType.DOUBLE)
+        return OperationNode(self.sds_context, 'moment', unnamed_inputs, output_type=OutputType.DOUBLE)

--- a/src/main/python/systemds/script_building/dag.py
+++ b/src/main/python/systemds/script_building/dag.py
@@ -33,10 +33,10 @@ class OutputType(Enum):
 class DAGNode(ABC):
     """A Node in the directed-acyclic-graph (DAG) defining all operations."""
     sds_context: 'SystemDSContext'
-    unnamed_input_nodes: Sequence[Union['DAGNode', str, int, float, bool]]
-    named_input_nodes: Dict[str, Union['DAGNode', str, int, float, bool]]
-    output_type: OutputType
-    is_python_local_data: bool
+    _unnamed_input_nodes: Sequence[Union['DAGNode', str, int, float, bool]]
+    _named_input_nodes: Dict[str, Union['DAGNode', str, int, float, bool]]
+    _output_type: OutputType
+    _is_python_local_data: bool
 
     def compute(self, verbose: bool = False, lineage: bool = False) -> Any:
         """Get result of this operation. Builds the dml script and executes it in SystemDS, before this method is called
@@ -73,3 +73,15 @@ class DAGNode(ABC):
         :param prepared_script: the prepared script
         """
         raise NotImplementedError
+
+    @property
+    def unnamed_input_nodes(self):
+        return self._unnamed_input_nodes
+
+    @property
+    def named_input_nodes(self):
+        return self._named_input_nodes
+
+    @property
+    def is_python_local_data(self):
+        return self._is_python_local_data

--- a/src/main/python/systemds/script_building/dag.py
+++ b/src/main/python/systemds/script_building/dag.py
@@ -15,10 +15,14 @@
 # ------------------------------------------------------------------------------
 
 from enum import Enum, auto
-from typing import Any, Dict, Union, Sequence
+from typing import Any, Dict, Union, Sequence, TYPE_CHECKING
 from abc import ABC
 
 from py4j.java_gateway import JavaObject, JVMView
+
+if TYPE_CHECKING:
+    # so we don't get cyclic dependencies during runtime
+    from systemds.context import SystemDSContext
 
 
 class OutputType(Enum):
@@ -28,6 +32,7 @@ class OutputType(Enum):
 
 class DAGNode(ABC):
     """A Node in the directed-acyclic-graph (DAG) defining all operations."""
+    sds_context: 'SystemDSContext'
     unnamed_input_nodes: Sequence[Union['DAGNode', str, int, float, bool]]
     named_input_nodes: Dict[str, Union['DAGNode', str, int, float, bool]]
     output_type: OutputType
@@ -38,14 +43,16 @@ class DAGNode(ABC):
         all operations are only building the DAG without actually executing (lazy evaluation).
 
         :param verbose: Can be activated to print additional information such as created DML-Script
-        :lineage: Can be activated to print lineage trace till this node
+        :param lineage: Can be activated to print lineage trace till this node
         :return: the output as an python builtin data type or numpy array
         """
         raise NotImplementedError
 
-    def getLineageTrace(self) -> str:
-        """Get lineage trace of this operation. This executes the dml script but unlike compute, doesn't store the results
-        """
+    def get_lineage_trace(self) -> str:
+        """Get lineage trace of this operation. This executes the dml script but unlike compute,
+        doesn't store the results"""
+        # TODO why do we not want to store the results? The execution script will should stay the same
+        #  therefore we could cache the result.
         raise NotImplementedError
 
     def code_line(self, var_name: str, unnamed_input_vars: Sequence[str], named_input_vars: Dict[str, str]) -> str:
@@ -66,6 +73,3 @@ class DAGNode(ABC):
         :param prepared_script: the prepared script
         """
         raise NotImplementedError
-
-
-VALID_INPUT_TYPES = Union[DAGNode, str, int, float, bool]

--- a/src/main/python/systemds/script_building/script.py
+++ b/src/main/python/systemds/script_building/script.py
@@ -14,14 +14,17 @@
 #  limitations under the License.
 # ------------------------------------------------------------------------------
 
-from typing import Any, Dict, Optional, Collection, KeysView, Union, Tuple
+from typing import Any, Collection, KeysView, Tuple, Union, Optional, Dict, TYPE_CHECKING
 
 from py4j.java_collections import JavaArray
-from py4j.java_gateway import JavaObject
+from py4j.java_gateway import JavaObject, JavaGateway
 
-from systemds.utils.helpers import get_gateway
-from systemds.script_building.dag import DAGNode, VALID_INPUT_TYPES
-from typing import Union, Optional, Dict
+from systemds.script_building.dag import DAGNode
+from systemds.utils.consts import VALID_INPUT_TYPES
+
+if TYPE_CHECKING:
+    # so we don't get cyclic dependencies during runtime
+    from systemds.context import SystemDSContext
 
 
 class DMLScript:
@@ -34,13 +37,15 @@ class DMLScript:
 
     TODO rerun with different inputs without recompilation
     """
+    sds_context: 'SystemDSContext'
     dml_script: str
     inputs: Dict[str, DAGNode]
     prepared_script: Optional[Any]
     out_var_name: str
     _variable_counter: int
 
-    def __init__(self) -> None:
+    def __init__(self, context: 'SystemDSContext') -> None:
+        self.sds_context = context
         self.dml_script = ''
         self.inputs = {}
         self.prepared_script = None
@@ -70,14 +75,14 @@ class DMLScript:
         """
         # we could use the gateway directly, non defined functions will be automatically
         # sent to the entry_point, but this is safer
-        gateway = get_gateway()
+        gateway = self.sds_context.java_gateway
         entry_point = gateway.entry_point
         if self.prepared_script is None:
             input_names = self.inputs.keys()
             connection = entry_point.getConnection()
             self.prepared_script = connection.prepareScript(self.dml_script,
-                                                            _list_to_java_array(input_names),
-                                                            _list_to_java_array([self.out_var_name]))
+                                                            _list_to_java_array(gateway, input_names),
+                                                            _list_to_java_array(gateway, [self.out_var_name]))
             for (name, input_node) in self.inputs.items():
                 input_node.pass_python_data_to_prepared_script(gateway.jvm, name, self.prepared_script)
 
@@ -90,24 +95,23 @@ class DMLScript:
 
         return ret
 
-    def getlineage(self) -> str:
-        gateway = get_gateway()
+    def get_lineage(self) -> str:
+        gateway = self.sds_context.java_gateway
         entry_point = gateway.entry_point
         if self.prepared_script is None:
             input_names = self.inputs.keys()
             connection = entry_point.getConnection()
             self.prepared_script = connection.prepareScript(self.dml_script,
-                                                            _list_to_java_array(input_names),
-                                                            _list_to_java_array([self.out_var_name]))
+                                                            _list_to_java_array(gateway, input_names),
+                                                            _list_to_java_array(gateway, [self.out_var_name]))
             for (name, input_node) in self.inputs.items():
                 input_node.pass_python_data_to_prepared_script(gateway.jvm, name, self.prepared_script)
 
             connection.setLineage(True)
 
-        ret = self.prepared_script.executeScript()
+        self.prepared_script.executeScript()
         lineage = self.prepared_script.getLineageTrace(self.out_var_name)
         return lineage
-        
 
     def build_code(self, dag_root: DAGNode) -> None:
         """Builds code from our DAG
@@ -151,13 +155,12 @@ class DMLScript:
 
 
 # Helper Functions
-def _list_to_java_array(py_list: Union[Collection[str], KeysView[str]]) -> JavaArray:
+def _list_to_java_array(gateway: JavaGateway, py_list: Union[Collection[str], KeysView[str]]) -> JavaArray:
     """Convert python collection to java array.
 
     :param py_list: python collection
     :return: java array
     """
-    gateway = get_gateway()
     array = gateway.new_array(gateway.jvm.java.lang.String, len(py_list))
     for (i, e) in enumerate(py_list):
         array[i] = e

--- a/src/main/python/systemds/utils/consts.py
+++ b/src/main/python/systemds/utils/consts.py
@@ -13,5 +13,11 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 # ------------------------------------------------------------------------------
+from typing import Union
 
-__all__ = ['context', 'matrix']
+MODULE_NAME = 'systemds'
+VALID_INPUT_TYPES = Union['DAGNode', str, int, float, bool]
+BINARY_OPERATIONS = ['+', '-', '/', '//', '*', '<', '<=', '>', '>=', '==', '!=']
+# TODO add numpy array and implement for numpy array
+VALID_ARITHMETIC_TYPES = Union['DAGNode', int, float]
+

--- a/src/main/python/systemds/utils/converters.py
+++ b/src/main/python/systemds/utils/converters.py
@@ -39,7 +39,7 @@ def numpy_to_matrix_block(jvm: JVMView, np_arr: np.array):
 
 
 def matrix_block_to_numpy(jvm: JVMView, mb: JavaObject):
-    numRows = mb.getNumRows()
-    numCols = mb.getNumColumns()
+    num_ros = mb.getNumRows()
+    num_cols = mb.getNumColumns()
     buf = jvm.org.tugraz.sysds.runtime.compress.utils.Py4jConverterUtils.convertMBtoPy4JDenseArr(mb)
-    return np.frombuffer(buf, count=numRows * numCols, dtype=np.float64).reshape((numRows, numCols))
+    return np.frombuffer(buf, count=num_ros * num_cols, dtype=np.float64).reshape((num_ros, num_cols))

--- a/src/main/python/systemds/utils/helpers.py
+++ b/src/main/python/systemds/utils/helpers.py
@@ -15,53 +15,11 @@
 # ------------------------------------------------------------------------------
 
 import os
-import subprocess
 from itertools import chain
 from typing import Iterable, Dict
 from importlib.util import find_spec
 
-from py4j.java_gateway import JavaGateway
-from py4j.protocol import Py4JNetworkError
-
-JAVA_GATEWAY = None
-MODULE_NAME = 'systemds'
-PROC = None
-
-
-def get_gateway() -> JavaGateway:
-    """
-    Gives the gateway with which we can communicate with the SystemDS instance running a
-    JMLC (Java Machine Learning Compactor) API.
-
-    :return: the java gateway object
-    """
-    global JAVA_GATEWAY
-    global PROC
-    if JAVA_GATEWAY is None:
-        try:
-            JAVA_GATEWAY = JavaGateway(eager_load=True)
-        except Py4JNetworkError:  # if no java instance is running start it
-            systemds_java_path = os.path.join(_get_module_dir(), 'systemds-java')
-            cp_separator = ':'
-            if os.name == 'nt':  # nt means its Windows
-                cp_separator = ';'
-            lib_cp = os.path.join(systemds_java_path, 'lib', '*')
-            systemds_cp = os.path.join(systemds_java_path, '*')
-            classpath = cp_separator.join([lib_cp, systemds_cp])
-            process = subprocess.Popen(['java', '-cp', classpath, 'org.tugraz.sysds.pythonapi.PythonDMLScript'],
-                                       stdout=subprocess.PIPE, stdin=subprocess.PIPE)
-            print(process.stdout.readline())  # wait for 'Gateway Server Started\n' written by server
-            assert process.poll() is None, "Could not start JMLC server"
-            JAVA_GATEWAY = JavaGateway()
-            PROC = process
-    return JAVA_GATEWAY
-
-
-def shutdown():
-    global JAVA_GATEWAY
-    global PROC
-    JAVA_GATEWAY.shutdown()
-    PROC.communicate(input=b'\n')
+from systemds.utils.consts import MODULE_NAME
 
 
 def create_params_string(unnamed_parameters: Iterable[str], named_parameters: Dict[str, str]) -> str:
@@ -77,7 +35,7 @@ def create_params_string(unnamed_parameters: Iterable[str], named_parameters: Di
     return ','.join(chain(unnamed_parameters, named_input_strs))
 
 
-def _get_module_dir() -> os.PathLike:
+def get_module_dir() -> os.PathLike:
     """
     Gives the path to our module
 

--- a/src/main/python/tests/test_l2svm.py
+++ b/src/main/python/tests/test_l2svm.py
@@ -25,8 +25,11 @@ import numpy as np
 
 path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../")
 sys.path.insert(0, path)
+
+from systemds.context import SystemDSContext
 from systemds.matrix import Matrix
-from systemds.utils import helpers
+
+sds = SystemDSContext()
 
 class TestL2svm(unittest.TestCase):
 
@@ -64,9 +67,9 @@ def generate_matrices_for_l2svm(dims: int, seed: int = 1234) -> Tuple[Matrix, Ma
     for i in range(dims):
         if np.random.random() > 0.5:
             m2[i][0] = 1
-    return Matrix(m1), Matrix(m2)
+    return sds.matrix(m1), sds.matrix(m2)
 
 
 if __name__ == "__main__":
     unittest.main(exit=False)
-    helpers.shutdown()
+    sds.close()

--- a/src/main/python/tests/test_l2svm_lineage.py
+++ b/src/main/python/tests/test_l2svm_lineage.py
@@ -25,7 +25,10 @@ import numpy as np
 path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../")
 sys.path.insert(0, path)
 from systemds.matrix import Matrix
-from systemds.utils import helpers
+from systemds.context import SystemDSContext
+
+sds = SystemDSContext()
+
 
 class TestAPI(unittest.TestCase):
 
@@ -41,8 +44,8 @@ class TestAPI(unittest.TestCase):
 
     def test_getl2svm_lineage(self):
         features, labels = generate_matrices_for_l2svm(10, seed=1304)
-        #get the lineage trace
-        lt = features.l2svm(labels).getLineageTrace()
+        # get the lineage trace
+        lt = features.l2svm(labels).get_lineage_trace()
         with open(os.path.join("tests", "lt_l2svm.txt"), "r") as file:
             data = file.read()
         file.close()
@@ -50,8 +53,8 @@ class TestAPI(unittest.TestCase):
 
     def test_getl2svm_lineage2(self):
         features, labels = generate_matrices_for_l2svm(10, seed=1304)
-        #get the lineage trace
-        model, lt = features.l2svm(labels).compute(lineage = True)
+        # get the lineage trace
+        model, lt = features.l2svm(labels).compute(lineage=True)
         with open(os.path.join("tests", "lt_l2svm.txt"), "r") as file:
             data = file.read()
         file.close()
@@ -66,14 +69,15 @@ def generate_matrices_for_l2svm(dims: int, seed: int = 1234) -> Tuple[Matrix, Ma
     for i in range(dims):
         if np.random.random() > 0.5:
             m2[i][0] = 1
-    return Matrix(m1), Matrix(m2)
+    return sds.matrix(m1), sds.matrix(m2)
+
 
 def reVars(s: str) -> str:
     s = re.sub(r'\b_mVar\d*\b', '', s)
     s = re.sub(r'\b_Var\d*\b', '', s)
     return s
-    
+
 
 if __name__ == "__main__":
     unittest.main(exit=False)
-    helpers.shutdown()
+    sds.close()

--- a/src/main/python/tests/test_lineagetrace.py
+++ b/src/main/python/tests/test_lineagetrace.py
@@ -21,8 +21,10 @@ import re
 
 path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../")
 sys.path.insert(0, path)
-from systemds.matrix import Matrix, full, seq
-from systemds.utils import helpers
+from systemds.context import SystemDSContext
+
+sds = SystemDSContext()
+
 
 class TestLineageTrace(unittest.TestCase):
 
@@ -36,19 +38,19 @@ class TestLineageTrace(unittest.TestCase):
                                 message="unclosed",
                                 category=ResourceWarning)
 
-    def test_compare_trace1(self): #test getLineageTrace() on an intermediate
-        m = full((5, 10), 4.20)
+    def test_compare_trace1(self):  # test getLineageTrace() on an intermediate
+        m = sds.full((5, 10), 4.20)
         m_res = m * 3.1
-        m_sum = m_res.sum()       
+        m_sum = m_res.sum()
         with open(os.path.join("tests", "lt.txt"), "r") as file:
             data = file.read()
         file.close()
-        self.assertEqual(reVars(m_res.getLineageTrace()), reVars(data))
+        self.assertEqual(reVars(m_res.get_lineage_trace()), reVars(data))
 
-    def test_compare_trace2(self): #test (lineage=True) as an argument to compute
-        m = full((5, 10), 4.20)
+    def test_compare_trace2(self):  # test (lineage=True) as an argument to compute
+        m = sds.full((5, 10), 4.20)
         m_res = m * 3.1
-        sum, lt = m_res.sum().compute(lineage = True)       
+        sum, lt = m_res.sum().compute(lineage=True)
         lt = re.sub(r'\b_mVar\d*\b', '', lt)
         with open(os.path.join("tests", "lt2.txt"), "r") as file:
             data = file.read()
@@ -61,6 +63,7 @@ def reVars(s: str) -> str:
     s = re.sub(r'\b_Var\d*\b', '', s)
     return s
 
+
 if __name__ == "__main__":
     unittest.main(exit=False)
-    helpers.shutdown()
+    sds.close()

--- a/src/main/python/tests/test_matrix_aggregations.py
+++ b/src/main/python/tests/test_matrix_aggregations.py
@@ -31,15 +31,15 @@ import numpy as np
 
 path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../")
 sys.path.insert(0, path)
-
-from systemds.matrix import Matrix, full, seq
-from systemds.utils import helpers
+from systemds.context import SystemDSContext
 
 dim = 5
 m1 = np.array(np.random.randint(100, size=dim * dim) + 1.01, dtype=np.double)
 m1.shape = (dim, dim)
 m2 = np.array(np.random.randint(5, size=dim * dim) + 1, dtype=np.double)
 m2.shape = (dim, dim)
+
+sds = SystemDSContext()
 
 
 class TestMatrixAggFn(unittest.TestCase):
@@ -55,39 +55,39 @@ class TestMatrixAggFn(unittest.TestCase):
                                 category=ResourceWarning)
 
     def test_sum1(self):
-        self.assertTrue(np.allclose(Matrix(m1).sum().compute(), m1.sum()))
+        self.assertTrue(np.allclose(sds.matrix(m1).sum().compute(), m1.sum()))
 
     def test_sum2(self):
-        self.assertTrue(np.allclose(Matrix(m1).sum(axis=0).compute(), m1.sum(axis=0)))
+        self.assertTrue(np.allclose(sds.matrix(m1).sum(axis=0).compute(), m1.sum(axis=0)))
 
     def test_sum3(self):
-        self.assertTrue(np.allclose(Matrix(m1).sum(axis=1).compute(), m1.sum(axis=1).reshape(dim, 1)))
+        self.assertTrue(np.allclose(sds.matrix(m1).sum(axis=1).compute(), m1.sum(axis=1).reshape(dim, 1)))
 
     def test_mean1(self):
-        self.assertTrue(np.allclose(Matrix(m1).mean().compute(), m1.mean()))
+        self.assertTrue(np.allclose(sds.matrix(m1).mean().compute(), m1.mean()))
 
     def test_mean2(self):
-        self.assertTrue(np.allclose(Matrix(m1).mean(axis=0).compute(), m1.mean(axis=0)))
+        self.assertTrue(np.allclose(sds.matrix(m1).mean(axis=0).compute(), m1.mean(axis=0)))
 
     def test_mean3(self):
-        self.assertTrue(np.allclose(Matrix(m1).mean(axis=1).compute(), m1.mean(axis=1).reshape(dim, 1)))
+        self.assertTrue(np.allclose(sds.matrix(m1).mean(axis=1).compute(), m1.mean(axis=1).reshape(dim, 1)))
 
     def test_full(self):
-        self.assertTrue(np.allclose(full((2, 3), 10.1).compute(), np.full((2, 3), 10.1)))
+        self.assertTrue(np.allclose(sds.full((2, 3), 10.1).compute(), np.full((2, 3), 10.1)))
 
     def test_seq(self):
-        self.assertTrue(np.allclose(seq(3).compute(), np.arange(4).reshape(4, 1)))
+        self.assertTrue(np.allclose(sds.seq(3).compute(), np.arange(4).reshape(4, 1)))
 
     def test_var1(self):
-        self.assertTrue(np.allclose(Matrix(m1).var().compute(), m1.var(ddof=1)))
+        self.assertTrue(np.allclose(sds.matrix(m1).var().compute(), m1.var(ddof=1)))
 
     def test_var2(self):
-        self.assertTrue(np.allclose(Matrix(m1).var(axis=0).compute(), m1.var(axis=0, ddof=1)))
+        self.assertTrue(np.allclose(sds.matrix(m1).var(axis=0).compute(), m1.var(axis=0, ddof=1)))
 
     def test_var3(self):
-        self.assertTrue(np.allclose(Matrix(m1).var(axis=1).compute(), m1.var(axis=1, ddof=1).reshape(dim, 1)))
+        self.assertTrue(np.allclose(sds.matrix(m1).var(axis=1).compute(), m1.var(axis=1, ddof=1).reshape(dim, 1)))
 
 
 if __name__ == "__main__":
     unittest.main(exit=False)
-    helpers.shutdown()
+    sds.close()

--- a/src/main/python/tests/test_matrix_binary_op.py
+++ b/src/main/python/tests/test_matrix_binary_op.py
@@ -31,8 +31,7 @@ import numpy as np
 path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../")
 sys.path.insert(0, path)
 
-from systemds.matrix import Matrix
-from systemds.utils import helpers
+from systemds.context import SystemDSContext
 
 dim = 5
 m1 = np.array(np.random.randint(100, size=dim * dim) + 1.01, dtype=np.double)
@@ -41,6 +40,7 @@ m2 = np.array(np.random.randint(5, size=dim * dim) + 1, dtype=np.double)
 m2.shape = (dim, dim)
 s = 3.02
 
+sds = SystemDSContext()
 
 class TestBinaryOp(unittest.TestCase):
 
@@ -55,51 +55,51 @@ class TestBinaryOp(unittest.TestCase):
                                 category=ResourceWarning)
 
     def test_plus(self):
-        self.assertTrue(np.allclose((Matrix(m1) + Matrix(m2)).compute(), m1 + m2))
+        self.assertTrue(np.allclose((sds.matrix(m1) + sds.matrix(m2)).compute(), m1 + m2))
 
     def test_minus(self):
-        self.assertTrue(np.allclose((Matrix(m1) - Matrix(m2)).compute(), m1 - m2))
+        self.assertTrue(np.allclose((sds.matrix(m1) - sds.matrix(m2)).compute(), m1 - m2))
 
     def test_mul(self):
-        self.assertTrue(np.allclose((Matrix(m1) * Matrix(m2)).compute(), m1 * m2))
+        self.assertTrue(np.allclose((sds.matrix(m1) * sds.matrix(m2)).compute(), m1 * m2))
 
     def test_div(self):
-        self.assertTrue(np.allclose((Matrix(m1) / Matrix(m2)).compute(), m1 / m2))
+        self.assertTrue(np.allclose((sds.matrix(m1) / sds.matrix(m2)).compute(), m1 / m2))
 
     # TODO arithmetic with numpy rhs
 
     # TODO arithmetic with numpy lhs
 
     def test_plus3(self):
-        self.assertTrue(np.allclose((Matrix(m1) + s).compute(), m1 + s))
+        self.assertTrue(np.allclose((sds.matrix(m1) + s).compute(), m1 + s))
 
     def test_minus3(self):
-        self.assertTrue(np.allclose((Matrix(m1) - s).compute(), m1 - s))
+        self.assertTrue(np.allclose((sds.matrix(m1) - s).compute(), m1 - s))
 
     def test_mul3(self):
-        self.assertTrue(np.allclose((Matrix(m1) * s).compute(), m1 * s))
+        self.assertTrue(np.allclose((sds.matrix(m1) * s).compute(), m1 * s))
 
     def test_div3(self):
-        self.assertTrue(np.allclose((Matrix(m1) / s).compute(), m1 / s))
+        self.assertTrue(np.allclose((sds.matrix(m1) / s).compute(), m1 / s))
 
     # TODO arithmetic with scala lhs
 
     def test_lt(self):
-        self.assertTrue(np.allclose((Matrix(m1) < Matrix(m2)).compute(), m1 < m2))
+        self.assertTrue(np.allclose((sds.matrix(m1) < sds.matrix(m2)).compute(), m1 < m2))
 
     def test_gt(self):
-        self.assertTrue(np.allclose((Matrix(m1) > Matrix(m2)).compute(), m1 > m2))
+        self.assertTrue(np.allclose((sds.matrix(m1) > sds.matrix(m2)).compute(), m1 > m2))
 
     def test_le(self):
-        self.assertTrue(np.allclose((Matrix(m1) <= Matrix(m2)).compute(), m1 <= m2))
+        self.assertTrue(np.allclose((sds.matrix(m1) <= sds.matrix(m2)).compute(), m1 <= m2))
 
     def test_ge(self):
-        self.assertTrue(np.allclose((Matrix(m1) >= Matrix(m2)).compute(), m1 >= m2))
+        self.assertTrue(np.allclose((sds.matrix(m1) >= sds.matrix(m2)).compute(), m1 >= m2))
 
     def test_abs(self):
-        self.assertTrue(np.allclose(Matrix(m1).abs().compute(), np.abs(m1)))
+        self.assertTrue(np.allclose(sds.matrix(m1).abs().compute(), np.abs(m1)))
 
 
 if __name__ == "__main__":
     unittest.main(exit=False)
-    helpers.shutdown()
+    sds.close()


### PR DESCRIPTION
Switch to using `SystemDSContext` as a `ContextManager` instead of purely automatic startup and manual shutdown. This makes performance impact more obvious for the user because the expensive startup of a java process happens during `SystemDSContext` creation and allows for us to ensure the closing of the py4j connection and shutdown of subprocess if the user decides to use `with SystemDSContext() as sds:`. Manual shutdown with `.close()` is also possible for cases where the user wants to keep the `SystemDSContext` around longer, for example as an member variable of his class.